### PR TITLE
fix: isolate node_modules for hot-reload in dev container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,8 @@ services:
     build:
       context: ./frontend
     container_name: nuxt_frontend
-    # This section allows for hot reloading for some contributors but is a breaking change for others
-    # See: https://github.com/activist-org/activist/issues/55
-    # volumes:
-    #   - ./frontend:/app
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
     ports:
       - "3000:3000"


### PR DESCRIPTION
**Description:**

- Updated the `docker-compose.yml` to isolate the `node_modules` directory in its own volume
   - Hot-reload now works when attaching the frontend code as a volume. The frontend volume won't override the `node_modules` directory 