### PR TITLE
edited icon transitions

### DIFF
--- a/frontend/components/MenuSelector.vue
+++ b/frontend/components/MenuSelector.vue
@@ -1,14 +1,14 @@
 <template>
   <NuxtLink
     :to="localePath(`${btnURL}`)"
-    class="flex items-center w-full px-3 py-2 space-x-2 text-sm text-left transition duration-200 rounded-md font-md group text-light-text dark:text-dark-text hover:bg-light-highlight dark:hover:bg-dark-highlight"
+    class="flex items-center w-full h-10 px-3 py-1 space-x-2 text-sm text-left transition duration-200 rounded-md font-md group text-light-text dark:text-dark-text hover:bg-light-highlight dark:hover:bg-dark-highlight"
     :class="{
       'bg-light-menu-selection dark:bg-dark-menu-selection text-light-distinct dark:text-dark-distinct':
         selected == true,
       'text-light-text dark:text-dark-text': selected == false,
     }"
   >
-    <Icon :name="iconURL" size="1.25em" />
+    <Icon :name="iconURL" class="flex-shrink-0 w-5 h-5"/>
     <Transition>
       <p
         v-if="sidebar.collapsed == false || sidebar.collapsedSwitch == false"
@@ -21,7 +21,10 @@
 </template>
 
 <style>
-.v-enter-active,
+.v-enter-active {
+  transition: opacity 0.25s ease;
+  transition-delay: .125s;
+}
 .v-leave-active {
   transition: opacity 0.25s ease;
 }
@@ -45,18 +48,3 @@ defineProps<{
 const localePath = useLocalePath();
 const sidebar = useSidebar();
 </script>
-
-<style>
-.v-enter-active,
-.v-leave-active {
-  transition: opacity 0.25s ease;
-}
-
-.v-enter-from,
-.v-leave-to {
-  opacity: 0;
-}
-.v-enter-from .inner {
-  transition-delay: 0.25s;
-}
-</style>

--- a/frontend/components/Sidebar/SidebarFooter.vue
+++ b/frontend/components/Sidebar/SidebarFooter.vue
@@ -7,11 +7,7 @@
     }"
   >
     <div
-      class="flex flex-col pt-2 pb-3 space-y-2"
-      :class="{
-        'px-2': sidebar.collapsed == false || sidebar.collapsedSwitch == false,
-        'px-3': sidebar.collapsed == true && sidebar.collapsedSwitch == true,
-      }"
+      class="flex flex-col pt-2 pb-3 space-y-2 px-2"
     >
       <Disclosure v-slot="{ open, close }">
         <DisclosureButton
@@ -22,16 +18,19 @@
           <div
             class="relative z-0 flex items-center w-full px-3 py-2 space-x-2 text-sm font-medium text-left"
           >
-            <Icon name="bi:plus-circle" size="1.25em" />
-            <p
-              v-if="
-                sidebar.collapsed == false || sidebar.collapsedSwitch == false
-              "
-            >
-              {{ $t("Create") }}
-            </p>
+            <Icon name="bi:plus-circle" size="1.25em" class="flex-shrink-0 w-5 h-5"/>
+            <Transition name="text">
+              <p
+                v-if="
+                  sidebar.collapsed == false || sidebar.collapsedSwitch == false
+                "
+              >
+                {{ $t("Create") }}
+              </p>
+            </Transition>
           </div>
-          <Icon
+          <Transition name="askdjfsad">
+            <Icon
             v-if="
               sidebar.collapsed == false || sidebar.collapsedSwitch == false
             "
@@ -39,6 +38,7 @@
             class="absolute right-0 mr-6"
             :class="open ? 'rotate-180 transform' : ''"
           />
+          </Transition>
         </DisclosureButton>
         <DisclosurePanel class="space-y-1">
           <MenuSelector
@@ -76,16 +76,19 @@
           <div
             class="relative z-0 flex items-center w-full px-3 py-2 space-x-2 text-sm font-medium text-left"
           >
-            <Icon name="bi:info-circle" size="1.25em" />
-            <p
-              v-if="
-                sidebar.collapsed == false || sidebar.collapsedSwitch == false
-              "
-            >
-              {{ $t("Info") }}
-            </p>
+            <Icon name="bi:info-circle" size="1.25em" class="flex-shrink-0 w-5 h-5"/>
+            <Transition name="text">
+              <p
+                v-if="
+                  sidebar.collapsed == false || sidebar.collapsedSwitch == false
+                "
+              >
+                {{ $t("Info") }}
+              </p>
+            </Transition>
           </div>
-          <Icon
+          <Transition name="askdjfsad">
+            <Icon
             v-if="
               sidebar.collapsed == false || sidebar.collapsedSwitch == false
             "
@@ -93,6 +96,7 @@
             class="absolute right-0 mr-6"
             :class="open ? 'rotate-180 transform' : ''"
           />
+          </Transition>
         </DisclosureButton>
         <DisclosurePanel class="space-y-1">
           <MenuSelector
@@ -118,17 +122,20 @@
           <div
             class="relative z-0 flex items-center w-full px-3 py-2 space-x-2 text-sm font-medium text-left"
           >
-            <Icon name="bi:person-circle" size="1.25em" />
-            <p
-              v-if="
-                sidebar.collapsed == false || sidebar.collapsedSwitch == false
-              "
-              class="font-bold"
-            >
-              {{ $t("Username") }}
-            </p>
+            <Icon name="bi:person-circle" size="1.25em" class="flex-shrink-0 w-5 h-5"/>
+            <Transition name="text">
+              <p
+                v-if="
+                  sidebar.collapsed == false || sidebar.collapsedSwitch == false
+                "
+                class="font-bold"
+              >
+                {{ $t("Username") }}
+              </p>
+            </Transition>
           </div>
-          <Icon
+          <Transition name="askdjfsad">
+            <Icon
             v-if="
               sidebar.collapsed == false || sidebar.collapsedSwitch == false
             "
@@ -136,6 +143,7 @@
             class="absolute right-0 mr-6"
             :class="open ? 'rotate-180 transform' : ''"
           />
+          </Transition>
         </DisclosureButton>
         <DisclosurePanel class="space-y-1">
           <MenuSelector
@@ -190,3 +198,35 @@ const closeOtherMenus = (id) => {
 };
 const sidebar = useSidebar();
 </script>
+
+<style>
+.text-enter-active {
+  transition: opacity 0.25s ease;
+  transition-delay: .125s;
+}
+.text-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.text-enter-from,
+.text-leave-to {
+  opacity: 0;
+}
+.text-enter-from {
+  transition-delay: 0.25s;
+}
+
+.askdjfsad-enter-active {
+  transition: opacity .25s ease;
+  transition-delay: .25s;
+}
+.askdjfsad-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.askdjfsad-enter-from,
+.askdjfsad-leave-to {
+  opacity: 0;
+}
+
+</style>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

If you're not already a member of our public Matrix community, please consider joining via the following link:
https://matrix.to/#/#activist_community:matrix.org

It'd be great to have you!

Also if you're new to open source, check that the email you use for GitHub (https://github.com/settings/emails) is the same the one you have for git so you get credit for your contribution. You can see your git email by typing `git config user.email` and set it globally with `git config --global user.email "your_email@email.com"`.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
  <!-- - [ ] I have updated the [CHANGELOG](https://github.com/activist-org/activist/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary)  -->
  <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

Minor css and transition changes to the icons in [SidebarMainSectionSelectors](https://github.com/activist-org/activist/blob/main/frontend/components/Sidebar/SidebarMainSectionSelectors.vue) and [SidebarFooter](https://github.com/activist-org/activist/blob/main/frontend/components/Sidebar/SidebarFooter.vue). 

Not sure exactly what I could do to make the text any more appealing but I basically played around with the delays and fade ins until I got it to a point that looked good. I think in this case simpler is better and making it any fancier might end up looking worse. Happy to take another stab at it if you have any ideas though.

- specified height and changed padding on the sidebar links to stop them from changing sizes when sidebar is selected
- switched size -> class on Icon in MenuSelector to stop it from changing sizes
- cleaned up transition for the text to add a delay when fading in so it doesn't clip with the sidebar
- deleted unnecessary extra style code (was this here for a reason?)
- removed style change from top SidebarFooter div, was causing a "jump" to the right when sidebar was selected
- Added transition to the text and chevron icon in the SidebarFooter Disclosures

Tested by frantically swiping my mouse back and forth over the sidebar with several different screen sizes.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #88 
