### PR TITLE
added frontend formatting check and stand. steps

### DIFF
--- a/.github/workflows/pr_backend_formatting_check.yaml
+++ b/.github/workflows/pr_backend_formatting_check.yaml
@@ -1,4 +1,4 @@
-name: pr_python_formatting_check
+name: pr_backend_formatting_check
 on:
   pull_request_target:
     branches:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   black:
-    name: Run PR Python Formatting Check
+    name: Run PR Backend Formatting Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr_frontend_formatting_check.yaml
+++ b/.github/workflows/pr_frontend_formatting_check.yaml
@@ -1,4 +1,4 @@
-name: pr_python_formatting_check
+name: pr_frontend_formatting_check
 on:
   pull_request_target:
     branches:
@@ -11,14 +11,15 @@ on:
       - completed
 
 jobs:
-  black:
-    name: Run PR Python Formatting Check
+  prettier:
+    name: Run PR Frontend Formatting Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Run Black
-        uses: psf/black@stable
+      - name: Run Prettier
+        uses: creyD/prettier_action@v4.3
         with:
-          options: --check --verbose --exclude "migrations/"
-          src: ./backend
+          working_directory: ./frontend
+          dry: True
+          prettier_options: --check


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR adds a github workflow to check frontend formatting with [prettier](https://prettier.io/). The workflow file `pr_frontend_formatting_check.yaml` was added. It targets the frontend folder and checks the formatting. Files are not changed but this can be changed in the long run with `dry: False`. 

Similar to #316 i tried to use [act](https://github.com/nektos/act) to run the GitHub action locally but ran into a known issue.

<ins>Additional</ins>:
I standardize the steps inside pr_python_formatting_check.yaml. Minor change that makes the github actions logs more readable. We have to check this with a PR again 😃.

<ins>Suggestions</ins>:
I named the file `pr_frontend_formatting_check` could also be `pr_prettier_formatting_check` (or something else 😄) but i do like the frontend and backend distinction and would suggest to rename `pr_python_formatting_check` to `pr_backend_formatting_check.`


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #323 
