### PR TITLE
Add user search result card per Figma specs

### DIFF
--- a/frontend/components/card/search-result/CardSearchResult.vue
+++ b/frontend/components/card/search-result/CardSearchResult.vue
@@ -21,6 +21,12 @@
     >
       <CardSearchResultResource :resource="resource" :isPrivate="isPrivate" />
     </div>
+    <div
+      v-if="searchResultType === 'user'"
+      class="flex md:flex-row flex-col p-2 sm:px-5 sm:py-3 h-fit"
+    >
+      <CardSearchResultUser :user="user" :isPrivate="isPrivate" />
+    </div>
   </div>
 </template>
 
@@ -28,12 +34,14 @@
 import type { Event } from "~~/types/event";
 import type { Organization } from "~~/types/organization";
 import type { Resource } from "~~/types/resource";
+import type { User } from "~~/types/user";
 
 const props = defineProps<{
-  searchResultType: "organization" | "event" | "resource";
+  searchResultType: "organization" | "event" | "resource" | "user";
   isPrivate?: boolean;
   organization?: Organization;
   event?: Event;
   resource?: Resource;
+  user?: User;
 }>();
 </script>

--- a/frontend/components/card/search-result/CardSearchResultUser.vue
+++ b/frontend/components/card/search-result/CardSearchResultUser.vue
@@ -1,0 +1,46 @@
+<template>
+    <div
+      class="border w-fit h-[100%] border-light-section-div dark:border-dark-section-div rounded-lg bg-light-content dark:bg-dark-content"
+    >
+      <div
+        class="w-[200px] h-[200px] flex justify-center items-center fill-light-text dark:fill-dark-text"
+      >
+        <Icon name="bi:person" class="w-[75%] h-[75%]" />
+      </div>
+    </div>
+    <div class="px-6 pb-1 space-y-4 md:grow">
+      <div class="flex justify-between">
+        <div class="flex items-center space-x-4">
+          <h2 class="font-bold responsive-h3">
+            {{ user.name }}
+          </h2>
+          <div class="text-light-cta-orange dark:text-dark-cta-orange">
+            <Icon name="ph:dots-three-circle-vertical" size="2em" />
+          </div>
+        </div>
+      </div>
+      <div class="flex gap-4" v-if="user">
+        <div class="flex items-center gap-1" v-if="user.location">
+          <Icon name="ic:sharp-location-on" class="mr-1" size="1.25em" />
+          {{ user.location }}
+        </div>
+        <div class="flex items-center gap-1">
+          <Icon name="bi:people" class="mr-1" />
+          {{ user.supporters }} supporters
+        </div>
+      </div>
+      <div>
+        {{ user.description }}
+      </div>
+    </div>
+  </template>
+  
+  <script setup lang="ts">
+  import type { User } from "~~/types/user";
+  
+  const props = defineProps<{
+    isPrivate?: boolean;
+    user?: User;
+  }>();
+  </script>
+  

--- a/frontend/pages/home/index.vue
+++ b/frontend/pages/home/index.vue
@@ -37,6 +37,11 @@
         :isPrivate="false"
         :resource="resource"
       />
+      <CardSearchResult
+        searchResultType="user"
+        :isPrivate="false"
+        :user="user"
+      />
     </div>
   </div>
 </template>
@@ -45,6 +50,7 @@
 import { Event } from "~~/types/event";
 import { Organization } from "~~/types/organization";
 import { Resource } from "~~/types/resource";
+import { User } from "~~/types/user";
 const title = ref("Home");
 
 const { data: organizations } = await useFetch(
@@ -90,5 +96,12 @@ const event: Event = {
   onlineLocation: "Zoom Test Room",
   date: new Date(),
   supporters: 10,
+};
+
+const user: User = {
+  name: "John A. Tester",
+  location: "Testville, TN",
+  supporters: 123,
+  description: "I love to test!",
 };
 </script>

--- a/frontend/types/user.d.ts
+++ b/frontend/types/user.d.ts
@@ -1,0 +1,6 @@
+export interface User {
+    name: string;
+    location?: string;
+    supporters: number;
+    description: string;
+}


### PR DESCRIPTION
Add user search result card per Figma specs

Add user typescript definition

Note that the icon for the user is just the bootstrap person icon. We'll eventually need some icon SVG defined to replace this to keep in style with the other search result cards

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #265 
