### PR TITLE
Fix: fixes TS errors in misc components

### DIFF
--- a/frontend/components/PageBreadcrumbs.vue
+++ b/frontend/components/PageBreadcrumbs.vue
@@ -59,7 +59,7 @@ defineProps<{
   event?: Event;
 }>();
 
-const breadcrumbs = ref([]);
+const breadcrumbs = ref<string[]>([]);
 
 function setBreadcrumbs() {
   const url = window.location.pathname;
@@ -67,7 +67,7 @@ function setBreadcrumbs() {
   breadcrumbs.value = nonEmptySegments;
 }
 
-function getNonEmptySegmentsFromURL(url) {
+function getNonEmptySegmentsFromURL(url: string) {
   const segments = url.split("/");
   const nonEmptySegments = segments.filter((segment) => segment);
   return nonEmptySegments;
@@ -77,22 +77,22 @@ onMounted(() => {
   setBreadcrumbs();
 });
 
-function isLocaleSegment(segment) {
-  return locales.value.some((i) => i.code === segment);
+function isLocaleSegment(segment: string) {
+  return locales.value.some((locale) => typeof (locale) === "string" ? locale === segment : locale.code === segment);
 }
 
 const displayBreadcrumbs = computed(() => {
   return breadcrumbs.value.filter((segment) => !isLocaleSegment(segment));
 });
 
-function makeURL(breadcrumb) {
+function makeURL(breadcrumb: string) {
   const clickedBreadcrumbIndex = breadcrumbs.value.indexOf(breadcrumb);
   const segmentsForURL = breadcrumbs.value.slice(0, clickedBreadcrumbIndex + 1);
   const url = "/" + segmentsForURL.join("/");
   return url;
 }
 
-function capitalizeFirstLetter(string) {
+function capitalizeFirstLetter(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 </script>

--- a/frontend/components/landing/LandingContent.vue
+++ b/frontend/components/landing/LandingContent.vue
@@ -157,6 +157,7 @@
         <GridSupporters class="mt-6 xl:mt-8" />
       </div>
       <p
+        v-if="subText"
         class="pt-8 mx-12 text-center md:max-w-md lg:max-w-lg xl:pt-12 text-light-special-text dark:text-dark-special-text"
       >
         {{ $t(subText) }}

--- a/frontend/components/modal/ModalImage.vue
+++ b/frontend/components/modal/ModalImage.vue
@@ -56,10 +56,10 @@
 import { Dialog, DialogPanel } from "@headlessui/vue";
 import { ref } from "vue";
 
-const props = defineProps({
-  imageURL: String,
-  imageAltText: String,
-});
+defineProps<{
+  imageURL: string,
+  imageAltText: string,
+}>();
 
 const isOpen = ref(false);
 

--- a/frontend/components/selector/SelectorLanguage.vue
+++ b/frontend/components/selector/SelectorLanguage.vue
@@ -42,8 +42,8 @@
         <ul class="px-2 py-2">
           <NuxtLink
             v-for="locale in availableLocales"
-            :key="locale.code"
-            :to="switchLocalePath(locale.code)"
+            :key="getLocaleCode(locale)"
+            :to="switchLocalePath(getLocaleCode(locale))"
           >
             <MenuItem v-slot="{ active }">
               <li
@@ -54,7 +54,7 @@
                   'group flex w-full [word-spacing:0.5em] items-center rounded-md pl-4 pr-2 py-2 text-sm',
                 ]"
               >
-                {{ locale.name }}
+                {{ getLocaleCode(locale) }}
               </li>
             </MenuItem>
           </NuxtLink>
@@ -66,13 +66,21 @@
 
 <script setup lang="ts">
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/vue";
+import { LocaleObject } from "@nuxtjs/i18n/dist/runtime/composables";
 const props = defineProps({
   location: String,
 });
 
 const { locale, locales } = useI18n();
 const switchLocalePath = useSwitchLocalePath();
+
+const localesValues: Array<string | LocaleObject> = locales.value;
+  
 const availableLocales = computed(() => {
-  return locales.value.filter((i) => i.code !== locale.value);
+  return localesValues.filter((i) => getLocaleCode(i) !== locale.value);
 });
+
+function getLocaleCode(locale: string | LocaleObject) {
+  return typeof locale === "string" ? locale : locale.code;
+}
 </script>

--- a/frontend/components/sidebar/left/SidebarLeft.vue
+++ b/frontend/components/sidebar/left/SidebarLeft.vue
@@ -41,6 +41,6 @@ if (route.path.includes("organizations")) {
 }
 
 // TODO use real name of organization / event when available from backend.
-const placeholderName = route.path.split("/").at(-2).replaceAll("-", " ");
+const placeholderName = route.path.split("/").at(-2)?.replaceAll("-", " ");
 const placeholderLogo = "/images/tech-from-below.svg";
 </script>

--- a/frontend/components/sidebar/left/SidebarLeftFooter.vue
+++ b/frontend/components/sidebar/left/SidebarLeftFooter.vue
@@ -246,13 +246,14 @@
 
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/vue";
+import type { Ref } from "vue";
 
 const route = useRoute();
 const onHomePage = route.path.includes("home");
 
-const disclosure = ref([]);
+const disclosure = ref<((ref?: Ref | HTMLElement) => void)[]>([]);
 const closeOtherMenus = (id: number) => {
-  disclosure.value.filter((d, i) => i !== id).forEach((c) => c());
+  disclosure.value.filter((d, i) => i !== id).forEach((close) => close());
 };
 const sidebar = useSidebar();
 </script>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Fixes TS errors for several misc components listed as below:

1. `PageBreadcrumbs`
2. `ModalImage`
3. `LandingContent`
4. `SidebarLeft`
5. `SidebarLeftFooter`
6. `SelectorLanguage`

Although now TS errors are all gone, I am not happy about the work-arounds relating i18n's `locales` interface. For example, in `SelectorLanguage`, the original error was about `locales.value.filter` because locales has an union of `string[] | LocaleObject[]`. 

I researched for some time and found only a walkaround as in my PR, and the result is that now the `availableLocales` has a type of `Array<string | LocaleObject>`, so another function `getLocaleCode` is added. 

I don't think this is an elegant solution so maybe you can take a look at it?

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #262 
