### PR TITLE
Card resource search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 ### ✨ Features
 
 - Content to describe the goal of activist.
-- Search results for events and organizations.
+- Search results for events, organizations, and resources.
 - Metric cards display new organizations and events to the user.
 - Links to activist GitHub and socials as well as supporter websites.
 - Landing page elements are reactive to screen sizes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,4 @@ services:
       - /app/node_modules
     ports:
       - "3000:3000"
+      - "24678:24678"

--- a/frontend/components/Btn/BtnLabeled.vue
+++ b/frontend/components/Btn/BtnLabeled.vue
@@ -16,9 +16,14 @@
       'text-base sm:text-lg xl:text-3xl xl:px-6 xl:py-3': fontSize == '3xl',
     }"
   >
-    <Icon v-if="leftIcon" :name="leftIcon" class="mb-1 mr-2" />
+    <Icon v-if="leftIcon" :name="leftIcon" class="mb-1 mr-2" :size="iconSize" />
     {{ $t(label) }}
-    <Icon v-if="rightIcon" :name="rightIcon" class="mb-1 ml-2" />
+    <Icon
+      v-if="rightIcon"
+      :name="rightIcon"
+      class="mb-1 ml-2"
+      :size="iconSize"
+    />
   </div>
   <a
     v-else-if="linkTo.includes('http')"
@@ -38,9 +43,14 @@
       'text-base sm:text-lg xl:text-3xl xl:px-6 xl:py-3': fontSize == '3xl',
     }"
   >
-    <Icon v-if="leftIcon" :name="leftIcon" class="mb-1 mr-2" />
+    <Icon v-if="leftIcon" :name="leftIcon" class="mb-1 mr-2" :size="iconSize" />
     {{ $t(label) }}
-    <Icon v-if="rightIcon" :name="rightIcon" class="mb-1 ml-2" />
+    <Icon
+      v-if="rightIcon"
+      :name="rightIcon"
+      class="mb-1 ml-2"
+      :size="iconSize"
+    />
   </a>
   <NuxtLink
     v-else
@@ -60,9 +70,14 @@
       'text-base sm:text-lg xl:text-3xl xl:px-6 xl:py-3': fontSize == '3xl',
     }"
   >
-    <Icon v-if="leftIcon" :name="leftIcon" class="mb-1 mr-2" />
+    <Icon v-if="leftIcon" :name="leftIcon" class="mb-1 mr-2" :size="iconSize" />
     {{ $t(label) }}
-    <Icon v-if="rightIcon" :name="rightIcon" class="mb-1 ml-2" />
+    <Icon
+      v-if="rightIcon"
+      :name="rightIcon"
+      class="mb-1 ml-2"
+      :size="iconSize"
+    />
   </NuxtLink>
 </template>
 
@@ -74,6 +89,11 @@ defineProps<{
   fontSize: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
   leftIcon?: string;
   rightIcon?: string;
+  iconSize: {
+    default: "1em";
+    type: string;
+    required: false;
+  };
 }>();
 const localePath = useLocalePath();
 </script>

--- a/frontend/components/Card/CardGetInvolved.vue
+++ b/frontend/components/Card/CardGetInvolved.vue
@@ -17,6 +17,8 @@
           label="Join organization"
           linkTo="/"
           fontSize="base"
+          rightIcon="bi:arrow-right"
+          iconSize="1.25em"
         />
       </div>
     </div>
@@ -50,6 +52,8 @@
           label="Offer to help"
           linkTo="/"
           fontSize="base"
+          rightIcon="bi:arrow-right"
+          iconSize="1.25em"
         />
       </div>
     </div>

--- a/frontend/components/Card/CardSearchResult.vue
+++ b/frontend/components/Card/CardSearchResult.vue
@@ -26,15 +26,15 @@
         </h2>
         <TopicMarker :topic="organization.topic" />
         <div class="flex gap-4" v-if="organization">
-          <div>
+          <div class="flex gap-1 items-center">
             <Icon name="bi:pin-map" class="mr-1" />
             {{ organization.location }}
           </div>
-          <div>
+          <div class="flex gap-1 items-center">
             <Icon name="bi:people" class="mr-1" />
             {{ organization.members }} {{ $t("members") }}
           </div>
-          <div>
+          <div class="flex gap-1 items-center">
             <Icon name="IconSupport" class="mr-1" />
             {{ organization.supporters }} {{ $t("supporters") }}
           </div>
@@ -70,11 +70,11 @@
             {{ event.name }}
           </h2>
           <div class="flex items-center gap-4">
-            <div v-if="event?.inPersonLocation">
+            <div class="flex gap-1 items-center" v-if="event?.inPersonLocation">
               <Icon name="bi:pin-map" class="mr-1" />
               {{ event?.inPersonLocation }}
             </div>
-            <div v-if="event?.onlineLocation">
+            <div class="flex gap-1 items-center" v-if="event?.onlineLocation">
               <Icon
                 v-if="event?.onlineLocation"
                 name="bi:camera-video"
@@ -82,7 +82,7 @@
               />
               {{ event?.onlineLocation }}
             </div>
-            <div>
+            <div class="flex gap-1 items-center">
               <Icon name="bi:calendar2-plus" class="mr-1" />
               {{ event?.date.toLocaleDateString() }}
             </div>
@@ -90,11 +90,11 @@
         </div>
         <TopicMarker :topic="event.topic" />
         <div class="flex gap-4" v-if="event">
-          <div>
+          <div class="flex gap-1 items-center">
             <Icon name="IconOrganization" class="mr-1" />
             {{ event.organizer }}
           </div>
-          <div>
+          <div class="flex gap-1 items-center">
             <Icon name="bi:person-fill-check" class="mr-1" />
             {{ event.supporters }} {{ $t("attending") }}
           </div>
@@ -104,17 +104,70 @@
         </div>
       </div>
     </div>
+    <div
+      v-if="searchResultType === 'resource'"
+      class="flex items-center p-2 grow sm:px-5 sm:py-3"
+    >
+      <div
+        class="border h-[90%] border-light-section-div dark:border-dark-section-div rounded-lg bg-light-content"
+      >
+        <img
+          v-if="resource.imageURL"
+          class="w-[200px] h-[200px]"
+          :src="resource.imageURL"
+          :alt="'The event logo of ' + resource.name"
+        />
+        <div
+          v-else
+          class="w-[200px] h-[200px] flex w-full justify-center items-center text-light-text dark:text-dark-text"
+        >
+          <!-- <Icon name="bi:tools" color="black" class="w-[75%] h-[75%]" /> -->
+          <Icon name="IconResource" class="w-[75%] h-[75%]"/>
+        </div>
+      </div>
+      <div class="px-6 pb-1 space-y-4 grow">
+        <div class="flex justify-between">
+          <h2 class="font-bold responsive-h3">
+            {{ resource.name }}
+          </h2>
+        </div>
+        <TopicMarker :topic="resource.topic" />
+        <div class="flex gap-4" v-if="resource">
+          <div class="flex gap-1 items-center">
+            <Icon name="bi:people" class="mr-1" />
+            {{ resource.organizer }}
+          </div>
+          <div class="flex gap-1 items-center">
+            <Icon name="bi:star" class="mr-1" />
+            {{ resource.stars }}
+          </div>
+          <div class="flex gap-1 items-center" v-if="resource.relatedLocation">
+            <Icon name="bi:pin-map" class="mr-1" />
+            {{  resource.relatedLocation }}
+          </div>
+          <div class="flex gap-1 items-center">
+            <Icon name="bi:calendar-plus" class="mr-1" />
+            {{ resource.creationDate.toLocaleDateString() }}
+          </div>
+        </div>
+        <div>
+          {{ resource.description }}
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { Event } from "../../types/event";
 import type { Organization } from "../../types/organization";
+import { Resource } from "~~/types/resource";
 
 const props = defineProps<{
   searchResultType: "organization" | "event" | "resource";
   isPrivate?: boolean;
   organization?: Organization;
   event?: Event;
+  resource?: Resource;
 }>();
 </script>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -28,6 +28,13 @@ export default defineNuxtConfig({
   imports: {
     dirs: ["./stores"],
   },
+  vite: {
+    server: {
+      watch: {
+        usePolling: true,
+      },
+    },
+  },
   colorMode: {
     classSuffix: "",
   },

--- a/frontend/pages/home/index.vue
+++ b/frontend/pages/home/index.vue
@@ -45,6 +45,11 @@
         :isPrivate="false"
         :event="event"
       />
+      <CardSearchResult
+        searchResultType="resource"
+        :isPrivate="false"
+        :resource="resource"
+      />
     </div>
   </div>
 </template>
@@ -52,12 +57,24 @@
 <script setup lang="ts">
 import { Event } from "~~/types/event";
 import { Organization } from "~~/types/organization";
+import { Resource } from "~~/types/resource";
 const title = ref("Home");
 
 definePageMeta({
   layout: "sidebar",
 });
 const sidebar = useSidebar();
+
+const resource: Resource = {
+  name: "Test Resource",
+  organizer: "Testers LLC",
+  resourceURL: "www.test.com",
+  description: "Test resource :D",
+  topic: "Tools",
+  relatedLocation: "Berlin",
+  creationDate: new Date(),
+  stars: 5,
+}
 
 const organization: Organization = {
   name: "tech from below",

--- a/frontend/types/resource.d.ts
+++ b/frontend/types/resource.d.ts
@@ -7,4 +7,5 @@ export interface Resource {
   relatedLocation?: string;
   creationDate: datetime;
   stars: number;
+  imageURL?: string;
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Added a hard-coded resource test search result to home. Also updated
the resource typescript definition to include an optional imageURL
seeing as the other cards had that property.

Also make some small tweaks to the other cards on how the icons were
being displayed with secondary information (location, org, attendees,
date, etc) to make them align with the text. Originally, they were 
slightly offset downwards by a few pixels. 

### Related issue

- #122 
