### PR TITLE
chore: add TS error check reference to pr_maintainer_workflow

### DIFF
--- a/.github/workflows/pr_maintainer_checklist.yaml
+++ b/.github/workflows/pr_maintainer_checklist.yaml
@@ -32,4 +32,8 @@ jobs:
               - The contributor's name and icon in remote commits should be the same as what appears in the PR
               - If there's a mismatch, the contributor needs to make sure that the [email they use for GitHub](https://github.com/settings/emails) matches what they have for `git config user.email` in their local activist repo
 
+            - [ ] The TypeScript errors logs within the workflow checks do not indicate new errors in the files changed.
+              - ${{ github.event.pull_request.number }} - [Netlify Logs](https://github.com/activist-org/activist/pull/${{ github.event.pull_request.number }}/checks)
+
             - [ ] The [CHANGELOG](https://github.com/activist-org/activist/blob/main/CHANGELOG.md) has been updated with a description of the changes for the upcoming release (if necessary)
+


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.

I attempted to pull the PR number directly to render a clickable link that redirects to the logs. Double-check this works!  Thank you.
-->

- Add a reference to the `pr_maintainer_checklist` workflow to check the TS error logs.

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #314 
