### PR TITLE
 Put exterior link icons on text baseline in /supporters and /supporter/join #70 

### DIFF
--- a/frontend/pages/supporters/index.vue
+++ b/frontend/pages/supporters/index.vue
@@ -25,12 +25,12 @@
       <p>
         The following organizations have supported activist via the 2022 edition
         of the
-        <a
-          href="https://www.wikimedia.de/unlock"
-          class="text-light-cta-orange dark:text-dark-cta-orange hover:underline focus-brand"
-          >Wikimedia UNLOCK accelerator
-          <Icon name="bi:box-arrow-up-right" size="1em" /></a
-        >. UNLOCK supports open-source software projects and non- technical
+        <a href="https://www.wikimedia.de/unlock"
+   class="text-light-cta-orange dark:text-dark-cta-orange hover:underline focus-brand items-center">
+  Wikimedia UNLOCK accelerator
+  <Icon name="bi:box-arrow-up-right" size="1em" style="vertical-align: baseline;" />
+</a>
+. UNLOCK supports open-source software projects and non- technical
         projects under free licenses. The UNLOCK Accelerator is committed to
         promoting solutions that make the world's knowledge more diverse, more
         accessible and inclusive for everyone.

--- a/frontend/pages/supporters/join.vue
+++ b/frontend/pages/supporters/join.vue
@@ -28,7 +28,7 @@
         <a
           href="https://www.wikimedia.de/unlock"
           class="text-light-cta-orange dark:text-dark-cta-orange hover:underline focus-brand"
-          >source code on GitHub <Icon name="bi:box-arrow-up-right" size="1em"
+          >source code on GitHub <Icon name="bi:box-arrow-up-right" size="1em" style="vertical-align: baseline;"
         /></a>
         to get involved!
       </p>
@@ -42,7 +42,7 @@
         <a
           href=""
           class="text-light-cta-orange dark:text-dark-cta-orange hover:underline focus-brand"
-          >page on elinor <Icon name="bi:box-arrow-up-right" size="1em"
+          >page on elinor <Icon name="bi:box-arrow-up-right" size="1em" style="vertical-align: baseline;"
         /></a>
         to donate today. Thank you for your support!
       </p>
@@ -85,7 +85,7 @@
         <a
           href=""
           class="text-light-cta-orange dark:text-dark-cta-orange hover:underline focus-brand"
-          >Crowdin <Icon name="bi:box-arrow-up-right" size="1em"
+          >Crowdin <Icon name="bi:box-arrow-up-right" size="1em" style="vertical-align: baseline;"
         /></a>
         page to help today.
       </p>


### PR DESCRIPTION
To reposition the exterior link icon to be on the same baseline as the text I added 

`style="vertical-align: baseline;"`

to the icons. This should solve the issue for the two pages