### PR TITLE
feat: Hide search bar hotkey indicators when user starts typing

### DIFF
--- a/frontend/components/SearchBar.vue
+++ b/frontend/components/SearchBar.vue
@@ -7,14 +7,17 @@
       <input
         v-if="sidebar.collapsed == false || sidebar.collapsedSwitch == false"
         ref="input"
-        class="w-16 h-5 bg-transparent outline-none"
+        class="w-16 focus:w-5/6 h-5 bg-transparent outline-none"
         type="text"
         placeholder="Search"
+        @focus="onFocus"
+        @blur="onFocusLost"
       />
     </Transition>
     <Transition name="shortcuts">
       <div
         v-if="sidebar.collapsed == false || sidebar.collapsedSwitch == false"
+        ref="hotkeyIndicators"
         class="flex space-x-1"
       >
         <div
@@ -57,6 +60,7 @@ import { useMagicKeys, whenever } from "@vueuse/core";
 import { ref } from "vue";
 const sidebar = useSidebar();
 const input = ref();
+const hotkeyIndicators = ref();
 const keys = useMagicKeys();
 
 whenever(keys.slash, () => {
@@ -68,6 +72,13 @@ whenever(keys.slash, () => {
     sidebar.collapsedSwitch = false;
   }
 });
+
+const onFocus = () => {
+  hotkeyIndicators.value.classList.add("hide");
+};
+const onFocusLost = () => {
+  hotkeyIndicators.value.classList.remove("hide");
+};
 </script>
 
 <style>
@@ -98,5 +109,9 @@ whenever(keys.slash, () => {
 .shortcuts-enter-from,
 .shortcuts-leave-to {
   opacity: 0;
+}
+
+.hide {
+  display: none;
 }
 </style>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

If you're not already a member of our public Matrix community, please consider joining via the following link:
https://matrix.to/#/#activist_community:matrix.org

It'd be great to have you!

Also if you're new to open source, check that the email you use for GitHub (https://github.com/settings/emails) is the same the one you have for git so you get credit for your contribution. You can see your git email by typing `git config user.email` and set it globally with `git config --global user.email "your_email@email.com"`.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
  <!-- - [ ] I have updated the [CHANGELOG](https://github.com/activist-org/activist/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary)  -->
  <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
When the user uses the search bar, the hotkey indicators hide and the input bar's length is increased so that the user can use the full search bar.

Below are screenhots of it in action:

![Screenshot 2023-05-15 135046](https://github.com/activist-org/activist/assets/57863161/68b66b5c-1a37-4e56-bf49-d8f7e434e48b)
![Screenshot 2023-05-15 135212](https://github.com/activist-org/activist/assets/57863161/f2604a72-f951-42b5-8e21-5725d93541cd)

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #118
