### PR TITLE
CardDangerZone implementation

### DIFF
--- a/frontend/components/card/CardDangerZone.vue
+++ b/frontend/components/card/CardDangerZone.vue
@@ -1,0 +1,36 @@
+<template>
+    <div
+        class="px-6 py-5 bg-light-act-red/30 dark:bg-dark-act-red/30 border border-light-act-red dark:border-dark-act-red rounded-md sm:rounded-lg shadow-sm shadow-zinc-700 text-light-text dark:text-dark-text">
+        <div class="flex flex-col gap-5">
+            <h3 class="text-left text-light-act-red dark:text-dark-act-red responsive-h3 font-display font-bold">Dange zone
+            </h3>
+            <p class="">{{ description }}</p>
+            <form method="post">
+                <div class="grid grid-cols-1 sm:grid-cols-2 justify-between gap-4 sm:gap-8">
+                    <div class="flex flex-col gap-2">
+                        <label for="username" class="text-light-act-red dark:text-dark-act-red responsive-h4 font-bold"
+                            placeholder="Enter your username">Your username *</label>
+                        <input
+                            id="username" class="py-1 px-3 bg-transparent border border-black rounded-md focus:outline-none focus:ring-1 focus:ring-black dark:focus:ring-blac">
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <label for="password" class="text-light-act-red dark:text-dark-act-red responsive-h4 font-bold"
+                            placeholder="Enter your password">Your password *</label>
+                        <input id="password" type="password"
+                            class="py-1 px-3 bg-transparent border border-black rounded-md focus:outline-none focus:ring-1 focus:ring-black dark:focus:ring-black">
+                    </div>
+                </div>
+                <div class="mt-5">
+                    <button aria-label="Delete account" type="" class="py-2 px-3 bg-black text-white rounded-md w-auto ">{{ ctaBtnText }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+    description: string,
+    ctaBtnText: { type: string, required: true }
+}>();
+</script>

--- a/frontend/pages/organizations/[id]/about.vue
+++ b/frontend/pages/organizations/[id]/about.vue
@@ -59,6 +59,12 @@
         :social-links="organization.socialLinks"
         :userIsAdmin="true"
       />
+      <CardDangerZone 
+      description="Here's where you can delete your account. Please note that this is not a reversible action - 
+                any permissions and settings that you have saved will be permanently lost. 
+                If you questions on your account please contact us on our contact page." 
+      ctaBtnText="Permanently delete my account" 
+      />
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR contains the CardDangerZone component. I tested the url `/en/organizations/1/about` and used the chrome devtools to check light/dark mode. 

Comments:
I used the styles from `card-style` for the first `<div>` element without the colors to keep the card consistent with the rest. But it will not be updated in case the `card-style` changes. I think a `base-card-style` without colors could help.

### Related issue

- #274 
