### PR TITLE
feat(documentation): add ts notes to styleguide and contributing 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ activist is very open to contributions from people in the early stages of their 
 - [Vue.js 3 docs](https://vuejs.org/guide/introduction.html)
 - [Vue docs on MDN](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_getting_started)
 - [Nuxt.js 3 docs](https://nuxt.com/docs/getting-started/introduction)
+- [Nuxt.js and TypeScript docs](https://nuxt.com/docs/guide/concepts/typescript)
 - [TypeScript docs](https://www.typescriptlang.org/docs/)
 - [Tailwind CSS docs](https://tailwindcss.com/docs/installation)
 - [Headless UI docs](https://headlessui.com/)
@@ -191,7 +192,7 @@ When making a contribution, adhering to the [GitHub flow](https://guides.github.
    ```bash
    git pull --rebase upstream <dev-branch>
    ```
-
+> **Note:** When working on the frontend, activist recommends running `yarn nuxi typecheck` from within the `frontend` directory to confirm your changes are type-safe. Existing TS errors may be ignored. PR's to fix these are always welcome.
 6. Push your topic branch up to your fork:
 
    ```bash

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -11,6 +11,7 @@ If you have questions or would like to communicate with the team, please [join u
 ## **Contents**
 
 - [Vue and Nuxt](#vue-and-nuxt)
+- [TypeScript](#typescript)
 - [Tailwind](#tailwind)
 - [Formatting](#formatting)
 - [Common styles](#common-styles)
@@ -32,16 +33,63 @@ The team chose Vue because of its broad usage across the development industry as
 Vue files (`.vue`) are Single-File Components that have `<template>`, `<script>` and `<style>` blocks. Conventions for writing Vue for activist include:
 
 - `<template>` blocks should come first, `<script>` second and `<style>` last
-- [TypeScript](https://www.typescriptlang.org/) should be used where ever possible within `<script>` blocks
-  - This will be more strictly enforced as the project matures
+- [TypeScript](https://www.typescriptlang.org/) should be used where ever possible within `<script>` blocks with `defineProps`
 - Self-closing components (`<Component />`) should be used for any component that doesn't have content
   - This style is [strongly recommended in Vue](https://vuejs.org/guide/essentials/component-basics.html#dom-template-parsing-caveats)
   - Generally if a component has a `<slot>` then this would imply that it would normally have content and thus require a closing tag
 
-<!-- <a id="typescript"></a>
+<a id="typescript"></a>
 
-## TypeScript -->
+## TypeScript [`⇧`](#contents)
 
+TypeScript configuration is ongoing. PR's are always welcome to improve the developer experience and project infrastructure.
+
+Currently `typescript.strict` and `typescript.typeCheck` in `nuxt.config.ts` are not enabled.
+
+> In the future, once all TS errors are resolved, activist will be enabling these strict checks. This was done to allow building the app outside `Docker`. Local and Netlify builds proceed despite TS errors with strict checks disabled.
+
+VSCode: Install these extensions (recommended) to enable in-editor type-checking.
+ - [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar)
+ - [Volar TS](https://marketplace.visualstudio.com/items?itemName=Vue.vscode-typescript-vue-plugin)
+
+
+**Regarding SFC (Single File Components) ie. each Vue files (.vue)**
+
+Create general frontend types in `frontend/types`
+
+See [Vue and TypeScript docs](https://vuejs.org/guide/typescript/composition-api.html#typing-component-props) for more information about typing component props.
+
+  <details><summary>With script setup lang="ts" (preferred)</summary>
+
+  - When using `<script setup lang="ts">` use `defineProps` with the generic type argument.
+    ```typescript
+    const props = defineProps<{
+      foo: string
+      bar?: number
+    }>()
+    ```
+  </details>
+  <details><summary>Without script setup lang="ts"</summary>
+
+  - It is necessary to use `defineComponent`
+  ```typescript
+  import { defineComponent } from 'vue'
+
+  export default defineComponent({
+    props: {
+      message: String
+    },
+    setup(props) {
+      props.message // <-- type: string
+    }
+  })
+  ```
+  </details>
+There is a limited set of package types that are available in the global scope.
+
+The current list can be found in `frontend/tsconfig.json` under `"compilerOptions.types"`, with this list being modified as the project matures.
+
+Before opening a new PR, it is recommended to run the command `yarn nuxi typecheck` from within the `frontend` directory. Within VSCode TS errors are visible, however, running this command will tell Nuxt to manually check types. This will help to ensure the new code does not introduce unintended TS errors at build time. Existing TS errors may be ignored. PR's are always welcome to address these errors!
 <a id="tailwind"></a>
 
 ## Tailwind [`⇧`](#contents)


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
In CONTRIBUTING 
- Added a  reference for Nuxt and TypeScript
- Added a note recommending manually check types with `yarn nuxi typecheck` before submitting a PR with new code changes within `frontend`

In STYLEGUIDE
- Created a new section outlining the status of TypeScript configuration with the reasoning behind certain choices.
- Provided recommendations and references for using 
    - `defineProps` within `<script>` tags. 
    - `defineComponent` otherwise.
- Details explaining the reasoning behind using `yarn nuxi typecheck` within the PR process.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #199 
