### PR TITLE
fix:social links opens in the same tab

### DIFF
--- a/frontend/components/Image/ImageGithubShield.vue
+++ b/frontend/components/Image/ImageGithubShield.vue
@@ -1,6 +1,7 @@
 <template>
   <a
     :href="href"
+    target="_blank"
     class="flex items-center px-3 py-1 border space-x-2 card-style focus-brand text-light-text dark:text-dark-text border-light-text dark:border-dark-text bg-light-content dark:bg-dark-content hover:bg-light-highlight dark:hover:bg-dark-highlight"
   >
     <slot></slot>

--- a/frontend/components/LandingPage/LandingPageCommunityBanner.vue
+++ b/frontend/components/LandingPage/LandingPageCommunityBanner.vue
@@ -7,6 +7,7 @@
     >
       <a
         href="https://github.com/activist-org/activist"
+        target="_blank"
         class="flex items-center space-x-3 hover:text-light-text dark:hover:text-dark-text focus-brand"
       >
         <Icon name="cib:github" size="1em" />
@@ -14,6 +15,7 @@
       </a>
       <a
         href="https://matrix.to/#/#activist_community:matrix.org"
+        target="_blank"
         class="flex items-center space-x-3 hover:text-light-text dark:hover:text-dark-text focus-brand"
       >
         <Icon name="IconMatrix" size="1.061em" />
@@ -21,6 +23,7 @@
       </a>
       <a
         href="https://twitter.com/activist_org"
+        target="_blank"
         class="flex items-center space-x-3 hover:text-light-text dark:hover:text-dark-text focus-brand"
       >
         <Icon name="cib:twitter" size="1em" />
@@ -28,6 +31,7 @@
       </a>
       <a
         href="https://instagram.com/activist_org"
+        target="_blank"
         class="flex items-center space-x-3 hover:text-light-text dark:hover:text-dark-text focus-brand"
       >
         <Icon name="cib:instagram" size="1em" />

--- a/frontend/components/WebsiteFooter.vue
+++ b/frontend/components/WebsiteFooter.vue
@@ -17,6 +17,7 @@
           <div class="hover:text-light-text dark:hover:text-dark-text">
             <a
               href="https://github.com/activist-org/activist/releases"
+              target="_blank"
               class="focus-brand"
             >
               v0.0.1
@@ -26,6 +27,7 @@
           <div class="hover:text-light-text dark:hover:text-dark-text">
             <a
               href="https://github.com/activist-org/activist"
+              target="_blank"
               class="focus-brand"
             >
               {{ $t("source-code") }}
@@ -49,6 +51,7 @@
           </p>
           <a
             href="https://github.com/activist-org/activist"
+            target="_blank"
             class="flex items-center mt-3 text-base space-x-2 hover:text-light-text dark:hover:text-dark-text focus-brand"
           >
             <Icon name="cib:github" size="1em" />
@@ -56,6 +59,7 @@
           </a>
           <a
             href="https://matrix.to/#/#activist_community:matrix.org"
+            target="_blank"
             class="flex items-center mt-2 text-base space-x-2 hover:text-light-text dark:hover:text-dark-text focus-brand"
           >
             <Icon name="IconMatrix" size="1.061em" />
@@ -63,6 +67,7 @@
           </a>
           <a
             href="https://twitter.com/activist_org"
+            target="_blank"
             class="flex items-center mt-2 text-base space-x-2 hover:text-light-text dark:hover:text-dark-text focus-brand"
           >
             <Icon name="cib:twitter" size="1em" />
@@ -70,6 +75,7 @@
           </a>
           <a
             href="https://instagram.com/activist_org"
+            target="_blank"
             class="flex items-center mt-2 text-base space-x-2 hover:text-light-text dark:hover:text-dark-text focus-brand"
           >
             <Icon name="cib:instagram" size="1em" />
@@ -186,6 +192,7 @@
           <div class="hover:text-light-text dark:hover:text-dark-text">
             <a
               href="https://github.com/activist-org/activist/releases"
+              target="_blank"
               class="focus-brand"
             >
               v0.0.1
@@ -195,6 +202,7 @@
           <div class="hover:text-light-text dark:hover:text-dark-text">
             <a
               href="https://github.com/activist-org/activist"
+              target="_blank"
               class="focus-brand"
             >
               {{ $t("source-code") }}
@@ -240,6 +248,7 @@
           </p>
           <a
             href="https://github.com/activist-org/activist"
+            target="_blank"
             class="flex items-center mt-3 text-base space-x-2 hover:text-light-text dark:hover:text-dark-text focus-brand"
           >
             <Icon name="cib:github" size="1em" />
@@ -247,6 +256,7 @@
           </a>
           <a
             href="https://matrix.to/#/#activist_community:matrix.org"
+            target="_blank"
             class="flex items-center mt-2 text-base space-x-2 hover:text-light-text dark:hover:text-dark-text focus-brand"
           >
             <Icon name="IconMatrix" size="1.061em" />
@@ -254,6 +264,7 @@
           </a>
           <a
             href="https://twitter.com/activist_org"
+            target="_blank"
             class="flex items-center mt-2 text-base space-x-2 hover:text-light-text dark:hover:text-dark-text focus-brand"
           >
             <Icon name="cib:twitter" size="1em" />
@@ -261,6 +272,7 @@
           </a>
           <a
             href="https://instagram.com/activist_org"
+            target="_blank"
             class="flex items-center mt-2 text-base space-x-2 hover:text-light-text dark:hover:text-dark-text focus-brand"
           >
             <Icon name="cib:instagram" size="1em" />


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

The code changes in this PR modify the handling of social media links to ensure they open in a new tab or window. This way, users can access the linked social media profiles while keeping the original page intact.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #225 
