### PR TITLE
IconOrganizationStatus component added

### DIFF
--- a/frontend/components/icon/IconOrganizationStatus.vue
+++ b/frontend/components/icon/IconOrganizationStatus.vue
@@ -1,6 +1,6 @@
 <template>
-    <span v-if="status == 'approved'" class="">
-        <div id="approved" class="w-5 sm:w-6 md:w-7 xl:w-9">
+    <span v-if="status == 'approved'">
+        <div class="w-5 sm:w-6 md:w-7 xl:w-9">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
                 <path class="fill-light-accepted-green fill-dark-accepted-green"  d="M10.97 4.97a.235.235 0 0 0-.02.022L7.477 9.417L5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-1.071-1.05z"/>
                 <path class="fill-light-accepted-green/40 fill-dark-accepted-green/40"  d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417L5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
@@ -9,7 +9,7 @@
         </div>
     </span>
     <span v-else>
-        <div id="pending" class="w-5 sm:w-6 md:w-7 xl:w-9">
+        <div class="w-5 sm:w-6 md:w-7 xl:w-9">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
                 <path class="fill-light-pending-yellow fill-dark-pending-yellow" d="M7.002 12a1 1 0 1 1 2 0a1 1 0 0 1-2 0zM7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995z"/>
                 <path class="fill-light-pending-yellow/40 fill-dark-pending-yellow/40" d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2a1 1 0 0 1 0-2z"/>
@@ -21,6 +21,6 @@
 
 <script setup lang="ts">
 defineProps<{
-    status: 'pending' | 'approved'
+    status: 'approved'
 }>();
 </script>

--- a/frontend/components/icon/IconOrganizationStatus.vue
+++ b/frontend/components/icon/IconOrganizationStatus.vue
@@ -1,0 +1,26 @@
+<template>
+    <span v-if="status == 'approved'" class="">
+        <div id="approved" class="w-5 sm:w-6 md:w-7 xl:w-9">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+                <path class="fill-light-accepted-green fill-dark-accepted-green"  d="M10.97 4.97a.235.235 0 0 0-.02.022L7.477 9.417L5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-1.071-1.05z"/>
+                <path class="fill-light-accepted-green/40 fill-dark-accepted-green/40"  d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417L5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+                <path class="fill-light-accepted-green fill-dark-accepted-green"  d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+            </svg>
+        </div>
+    </span>
+    <span v-else>
+        <div id="pending" class="w-5 sm:w-6 md:w-7 xl:w-9">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+                <path class="fill-light-pending-yellow fill-dark-pending-yellow" d="M7.002 12a1 1 0 1 1 2 0a1 1 0 0 1-2 0zM7.1 5.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995z"/>
+                <path class="fill-light-pending-yellow/40 fill-dark-pending-yellow/40" d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2a1 1 0 0 1 0-2z"/>
+                <path class="fill-light-pending-yellow fill-dark-pending-yellow" d="M7.938 2.016A.13.13 0 0 1 8.002 2a.13.13 0 0 1 .063.016a.146.146 0 0 1 .054.057l6.857 11.667c.036.06.035.124.002.183a.163.163 0 0 1-.054.06a.116.116 0 0 1-.066.017H1.146a.115.115 0 0 1-.066-.017a.163.163 0 0 1-.054-.06a.176.176 0 0 1 .002-.183L7.884 2.073a.147.147 0 0 1 .054-.057zm1.044-.45a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566z"/>
+            </svg>
+        </div>
+    </span>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+    status: 'pending' | 'approved'
+}>();
+</script>

--- a/frontend/pages/organizations/[id]/about.vue
+++ b/frontend/pages/organizations/[id]/about.vue
@@ -13,7 +13,7 @@
           {{ organization.name }}
           
         </h1>
-        <IconOrganizationStatus :status="'approved'"></IconOrganizationStatus>
+        <IconOrganizationStatus :status="''"></IconOrganizationStatus>
       </div>
     <flex class="relative flex items-center w-full py-6"
       ><h2

--- a/frontend/pages/organizations/[id]/about.vue
+++ b/frontend/pages/organizations/[id]/about.vue
@@ -6,11 +6,15 @@
       <Title>{{ organization.name }}</Title>
     </Head>
     <PageBreadcrumbs class="mt-4" :organization="organization" />
-    <h1
-      class="pt-6 font-bold transition-all duration-500 responsive-h1 text-light-text dark:text-dark-text"
-    >
-      {{ organization.name }}
-    </h1>
+      <div class="flex items-baseline gap-2">
+        <h1
+          class=" pt-6 font-bold transition-all duration-500 responsive-h1 text-light-text dark:text-dark-text"
+        >
+          {{ organization.name }}
+          
+        </h1>
+        <IconOrganizationStatus :status="'approved'"></IconOrganizationStatus>
+      </div>
     <flex class="relative flex items-center w-full py-6"
       ><h2
         :v-if="organization.tagline"
@@ -67,6 +71,7 @@ definePageMeta({
 });
 
 import { Organization } from "~~/types/organization";
+import IconOrganizationStatus from "../../../components/icon/IconOrganizationStatus.vue";
 
 const organization: Organization = {
   name: "tech from below",


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

In this PR the IconOrganizationStatus component was added. The Icon was made with [bootstrap icons](https://icones.js.org/collection/bi). 

The approved icon is a combination of `check-circle` and `check-circle-fill`.
The pending icon is a combination of `exclamation-triangle` and `exclamation-triangle-fill`.

Prop `status` takes a string `'approved' ` or else it's not approved by default.

To test the component i used the url `.../en/organizations/1/about`. I implemented the component in the about section.

### Related issue

- #272 
