### PR TITLE
feat: add transition to hidden hotkey indicators

### DIFF
--- a/frontend/components/SearchBar.vue
+++ b/frontend/components/SearchBar.vue
@@ -7,18 +7,19 @@
       <input
         v-if="sidebar.collapsed == false || sidebar.collapsedSwitch == false"
         ref="input"
-        class="w-16 h-5 bg-transparent outline-none focus:w-5/6"
+        class="w-16 h-5 bg-transparent outline-none"
         type="text"
         placeholder="Search"
         @focus="onFocus"
         @blur="onFocusLost"
+        :class="{'focus:w-5/6': isInputFocused }"
       />
     </Transition>
     <Transition name="shortcuts">
       <div
         v-if="sidebar.collapsed == false || sidebar.collapsedSwitch == false"
         ref="hotkeyIndicators"
-        class="flex space-x-1"
+        class="flex space-x-1 transition-opacity transition-duration-200"
       >
         <div
           class="w-5 h-5 text-sm text-center rounded-md has-tooltip bg-light-highlight dark:bg-dark-highlight text-light-special-text dark:text-dark-special-text"
@@ -61,6 +62,7 @@ import { ref } from "vue";
 const sidebar = useSidebar();
 const input = ref();
 const hotkeyIndicators = ref();
+const isInputFocused = ref(false)
 const keys = useMagicKeys();
 
 whenever(keys.slash, () => {
@@ -75,9 +77,17 @@ whenever(keys.slash, () => {
 
 const onFocus = () => {
   hotkeyIndicators.value.classList.add("hide");
+  setTimeout(() => {
+    isInputFocused.value = true;
+    hotkeyIndicators.value.classList.add("hidden");
+  }, 200)
 };
 const onFocusLost = () => {
-  hotkeyIndicators.value.classList.remove("hide");
+  hotkeyIndicators.value.classList.remove("hidden");
+  isInputFocused.value = false;
+  setTimeout(() => {
+    hotkeyIndicators.value.classList.remove("hide");
+  }, 200)
 };
 </script>
 
@@ -112,6 +122,6 @@ const onFocusLost = () => {
 }
 
 .hide {
-  display: none;
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

If you're not already a member of our public Matrix community, please consider joining via the following link:
https://matrix.to/#/#activist_community:matrix.org

It'd be great to have you!

Also if you're new to open source, check that the email you use for GitHub (https://github.com/settings/emails) is the same the one you have for git so you get credit for your contribution. You can see your git email by typing `git config user.email` and set it globally with `git config --global user.email "your_email@email.com"`.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
  <!-- - [ ] I have updated the [CHANGELOG](https://github.com/activist-org/activist/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary)  -->
  <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
1. Add `transition-opacity transition-duration-200` to the hotKeyIndicators `div`
2. modify the existing CSS conditional `.hide` class from `display: none;` to `opacity: 0;`
3. Remove `focus:w-5/6` from parent input as it was causing a slight layout shift during the transition

Before:
![beforeHotkey](https://github.com/activist-org/activist/assets/102203363/4634327a-f1bc-40e3-9d08-78d61bd0e1c7)

After:
![afterHotkeyChanges](https://github.com/activist-org/activist/assets/102203363/adfbb7c3-8ffb-4001-9c80-0937ced4c1f5)

Layout Shift:
![layoutshiftissue](https://github.com/activist-org/activist/assets/102203363/5e161b04-5b99-4a86-9062-cadb80d9abd5)


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #125 
