### PR TITLE
Allow for LabeledBtn to take external URLs

### DIFF
--- a/frontend/components/LabeledBtn.vue
+++ b/frontend/components/LabeledBtn.vue
@@ -1,5 +1,26 @@
 <template>
+  <a
+    v-if="linkTo.includes('http')"
+    :href="linkTo"
+    class="px-4 py-2 font-medium text-center border rounded-md select-none xl:rounded-lg text-light-distinct border-light-distinct dark:text-dark-distinct dark:border-dark-distinct focus-brand"
+    :class="{
+      'bg-light-cta-orange dark:bg-dark-cta-orange hover:bg-light-cta-orange-light active:bg-light-cta-orange dark:hover:bg-dark-cta-orange-light dark:active:bg-dark-cta-orange':
+        cta == true,
+      'bg-neutral-500 dark:bg-gray-400 hover:bg-neutral-400 active:bg-neutral-500 dark:hover:bg-gray-300 dark:active:bg-gray-400 ':
+        cta == false,
+      'text-xs': fontSize == 'xs',
+      'text-sm': fontSize == 'sm',
+      'text-base': fontSize == 'base',
+      'text-lg': fontSize == 'lg',
+      'text-base sm:text-lg xl:text-xl xl:px-6 xl:py-3': fontSize == 'xl',
+      'text-base sm:text-lg xl:text-2xl xl:px-6 xl:py-3': fontSize == '2xl',
+      'text-base sm:text-lg xl:text-3xl xl:px-6 xl:py-3': fontSize == '3xl',
+    }"
+  >
+    {{ $t(label) }}
+  </a>
   <NuxtLink
+    v-else
     :to="localePath(`${linkTo}`)"
     class="px-4 py-2 font-medium text-center border rounded-md select-none xl:rounded-lg text-light-distinct border-light-distinct dark:text-dark-distinct dark:border-dark-distinct focus-brand"
     :class="{

--- a/frontend/components/LandingPage/LandingPageSplash.vue
+++ b/frontend/components/LandingPage/LandingPageSplash.vue
@@ -20,7 +20,7 @@
       <LabeledBtn
         :cta="true"
         :label="`${btnText1}`"
-        linkTo="/about"
+        linkTo="https://tally.so/r/nprxbq"
         fontSize="xl"
       />
     </div>
@@ -29,5 +29,5 @@
 
 <script setup>
 const localePath = useLocalePath();
-const btnText1 = "learn-more";
+const btnText1 = "Request access";
 </script>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -14,8 +14,8 @@
         tagline="get-active-tagline"
         text="get-active-text"
         imageURL="images/landing_page/1_get_active"
-        btnText1="learn-more"
-        btnURL1="/docs/get-active"
+        btnText1="Request access"
+        btnURL1="https://tally.so/r/nprxbq"
       />
       <LandingPageContent
         contentPosition="right"
@@ -23,8 +23,8 @@
         tagline="get-organized-tagline"
         text="get-organized-text"
         imageURL="images/landing_page/2_get_organized"
-        btnText1="learn-more"
-        btnURL1="/docs/get-organized"
+        btnText1="Request access"
+        btnURL1="https://tally.so/r/nprxbq"
       />
       <LandingPageContent
         contentPosition="left"
@@ -32,8 +32,8 @@
         tagline="grow-organization-tagline"
         text="grow-organization-text"
         imageURL="images/landing_page/3_grow_your_organization"
-        btnText1="learn-more"
-        btnURL1="/docs/grow-organization"
+        btnText1="Request access"
+        btnURL1="https://tally.so/r/nprxbq"
       />
       <LandingPageContent
         contentPosition="right"
@@ -41,8 +41,8 @@
         tagline="activist-section-tagline"
         text="activist-section-text"
         imageURL="images/landing_page/4_activist_icon"
-        btnText1="get-in-touch"
-        btnURL1="/help/contact"
+        btnText1="Request access"
+        btnURL1="https://tally.so/r/nprxbq"
       />
       <LandingPageContent
         contentPosition="top"


### PR DESCRIPTION
We’re trying to add external link functionality to LabeledBtn.vue. After this is checked some CTAs on the landing page will be changed to link to Tally forms. 

Note that this has been done on GitHub mobile web, and testing will just be via Netlify instances. 