### PR TITLE
Models standard structure

### DIFF
--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
-'''
+"""
 Considerations:
 
 - Every field without a default value has been temporarily set to null=True.
@@ -12,11 +12,11 @@ Considerations:
     last_updated = models.DateTimeField(auto_now=True)
 - All fields have on_delete=models.CASCADE: this needs to be reviewed, as SET_NULL is preferable in many cases.
 - More comments should be added to improve the readability and understanding of the code.
-'''
+"""
 
 
 class Support(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     supporter_type = models.IntegerField(null=True)
     supporter_entity = models.IntegerField(null=True)
@@ -26,9 +26,10 @@ class Support(models.Model):
     def __str__(self):
         return self.index
 
+
 # New user model
 class User(AbstractUser):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     password = models.CharField(max_length=255)
     location = models.CharField(max_length=30, null=True)
     description = models.TextField(max_length=500, null=True)
@@ -39,10 +40,10 @@ class User(AbstractUser):
     )
     social_accounts = ArrayField(models.CharField(max_length=255), null=True)
     total_flags = models.IntegerField(default=0)
-    
+
     creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
-    
+
     class Meta:
         verbose_name = "user"
         verbose_name_plural = "2. Users"
@@ -52,7 +53,7 @@ class User(AbstractUser):
 
 
 class Organization(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     tagline = models.CharField(max_length=255)
     application_id: models.IntegerField(null=True)
@@ -71,7 +72,7 @@ class Organization(models.Model):
 
 
 class Event(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
     tagline = models.CharField(max_length=255)
@@ -83,7 +84,7 @@ class Event(models.Model):
     offline_location_long = models.FloatField(null=True)
     description = models.TextField(max_length=500)
     get_involved_text = models.TextField(max_length=500)
-    
+
     creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
     start_time = models.DateField(null=True)
@@ -94,7 +95,7 @@ class Event(models.Model):
 
 
 class Role(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     is_custom = models.BooleanField(null=True)
     description = models.TextField(max_length=500)
@@ -112,7 +113,7 @@ class Role(models.Model):
 
 
 class Topic(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     active = models.BooleanField(null=True)
     description = models.TextField(max_length=500)
@@ -130,14 +131,14 @@ class Topic(models.Model):
 
 
 class Resource(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     topics = ArrayField(models.CharField(max_length=255))
     location = models.CharField(max_length=255)
     url = models.CharField(max_length=255)
     total_flags = models.IntegerField(null=True)
     description = models.TextField(max_length=500)
-    
+
     creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     deletion_date = models.DateField(null=True)
@@ -151,10 +152,10 @@ class Resource(models.Model):
 
 
 class Format(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=500)
-    
+
     creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     deprecation_date = models.DateField(null=True)
@@ -168,7 +169,7 @@ class Format(models.Model):
 
 
 class Group(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
     description = models.TextField(max_length=500)
@@ -188,7 +189,7 @@ class Group(models.Model):
 
 
 class Task(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=500)
     tags = ArrayField(models.CharField(max_length=255))
@@ -205,9 +206,8 @@ class Task(models.Model):
         return self.name
 
 
-
 class SupportEntityTypes(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     type = models.ForeignKey(Support, on_delete=models.CASCADE)
 
@@ -220,7 +220,7 @@ class SupportEntityTypes(models.Model):
 
 
 class UserResource(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
@@ -230,7 +230,7 @@ class UserResource(models.Model):
 
 
 class UserTopic(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -240,7 +240,7 @@ class UserTopic(models.Model):
 
 
 class UserTask(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     task_id = models.ForeignKey(Task, on_delete=models.CASCADE)
@@ -250,7 +250,7 @@ class UserTask(models.Model):
 
 
 class GroupMember(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -260,7 +260,7 @@ class GroupMember(models.Model):
 
 
 class GroupResource(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
@@ -270,7 +270,7 @@ class GroupResource(models.Model):
 
 
 class GroupTopic(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -280,7 +280,7 @@ class GroupTopic(models.Model):
 
 
 class GroupEvent(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
@@ -290,7 +290,7 @@ class GroupEvent(models.Model):
 
 
 class EventResource(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
@@ -300,7 +300,7 @@ class EventResource(models.Model):
 
 
 class EventRole(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     role_id = models.ForeignKey(Role, on_delete=models.CASCADE)
@@ -310,7 +310,7 @@ class EventRole(models.Model):
 
 
 class EventTopic(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -320,7 +320,7 @@ class EventTopic(models.Model):
 
 
 class EventAttendee(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -329,7 +329,7 @@ class EventAttendee(models.Model):
 
 
 class EventAttendeeStatus(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     status = models.IntegerField(null=True)
     status_name = models.CharField(max_length=255)
 
@@ -338,7 +338,7 @@ class EventAttendeeStatus(models.Model):
 
 
 class EventTask(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     task_id = models.ForeignKey(Task, on_delete=models.CASCADE)
@@ -348,7 +348,7 @@ class EventTask(models.Model):
 
 
 class TopicFormat(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index: models.IntegerField(null=True)
     topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
     format_id: models.ForeignKey(Format, on_delete=models.CASCADE)
@@ -358,7 +358,7 @@ class TopicFormat(models.Model):
 
 
 class ResourceTopic(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index: models.IntegerField(null=True)
     resource_id: models.ForeignKey(Resource, on_delete=models.CASCADE)
     topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -368,7 +368,7 @@ class ResourceTopic(models.Model):
 
 
 class OrganizationApplicationStatus(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     status: models.IntegerField(null=True)
     status_name: models.CharField(max_length=255)
 
@@ -377,7 +377,7 @@ class OrganizationApplicationStatus(models.Model):
 
 
 class OrganizationApplication(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     status = models.ForeignKey(OrganizationApplicationStatus, on_delete=models.CASCADE)
     org_id = models.IntegerField(null=True)
     orgs_in_favor: ArrayField(models.IntegerField)
@@ -391,7 +391,7 @@ class OrganizationApplication(models.Model):
 
 
 class OrganizationResource(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index: models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
 
@@ -400,7 +400,7 @@ class OrganizationResource(models.Model):
 
 
 class OrganizationMember(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index: models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     user_id: models.ForeignKey(User, on_delete=models.CASCADE)
@@ -413,7 +413,7 @@ class OrganizationMember(models.Model):
 
 
 class OrganizationTopic(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index: models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -423,17 +423,17 @@ class OrganizationTopic(models.Model):
 
 
 class OrganizationEvent(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     event_id: models.ForeignKey(Event, on_delete=models.CASCADE)
-        
+
     def __str__(self):
         return self.index
 
 
 class OrganizationTask(models.Model):
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     index = models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     task_id: models.ForeignKey(Task, on_delete=models.CASCADE)

--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -23,6 +23,9 @@ class Support(models.Model):
     supported_type = models.IntegerField(null=True)
     supported_entity = models.IntegerField(null=True)
 
+    def __str__(self):
+        return self.index
+
 # New user model
 class User(AbstractUser):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
@@ -40,7 +43,6 @@ class User(AbstractUser):
     creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
     
-
     class Meta:
         verbose_name = "user"
         verbose_name_plural = "2. Users"

--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -26,7 +26,6 @@ class Support(models.Model):
         return self.id
 
 
-# New user model
 class User(AbstractUser):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     password = models.CharField(max_length=255)

--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -331,8 +331,8 @@ class OrganizationApplication(models.Model):
     orgs_in_favor = ArrayField(models.IntegerField)
     orgs_against = ArrayField(models.IntegerField)
 
-    creation_date: models.DateTimeField(auto_now_add=True)
-    status_updated: models.DateTimeField(auto_now=True)
+    creation_date = models.DateTimeField(auto_now_add=True)
+    status_updated = models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return self.creation_date

--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -1,3 +1,4 @@
+import uuid
 from django.contrib.auth.models import AbstractUser
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -15,6 +16,7 @@ Considerations:
 
 
 class Support(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     supporter_type = models.IntegerField(null=True)
     supporter_entity = models.IntegerField(null=True)
@@ -23,6 +25,7 @@ class Support(models.Model):
 
 # New user model
 class User(AbstractUser):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     password = models.CharField(max_length=255)
     location = models.CharField(max_length=30, null=True)
     description = models.TextField(max_length=500, null=True)
@@ -45,6 +48,7 @@ class User(AbstractUser):
 
 
 class Organization(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     tagline = models.CharField(max_length=255)
     application_id: models.IntegerField(null=True)
@@ -62,6 +66,7 @@ class Organization(models.Model):
 
 
 class Event(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     creation_date = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
@@ -80,6 +85,7 @@ class Event(models.Model):
 
 
 class Role(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     is_custom = models.BooleanField(null=True)
     description = models.TextField(max_length=500)
@@ -98,6 +104,7 @@ class Role(models.Model):
 
 
 class Topic(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     active = models.BooleanField(null=True)
     description = models.TextField(max_length=500)
@@ -115,6 +122,7 @@ class Topic(models.Model):
 
 
 class Resource(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     topics = ArrayField(models.CharField(max_length=255))
     location = models.CharField(max_length=255)
@@ -135,6 +143,7 @@ class Resource(models.Model):
 
 
 class Format(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=500)
     # Timestamps
@@ -151,6 +160,7 @@ class Format(models.Model):
 
 
 class Group(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     creation_date = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -169,6 +179,7 @@ class Group(models.Model):
 
 
 class Task(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     creation_date = models.DateTimeField(auto_now_add=True)
     description = models.TextField(max_length=500)
@@ -186,6 +197,7 @@ class Task(models.Model):
 
 
 class SupportEntityTypes(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     type = models.ForeignKey(Support, on_delete=models.CASCADE)
 
@@ -198,6 +210,7 @@ class SupportEntityTypes(models.Model):
 
 
 class UserResource(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
@@ -207,6 +220,7 @@ class UserResource(models.Model):
 
 
 class UserTopic(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -216,6 +230,7 @@ class UserTopic(models.Model):
 
 
 class UserTask(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     task_id = models.ForeignKey(Task, on_delete=models.CASCADE)
@@ -225,6 +240,7 @@ class UserTask(models.Model):
 
 
 class GroupMember(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -234,6 +250,7 @@ class GroupMember(models.Model):
 
 
 class GroupResource(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
@@ -243,6 +260,7 @@ class GroupResource(models.Model):
 
 
 class GroupTopic(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -252,6 +270,7 @@ class GroupTopic(models.Model):
 
 
 class GroupEvent(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
@@ -261,6 +280,7 @@ class GroupEvent(models.Model):
 
 
 class EventResource(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
@@ -270,6 +290,7 @@ class EventResource(models.Model):
 
 
 class EventRole(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     role_id = models.ForeignKey(Role, on_delete=models.CASCADE)
@@ -279,6 +300,7 @@ class EventRole(models.Model):
 
 
 class EventTopic(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -288,6 +310,7 @@ class EventTopic(models.Model):
 
 
 class EventAttendee(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
@@ -296,6 +319,7 @@ class EventAttendee(models.Model):
 
 
 class EventAttendeeStatus(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     status = models.IntegerField(null=True)
     status_name = models.CharField(max_length=255)
 
@@ -304,6 +328,7 @@ class EventAttendeeStatus(models.Model):
 
 
 class EventTask(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     task_id = models.ForeignKey(Task, on_delete=models.CASCADE)
@@ -313,6 +338,7 @@ class EventTask(models.Model):
 
 
 class TopicFormat(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index: models.IntegerField(null=True)
     topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
     format_id: models.ForeignKey(Format, on_delete=models.CASCADE)
@@ -322,6 +348,7 @@ class TopicFormat(models.Model):
 
 
 class ResourceTopic(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index: models.IntegerField(null=True)
     resource_id: models.ForeignKey(Resource, on_delete=models.CASCADE)
     topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
@@ -331,6 +358,7 @@ class ResourceTopic(models.Model):
 
 
 class OrganizationApplicationStatus(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     status: models.IntegerField(null=True)
     status_name: models.CharField(max_length=255)
 
@@ -339,6 +367,7 @@ class OrganizationApplicationStatus(models.Model):
 
 
 class OrganizationApplication(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     creation_date: models.DateTimeField(auto_now_add=True)
     status = models.ForeignKey(OrganizationApplicationStatus, on_delete=models.CASCADE)
     status_updated: models.DateTimeField(auto_now=True)
@@ -351,6 +380,7 @@ class OrganizationApplication(models.Model):
 
 
 class OrganizationResource(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index: models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
 
@@ -359,6 +389,7 @@ class OrganizationResource(models.Model):
 
 
 class OrganizationMember(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index: models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     user_id: models.ForeignKey(User, on_delete=models.CASCADE)
@@ -368,18 +399,21 @@ class OrganizationMember(models.Model):
 
 
 class OrganizationTopic(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index: models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
 
 
 class OrganizationEvent(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     event_id: models.ForeignKey(Event, on_delete=models.CASCADE)
 
 
 class OrganizationTask(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     task_id: models.ForeignKey(Task, on_delete=models.CASCADE)

--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -37,8 +37,9 @@ class User(AbstractUser):
     social_accounts = ArrayField(models.CharField(max_length=255), null=True)
     total_flags = models.IntegerField(default=0)
     
-    deletion_date = models.DateField(null=True)
     creation_date = models.DateTimeField(auto_now_add=True)
+    deletion_date = models.DateField(null=True)
+    
 
     class Meta:
         verbose_name = "user"

--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -17,14 +17,13 @@ Considerations:
 
 class Support(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     supporter_type = models.IntegerField(null=True)
     supporter_entity = models.IntegerField(null=True)
     supported_type = models.IntegerField(null=True)
     supported_entity = models.IntegerField(null=True)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 # New user model
@@ -44,10 +43,6 @@ class User(AbstractUser):
     creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
 
-    class Meta:
-        verbose_name = "user"
-        verbose_name_plural = "2. Users"
-
     def __str__(self):
         return self.username
 
@@ -56,16 +51,12 @@ class Organization(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     tagline = models.CharField(max_length=255)
-    application_id: models.IntegerField(null=True)
-    social_accounts: ArrayField(models.CharField(max_length=255))
-    total_flags: models.IntegerField(null=True)
-    created_by: models.IntegerField(null=True)
+    application_id = models.IntegerField(null=True)
+    social_accounts = ArrayField(models.CharField(max_length=255))
+    total_flags = models.IntegerField(null=True)
+    created_by = models.IntegerField(null=True)
 
-    creation_date: models.DateTimeField(auto_now_add=True)
-
-    class Meta:
-        verbose_name = "organization"
-        verbose_name_plural = "2. Organizations"
+    creation_date = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
         return self.name
@@ -104,10 +95,6 @@ class Role(models.Model):
     last_updated = models.DateTimeField(auto_now=True)
     deprecation_date = models.DateField(null=True)
 
-    class Meta:
-        verbose_name = "role"
-        verbose_name_plural = "1. Role"
-
     def __str__(self):
         return self.name
 
@@ -121,10 +108,6 @@ class Topic(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     deprecation_date = models.DateField(null=True)
-
-    class Meta:
-        verbose_name = "topic"
-        verbose_name_plural = "1. Topic"
 
     def __str__(self):
         return self.name
@@ -143,10 +126,6 @@ class Resource(models.Model):
     last_updated = models.DateTimeField(auto_now=True)
     deletion_date = models.DateField(null=True)
 
-    class Meta:
-        verbose_name = "resource"
-        verbose_name_plural = "1. Resource"
-
     def __str__(self):
         return self.name
 
@@ -159,10 +138,6 @@ class Format(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     deprecation_date = models.DateField(null=True)
-
-    class Meta:
-        verbose_name = "format"
-        verbose_name_plural = "1. Format"
 
     def __str__(self):
         return self.name
@@ -180,10 +155,6 @@ class Group(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
 
-    class Meta:
-        verbose_name = "group"
-        verbose_name_plural = "1. Group"
-
     def __str__(self):
         return self.name
 
@@ -198,10 +169,6 @@ class Task(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
 
-    class Meta:
-        verbose_name = "task"
-        verbose_name_plural = "1. Task"
-
     def __str__(self):
         return self.name
 
@@ -211,117 +178,102 @@ class SupportEntityTypes(models.Model):
     name = models.CharField(max_length=255)
     type = models.ForeignKey(Support, on_delete=models.CASCADE)
 
-    class Meta:
-        verbose_name = "support entity type"
-        verbose_name_plural = "1. Support Entity Type"
-
     def __str__(self):
         return self.name
 
 
 class UserResource(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class UserTopic(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class UserTask(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     task_id = models.ForeignKey(Task, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class GroupMember(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class GroupResource(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class GroupTopic(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class GroupEvent(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     group_id = models.ForeignKey(Group, on_delete=models.CASCADE)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class EventResource(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class EventRole(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     role_id = models.ForeignKey(Role, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class EventTopic(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class EventAttendee(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     user_id = models.ForeignKey(User, on_delete=models.CASCADE)
     role_id = models.ForeignKey(Role, on_delete=models.CASCADE)
@@ -339,38 +291,35 @@ class EventAttendeeStatus(models.Model):
 
 class EventTask(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
     event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
     task_id = models.ForeignKey(Task, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class TopicFormat(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index: models.IntegerField(null=True)
-    topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
-    format_id: models.ForeignKey(Format, on_delete=models.CASCADE)
+    topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
+    format_id = models.ForeignKey(Format, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class ResourceTopic(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index: models.IntegerField(null=True)
-    resource_id: models.ForeignKey(Resource, on_delete=models.CASCADE)
-    topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
+    resource_id = models.ForeignKey(Resource, on_delete=models.CASCADE)
+    topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class OrganizationApplicationStatus(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    status: models.IntegerField(null=True)
-    status_name: models.CharField(max_length=255)
+    status = models.IntegerField(null=True)
+    status_name = models.CharField(max_length=255)
 
     def __str__(self):
         return self.status_name
@@ -380,8 +329,8 @@ class OrganizationApplication(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     status = models.ForeignKey(OrganizationApplicationStatus, on_delete=models.CASCADE)
     org_id = models.IntegerField(null=True)
-    orgs_in_favor: ArrayField(models.IntegerField)
-    orgs_against: ArrayField(models.IntegerField)
+    orgs_in_favor = ArrayField(models.IntegerField)
+    orgs_against = ArrayField(models.IntegerField)
 
     creation_date: models.DateTimeField(auto_now_add=True)
     status_updated: models.DateTimeField(auto_now=True)
@@ -392,51 +341,46 @@ class OrganizationApplication(models.Model):
 
 class OrganizationResource(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index: models.IntegerField(null=True)
-    org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
+    org_id = models.ForeignKey(Organization, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class OrganizationMember(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index: models.IntegerField(null=True)
-    org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
-    user_id: models.ForeignKey(User, on_delete=models.CASCADE)
-    is_owner: models.BooleanField(default=False)
-    is_admin: models.BooleanField(default=False)
-    is_comms: models.BooleanField(default=False)
+    org_id = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    user_id = models.ForeignKey(User, on_delete=models.CASCADE)
+    is_owner = models.BooleanField(default=False)
+    is_admin = models.BooleanField(default=False)
+    is_comms = models.BooleanField(default=False)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class OrganizationTopic(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index: models.IntegerField(null=True)
-    org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
-    topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
+    org_id = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    topic_id = models.ForeignKey(Topic, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class OrganizationEvent(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
-    org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
-    event_id: models.ForeignKey(Event, on_delete=models.CASCADE)
+    org_id = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    event_id = models.ForeignKey(Event, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id
 
 
 class OrganizationTask(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
-    index = models.IntegerField(null=True)
-    org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
-    task_id: models.ForeignKey(Task, on_delete=models.CASCADE)
+    org_id = models.ForeignKey(Organization, on_delete=models.CASCADE)
+    task_id = models.ForeignKey(Task, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.index
+        return self.id

--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -36,6 +36,7 @@ class User(AbstractUser):
     )
     social_accounts = ArrayField(models.CharField(max_length=255), null=True)
     total_flags = models.IntegerField(default=0)
+    
     deletion_date = models.DateField(null=True)
     creation_date = models.DateTimeField(auto_now_add=True)
 
@@ -55,6 +56,7 @@ class Organization(models.Model):
     social_accounts: ArrayField(models.CharField(max_length=255))
     total_flags: models.IntegerField(null=True)
     created_by: models.IntegerField(null=True)
+
     creation_date: models.DateTimeField(auto_now_add=True)
 
     class Meta:
@@ -67,12 +69,9 @@ class Organization(models.Model):
 
 class Event(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
-    creation_date = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
     name = models.CharField(max_length=255)
     tagline = models.CharField(max_length=255)
-    start_time = models.DateField(null=True)
-    end_time = models.DateField(null=True)
     type = models.CharField(max_length=255)
     format = models.CharField(max_length=255)
     online_location_link = models.CharField(max_length=255)
@@ -81,7 +80,11 @@ class Event(models.Model):
     offline_location_long = models.FloatField(null=True)
     description = models.TextField(max_length=500)
     get_involved_text = models.TextField(max_length=500)
+    
+    creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
+    start_time = models.DateField(null=True)
+    end_time = models.DateField(null=True)
 
 
 class Role(models.Model):
@@ -90,7 +93,6 @@ class Role(models.Model):
     is_custom = models.BooleanField(null=True)
     description = models.TextField(max_length=500)
 
-    #timestamps
     creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     deprecation_date = models.DateField(null=True)
@@ -108,7 +110,7 @@ class Topic(models.Model):
     name = models.CharField(max_length=255)
     active = models.BooleanField(null=True)
     description = models.TextField(max_length=500)
-    #timestamps
+
     creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     deprecation_date = models.DateField(null=True)
@@ -129,7 +131,7 @@ class Resource(models.Model):
     url = models.CharField(max_length=255)
     total_flags = models.IntegerField(null=True)
     description = models.TextField(max_length=500)
-    # Timestamps
+    
     creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     deletion_date = models.DateField(null=True)
@@ -146,7 +148,7 @@ class Format(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=500)
-    # Timestamps
+    
     creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
     deprecation_date = models.DateField(null=True)
@@ -162,12 +164,13 @@ class Format(models.Model):
 class Group(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
-    creation_date = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(User, on_delete=models.CASCADE)
     description = models.TextField(max_length=500)
     tagline = models.CharField(max_length=255)
     total_flags = models.IntegerField(null=True)
     social_accounts = ArrayField(models.CharField(max_length=255))
+
+    creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
 
     class Meta:
@@ -181,10 +184,11 @@ class Group(models.Model):
 class Task(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     name = models.CharField(max_length=255)
-    creation_date = models.DateTimeField(auto_now_add=True)
     description = models.TextField(max_length=500)
     tags = ArrayField(models.CharField(max_length=255))
     location = models.CharField(max_length=255)
+
+    creation_date = models.DateTimeField(auto_now_add=True)
     deletion_date = models.DateField(null=True)
 
     class Meta:
@@ -368,12 +372,13 @@ class OrganizationApplicationStatus(models.Model):
 
 class OrganizationApplication(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
-    creation_date: models.DateTimeField(auto_now_add=True)
     status = models.ForeignKey(OrganizationApplicationStatus, on_delete=models.CASCADE)
-    status_updated: models.DateTimeField(auto_now=True)
     org_id = models.IntegerField(null=True)
     orgs_in_favor: ArrayField(models.IntegerField)
     orgs_against: ArrayField(models.IntegerField)
+
+    creation_date: models.DateTimeField(auto_now_add=True)
+    status_updated: models.DateTimeField(auto_now=True)
 
     def __str__(self):
         return self.creation_date

--- a/backend/apps/models.py
+++ b/backend/apps/models.py
@@ -87,6 +87,9 @@ class Event(models.Model):
     start_time = models.DateField(null=True)
     end_time = models.DateField(null=True)
 
+    def __str__(self):
+        return self.name
+
 
 class Role(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
@@ -403,6 +406,9 @@ class OrganizationMember(models.Model):
     is_admin: models.BooleanField(default=False)
     is_comms: models.BooleanField(default=False)
 
+    def __str__(self):
+        return self.index
+
 
 class OrganizationTopic(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
@@ -410,12 +416,18 @@ class OrganizationTopic(models.Model):
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
 
+    def __str__(self):
+        return self.index
+
 
 class OrganizationEvent(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
     index = models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     event_id: models.ForeignKey(Event, on_delete=models.CASCADE)
+        
+    def __str__(self):
+        return self.index
 
 
 class OrganizationTask(models.Model):
@@ -423,3 +435,6 @@ class OrganizationTask(models.Model):
     index = models.IntegerField(null=True)
     org_id: models.ForeignKey(Organization, on_delete=models.CASCADE)
     task_id: models.ForeignKey(Task, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.index

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - DJANGO_ALLOWED_HOSTS=${DJANGO_ALLOWED_HOSTS}
       - DEBUG=${DEBUG}
       - SECRET_KEY=${SECRET_KEY}
+    depends_on:
+      - db
 
   frontend:
     build:


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

In this PR the standard model structure was implemented to all models inside `backend/apps/models.py`. 

The `index` for each model was changed to `id` and set as primary key.
```python
# previously
index = models.IntegerField(null=True)
# now
id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False) 
```
Timestamps have been grouped and seperated by a blank line on each model. 

Example: 
```python
class Role(models.Model):
    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
    name = models.CharField(max_length=255)
    is_custom = models.BooleanField(null=True)
    description = models.TextField(max_length=500)

    creation_date = models.DateTimeField(auto_now_add=True)
    last_updated = models.DateTimeField(auto_now=True)
    deprecation_date = models.DateField(null=True)

    def __str__(self):
        return self.name
```
`def __str__:` have been added to each model.

Some fields were assigned `:` instead of `=`. Now all fields are assigned correctly and checked by making migrations. 

Example:
```python
class TopicFormat(models.Model):
    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
    index: models.IntegerField(null=True)
    topic_id: models.ForeignKey(Topic, on_delete=models.CASCADE)
    format_id: models.ForeignKey(Format, on_delete=models.CASCADE)

    def __str__(self):
        return self.index
```
I deleted the `class Meta:` for all models since the default plural made sense to me.

```python
class Meta:
    verbose_name = "organization"
    verbose_name_plural = "2. Organizations"
```
Django will add a `s` to the end by default. For cases like `Child` it would be by default `Childs` instead of `Children`. But the models we have are all correct by default (to the best of my knowledge) like `Event` -> `Events`. This can ge reverted tho in no time :).

<ins>Comments:<ins>
I would suggest to deleted the initial migrations file `migrations/0001_initial.py`. Since we db is not in production yet.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #293 
