### PR TITLE
fix: typescript errors in pages dir, refactor style guide

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -55,39 +55,21 @@ VSCode: it is recommended to install these extensions to enable in-editor type-c
 
 **Regarding SFC (Single File Components) ie. each Vue files (.vue)**
 
-Create general frontend types in the [frontend/types](https://github.com/activist-org/activist/tree/main/frontend/types) directory. See [Vue and TypeScript docs](https://vuejs.org/guide/typescript/composition-api.html#typing-component-props) for more information about typing component props.
+Create general frontend types in the [frontend/types](https://github.com/activist-org/activist/tree/main/frontend/types) directory.
 
-<details><summary>With script setup lang="ts" (preferred)</summary>
+Recommendations:
+- When typing Arrays, use `'arrayElementType'[]` rather than the generic type `Array<T>` unless [extending](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#arrays)
+  - ```ts
+    const strArray: string[] = ["Hi", "thank", "you", "for", "contributing"]
+    ```
+- `withDefault` when types require [default values](https://vuejs.org/guide/typescript/composition-api.html#props-default-values)
 
-- When using `<script setup lang="ts">` use `defineProps` with the generic type argument.
-
-  ```typescript
-  const props = defineProps<{
-    foo: string;
-    bar?: number;
-  }>();
-  ```
-
-</details>
-
-<details><summary>Without script setup lang="ts"</summary>
-
-- It is necessary to use `defineComponent`
-
-```typescript
-import { defineComponent } from "vue";
-
-export default defineComponent({
-  props: {
-    message: String,
-  },
-  setup(props) {
-    props.message; // <-- type: string
-  },
-});
-```
-
-</details>
+Refer to the Vue docs:
+- Typing component props:
+  - [Vue and TypeScript docs](https://vuejs.org/guide/typescript/overview.html)
+- Syntax for:
+  - [Composition API](https://vuejs.org/guide/typescript/composition-api.html)
+  - [Options API](https://vuejs.org/guide/typescript/options-api.html)
 
 There is a limited set of package types that are available in the global scope. The current list can be found in `frontend/tsconfig.json` under `"compilerOptions.types"`, with this list being modified as the project matures.
 

--- a/frontend/components/card/CardConnect.vue
+++ b/frontend/components/card/CardConnect.vue
@@ -111,7 +111,7 @@
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/vue";
 
 const props = defineProps<{
-  socialLinks: Array<string>;
+  socialLinks: string[];
   userIsAdmin?: boolean;
 }>();
 

--- a/frontend/components/card/CardFeed.vue
+++ b/frontend/components/card/CardFeed.vue
@@ -8,6 +8,6 @@
 
 <script setup lang="ts">
 defineProps<{
-  feedItemURLs?: Array<string>;
+  feedItemURLs?: string[];
 }>();
 </script>

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -30,7 +30,7 @@ import "leaflet/dist/leaflet.css";
 import { ref } from "vue";
 
 const props = defineProps<{
-  addresses: Array<string>;
+  addresses: string[];
   title: string;
   type: string;
 }>();

--- a/frontend/types/event.d.ts
+++ b/frontend/types/event.d.ts
@@ -11,5 +11,5 @@ export interface Event {
   date?: datetime;
   supporters: number;
   imageURL?: string;
-  socialLinks?: [string];
+  socialLinks?: string[];
 }

--- a/frontend/types/organization.d.ts
+++ b/frontend/types/organization.d.ts
@@ -7,6 +7,6 @@ export interface Organization {
   members: number;
   supporters: number;
   imageURL?: string;
-  workingGroups?: Array<string>;
-  socialLinks?: [string];
+  workingGroups?: string[];
+  socialLinks?: string[];
 }


### PR DESCRIPTION

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
As discussed in #261. 
1. Refactored uses of `Array<T>` to `'arrayElemType'[]` as needed 
2. Removed `[string]` in `event` and `organization` to allow for string arrays `[string]` -> `string[]`
3. TS `STYLEGUIDE`: Removed `<script>` information  and added recommendations for TS and links to relevant docs

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #261 
