### PR TITLE
Feature: MediaImageCarousel converted to Swiper Element

### DIFF
--- a/frontend/components/media/MediaImageCarousel.vue
+++ b/frontend/components/media/MediaImageCarousel.vue
@@ -1,7 +1,6 @@
 <template>
-  <swiper
+  <swiper-container
     class="w-full h-full swiper card-style"
-    :modules="modules"
     :slides-per-view="1"
     :space-between="30"
     :loop="true"
@@ -18,28 +17,26 @@
         {{ n }}
       </p>
     </swiper-slide>
-  </swiper>
+  </swiper-container>
 </template>
 
-<script lang="ts">
-import { Navigation, Pagination } from "swiper";
-import "swiper/css";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
-import { Swiper, SwiperSlide } from "swiper/vue";
-import { defineComponent } from "vue";
-
-export default defineComponent({
-  title: "Loop mode / Infinite loop",
-  url: import.meta.url,
-  components: {
-    Swiper,
-    SwiperSlide,
-  },
-  setup() {
-    return {
-      modules: [Pagination, Navigation],
-    };
-  },
-});
+<script setup lang="ts">
+import { register } from "swiper/element/bundle";
+register();
 </script>
+
+<style>
+swiper-container::part(button-prev),
+swiper-container::part(button-next) {
+  @apply focus-brand text-light-cta-orange hover:text-light-cta-orange-hover dark:text-dark-cta-orange dark:hover:text-dark-cta-orange-hover;
+}
+
+swiper-container::part(bullet-active) {
+  @apply focus-brand bg-light-cta-orange dark:bg-dark-cta-orange;
+}
+
+swiper-container::part(bullet) {
+  @apply focus-brand hover:bg-light-cta-orange-hover dark:hover:bg-dark-cta-orange-hover;
+}
+
+</style>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

`MediaImageCarousel` is now converted to [Swiper Element](https://swiperjs.com/element). And it is now using Vue Composition API as well.

While I used [Parts](https://swiperjs.com/element#parts) to target prev and next buttons for some custom stylings:

```
swiper-container::part(button-prev),
swiper-container::part(button-next) {
  @apply focus-brand text-light-cta-orange hover:text-light-cta-orange-hover dark:text-dark-cta-orange dark:hover:text-dark-cta-orange-hover;
}
```

~I **can't** seem to target the **pagination bullets** for more custom CSS styles, I have tried the example but it does not work. I think it might be a bug for Swiper, please give it a spin and let me know if I should submit an issue for them.~

Just as I was writing up this PR, the custom CSS styles for pagination bullets works now. Great!

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #258 
