### PR TITLE
fix: TS errors in multiple files in components/card.*

### DIFF
--- a/frontend/components/card/CardAbout.vue
+++ b/frontend/components/card/CardAbout.vue
@@ -1,4 +1,4 @@
-<template>
+  <template>
   <div class="px-6 py-5 card-style">
     <div class="relative flex-col w-full gap-5">
       <div
@@ -11,7 +11,7 @@
           <h3 class="text-left responsive-h3 font-display">About</h3>
           <Icon name="bi:pencil-square" size="1.2em" />
         </div>
-        <div v-if="aboutType === 'event'" class="flex-col space-y-3">
+        <div v-if="event" class="flex-col space-y-3">
           <TopicMarker :topic="event.topic" class="" />
           <div class="flex items-center gap-3">
             <div
@@ -40,7 +40,7 @@
             </button>
           </div>
         </div>
-        <div v-if="aboutType === 'organization'">
+        <div v-if="organization">
           <div class="flex flex-col mb-3 gap-5 sm:items-center sm:flex-row">
             <TopicMarker :topic="organization.topic" class="" />
             <div class="flex items-center gap-2">

--- a/frontend/components/card/CardConnect.vue
+++ b/frontend/components/card/CardConnect.vue
@@ -93,7 +93,7 @@
           >
             <PopoverPanel class="absolute bottom-0 mb-12">
               <PopupNewField
-                @on-cta-clicked="(account) => emit('on-new-account', account)"
+                @on-cta-clicked="emit('on-new-account', account)"
                 @on-close-clicked="onClose(close)"
                 :title="'Add Account'"
                 :field-name-prompt="'Name'"

--- a/frontend/components/card/search-result/CardSearchResultEvent.vue
+++ b/frontend/components/card/search-result/CardSearchResultEvent.vue
@@ -64,6 +64,6 @@ import type { Event } from "~~/types/event";
 
 defineProps<{
   isPrivate?: boolean;
-  event?: Event;
+  event: Event;
 }>();
 </script>

--- a/frontend/components/card/search-result/CardSearchResultOrganization.vue
+++ b/frontend/components/card/search-result/CardSearchResultOrganization.vue
@@ -50,6 +50,6 @@ import type { Organization } from "~~/types/organization";
 
 const props = defineProps<{
   isPrivate?: boolean;
-  organization?: Organization;
+  organization: Organization;
 }>();
 </script>

--- a/frontend/components/card/search-result/CardSearchResultResource.vue
+++ b/frontend/components/card/search-result/CardSearchResultResource.vue
@@ -56,6 +56,6 @@ import type { Resource } from "~~/types/resource";
 
 const props = defineProps<{
   isPrivate?: boolean;
-  resource?: Resource;
+  resource: Resource;
 }>();
 </script>

--- a/frontend/components/card/search-result/CardSearchResultUser.vue
+++ b/frontend/components/card/search-result/CardSearchResultUser.vue
@@ -40,6 +40,6 @@ import type { User } from "~~/types/user";
 
 const props = defineProps<{
   isPrivate?: boolean;
-  user?: User;
+  user: User;
 }>();
 </script>

--- a/frontend/components/popup/PopupNewField.vue
+++ b/frontend/components/popup/PopupNewField.vue
@@ -46,7 +46,7 @@ defineProps<{
   ctaBtnLabel: string;
 }>();
 
-const inputValue = ref();
+const inputValue = ref<HTMLInputElement | null>(null);
 
 const emit = defineEmits(["on-cta-clicked", "on-close-clicked"]);
 </script>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,8 +5,5 @@
     "strict": true,
     "skipLibCheck": true,
     "types": ["@vueuse/nuxt", "@vueuse/core", "@pinia/nuxt"],
-    "paths": {
-      "@/*": ["./*"]
-    }
   }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Points to review:
1. `tsconfig` included an alias that appeared to be overriding the defaults from nuxt, causing imported types to not be recognized as well as leading to types from inside `node_modules` not being auto-imported. https://nuxt.com/docs/api/configuration/nuxt-config#alias

2. Change `v-if` in `CardAbout` to use `event` and `organization` instead of `aboutType` following the same style as `CardGetInvolved`

3. Added typing for template ref in `PopupNewField` according to https://vuejs.org/guide/typescript/composition-api.html#typing-template-refs (emit is typed now)

4. In each search result component, the specific result ie `User, organization, resource, event` should not be optional

5. In `CardConnect` removed the arrow function from the emit of `@on-cta-clicked` (I don't believe this is needed, and it was causing account to register `no explicit any` ts error)

Current TS errors

![image](https://github.com/activist-org/activist/assets/102203363/857cbd4c-4f9a-4da8-9d94-aafbda982e3f)


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #259 
