### PR TITLE
fixing loading component

### DIFF
--- a/frontend/components/Loading.vue
+++ b/frontend/components/Loading.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex items-center justify-center h-screen bg-light-header dark:bg-dark-header"
+    class="flex items-center justify-center h-screen bg-light-header dark:bg-dark-header fixed inset-0 z-20"
     v-show="show"
   >
     <div class="pb-10 loading-pulse">


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
When user navigates to a new page, then goes back, and then their view on the original page is lower than it was before.
This was caused because the loading component was not fixed, making the page going down.
To solve this problem I fixed the loading component and setting z-index to be above others components.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #318 
