### PR TITLE
Fix: TS prop errors for some components

### DIFF
--- a/frontend/components/Btn/BtnLabeled.vue
+++ b/frontend/components/Btn/BtnLabeled.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="linkTo == 'placeholder-link'"
-    class="px-4 py-2 font-semibold text-center border select-none rounded-md xl:rounded-lg text-light-distinct border-light-distinct dark:text-dark-distinct dark:border-dark-distinct focus-brand w-fit"
+    class="px-4 py-2 font-semibold text-center border rounded-md select-none xl:rounded-lg text-light-distinct border-light-distinct dark:text-dark-distinct dark:border-dark-distinct focus-brand w-fit"
     :class="{
       'bg-light-cta-orange dark:bg-dark-cta-orange hover:bg-light-cta-orange-hover active:bg-light-cta-orange dark:hover:bg-dark-cta-orange-hover dark:active:bg-dark-cta-orange':
         cta == true,
@@ -28,7 +28,7 @@
   <a
     v-else-if="linkTo.includes('http')"
     :href="linkTo"
-    class="px-4 py-2 font-semibold text-center border select-none rounded-md xl:rounded-lg text-light-distinct border-light-distinct dark:text-dark-distinct dark:border-dark-distinct focus-brand w-fit"
+    class="px-4 py-2 font-semibold text-center border rounded-md select-none xl:rounded-lg text-light-distinct border-light-distinct dark:text-dark-distinct dark:border-dark-distinct focus-brand w-fit"
     :class="{
       'bg-light-cta-orange dark:bg-dark-cta-orange hover:bg-light-cta-orange-hover active:bg-light-cta-orange dark:hover:bg-dark-cta-orange-hover dark:active:bg-dark-cta-orange':
         cta == true,
@@ -56,7 +56,7 @@
   <NuxtLink
     v-else
     :to="localePath(`${linkTo}`)"
-    class="px-4 py-2 font-semibold text-center border select-none rounded-md xl:rounded-lg text-light-distinct border-light-distinct dark:text-dark-distinct dark:border-dark-distinct focus-brand w-fit"
+    class="px-4 py-2 font-semibold text-center border rounded-md select-none xl:rounded-lg text-light-distinct border-light-distinct dark:text-dark-distinct dark:border-dark-distinct focus-brand w-fit"
     :class="{
       'bg-light-cta-orange dark:bg-dark-cta-orange hover:bg-light-cta-orange-hover active:bg-light-cta-orange dark:hover:bg-dark-cta-orange-hover dark:active:bg-dark-cta-orange':
         cta == true,
@@ -84,19 +84,20 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
+export interface Props {
   cta: boolean;
   linkTo: string;
   label: string;
   fontSize: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
   leftIcon?: string;
   rightIcon?: string;
-  iconSize: {
-    default: "1em";
-    type: string;
-    required: false;
-  };
-  alternateText: string | null;
-}>();
+  iconSize?: string;
+  alternateText?: string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  iconSize: "1em",
+});
+
 const localePath = useLocalePath();
 </script>

--- a/frontend/components/LandingPage/LandingPageContent.vue
+++ b/frontend/components/LandingPage/LandingPageContent.vue
@@ -164,13 +164,13 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
+  defineProps<{
   contentPosition: "left" | "right" | "top";
   header: string;
   tagline: string;
   text: string;
-  imageURL: string;
-  altText: string;
+  imageURL?: string;
+  altText?: string;
   btnText1: string;
   btnURL1: string;
   btnAlternateText1?: string;
@@ -179,5 +179,6 @@ defineProps<{
   btnAlternateText2?: string;
   subText?: string;
 }>();
+
 const localePath = useLocalePath();
 </script>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Fixes ts prop errors of `BtnLabeled.vue` and `LandingPageContent.vue`:

1. `BtnLabeled.vue`: 
   1. changed `alternateText` to be optional, its type to be string only.
   2. changed `iconSize` to be correctly typed with `withDefaults()` wrapper function so it is now optional and has a default value.

2. `LandingPageContent.vue`:
   1. changed `imageURL` and `altText` to be optional for the top position variant where there is no image.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #234 
- #233 
