### PR TITLE
[fix] Make safari ios status bar update with theme change #103

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -101,6 +101,18 @@ export default defineNuxtConfig({
           name: "description",
           content: "Open-source, nonprofit activism platform.",
         },
+        {
+          hid: "theme",
+          name: "theme-color",
+          content: "#f0f0eb",
+          media: "(prefers-color-scheme: light)"
+        },
+        {
+          hid: "theme",
+          name: "theme-color",
+          content: "#161b22",
+          media: "(prefers-color-scheme: dark)"
+        },
         { property: "og:site_name", content: "activist" },
         { hid: "og:type", property: "og:type", content: "website" },
         {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

If you're not already a member of our public Matrix community, please consider joining via the following link:
https://matrix.to/#/#activist_community:matrix.org

It'd be great to have you!

Also if you're new to open source, check that the email you use for GitHub (https://github.com/settings/emails) is the same the one you have for git so you get credit for your contribution. You can see your git email by typing `git config user.email` and set it globally with `git config --global user.email "your_email@email.com"`.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
  <!-- - [ ] I have updated the [CHANGELOG](https://github.com/activist-org/activist/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary)  -->
  <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

For Safari in iOS, The color used for the status bar is the background color by default ([link to short article](https://useyourloaf.com/blog/safari-15-theme-color/), [link to Apple dev forum thread](https://developer.apple.com/forums/thread/683403)). Following the instructions on those links, I added additional meta tags in nuxt.config.ts to include theme-color for the light and dark themes. When running locally on my PC (viewed in Chrome) this addition doesn't change anything (expected behavior). After I open the PR, I'll check the Netlify preview to confirm the effect for Safari in iOS is as expected.  

 

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #103 
