### PR TITLE
Added Black formatting Github Action

### DIFF
--- a/.github/workflows/pr_python_formatting_check.yaml
+++ b/.github/workflows/pr_python_formatting_check.yaml
@@ -1,0 +1,22 @@
+name: pr_python_formatting_check
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+  workflow_run:
+    workflows: [pr_maintainer_checklist]
+    types:
+      - completed
+
+jobs:
+  black:
+    name: Run PR Python formatting check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: psf/black@stable
+      with:
+        options: --check --verbose --exclude "migrations/"
+        src: ./backend


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR adds a GitHub Action workflow that checks if python code is formatted with black. The workflow targets the `backend` folder and excludes migrations. I have excluded migrations since they are autogenerated by django.

I have tested the black command:
```powershell
black ./backend --check --verbose --exclude "migrations/" 
```
Here is the result:
```
...
would reformat C:\Users\tobia\Documents\Projects\contrib\activist\activist\backend\apps\models.py
Oh no! 💥 💔 💥
1 file would be reformatted, 14 files would be left unchanged.
```
So currently the Github Action should fail because the models.py is not formatted with black.

I tried to test the Github Action locally with [act](https://github.com/nektos/act) but ran into a known [issue](https://github.com/nektos/act/issues/1765) that would have required me to install a 14gb image for testing. So i skipped testing :). Guess we have to give this a test via PR.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #316 
