### PR TITLE
Fix: SidebarLeftFooter tab control order fix and misc fixes

### DIFF
--- a/frontend/components/header/HeaderAppPage.vue
+++ b/frontend/components/header/HeaderAppPage.vue
@@ -27,8 +27,8 @@ import type { Event } from "../../types/event";
 import type { Organization } from "../../types/organization";
 
 const props = defineProps<{
-  header: string;
-  tagline: string;
+  header?: string;
+  tagline?: string;
   organization?: Organization;
   event?: Event;
 }>();
@@ -45,7 +45,7 @@ if (props.organization) {
   header = props.event.name;
   tagline = props.event.tagline;
 } else {
-  header = props.header;
-  tagline = props.tagline;
+  header = props.header || "Default Demo Header";
+  tagline = props.tagline || "Default Demo Tagline";
 }
 </script>

--- a/frontend/components/sidebar/left/SidebarLeftFooter.vue
+++ b/frontend/components/sidebar/left/SidebarLeftFooter.vue
@@ -14,7 +14,7 @@
       >
         <Disclosure v-slot="{ open, close }">
           <DisclosureButton
-            :ref="(el) => (disclosure[0] = close)"
+            :ref="(el) => (disclosureButtons[0] = { close, el })"
             class="flex items-center w-full rounded-md bg-light-menu-selection dark:bg-dark-menu-selection text-light-content dark:text-dark-content hover:bg-light-highlight dark:hover:bg-dark-highlight hover:text-light-special-text hover:dark:text-dark-special-text focus-brand"
             @click="closeOtherMenus(0)"
             v-on:keyup.enter="closeOtherMenus(0)"
@@ -53,6 +53,7 @@
           <DisclosurePanel class="flex flex-col">
             <div
               class="p-1 space-y-1 rounded-md bg-light-header dark:bg-dark-header"
+              :ref="(el) => (disclosurePanels[0] = el)"
             >
               <SidebarLeftSelector
                 :label="$t('components.sidebar-left-selector.label.new-event')"
@@ -91,7 +92,7 @@
         </Disclosure>
         <Disclosure v-slot="{ open, close }">
           <DisclosureButton
-            :ref="(el) => (disclosure[1] = close)"
+            :ref="(el) => (disclosureButtons[1] = { close, el })"
             class="flex items-center w-full rounded-md bg-light-menu-selection dark:bg-dark-menu-selection text-light-content dark:text-dark-content hover:bg-light-highlight dark:hover:bg-dark-highlight hover:text-light-special-text hover:dark:text-dark-special-text focus-brand"
             @click="closeOtherMenus(1)"
             v-on:keyup.enter="closeOtherMenus(1)"
@@ -130,6 +131,7 @@
           <DisclosurePanel class="flex flex-col">
             <div
               class="p-1 space-y-1 rounded-md bg-light-header dark:bg-dark-header"
+              :ref="(el) => (disclosurePanels[1] = el)"
             >
               <SidebarLeftSelector
                 :label="$t('components.sidebar-left-selector.label.help')"
@@ -159,7 +161,7 @@
         </Disclosure>
         <Disclosure v-slot="{ open, close }">
           <DisclosureButton
-            :ref="(el) => (disclosure[2] = close)"
+            :ref="(el) => (disclosureButtons[2] = { close, el })"
             class="flex items-center w-full rounded-md bg-light-menu-selection dark:bg-dark-menu-selection text-light-content dark:text-dark-content hover:bg-light-highlight dark:hover:bg-dark-highlight hover:text-light-special-text hover:dark:text-dark-special-text focus-brand"
             @click="closeOtherMenus(2)"
             v-on:keyup.enter="closeOtherMenus(2)"
@@ -201,6 +203,7 @@
           <DisclosurePanel class="flex flex-col">
             <div
               class="p-1 space-y-1 rounded-md bg-light-header dark:bg-dark-header"
+              :ref="(el) => (disclosurePanels[2] = el)"
             >
               <SidebarLeftSelector
                 :label="
@@ -268,9 +271,21 @@ import type { Ref } from "vue";
 const route = useRoute();
 const onHomePage = route.path.includes("home");
 
-const disclosure = ref<((ref?: Ref | HTMLElement) => void)[]>([]);
+const disclosureButtons = ref<({ 
+  close: (ref?: Ref | HTMLElement) => void, 
+  el: Ref | HTMLElement
+})[]>([]);
+const disclosurePanels = ref<(Element | ComponentPublicInstance | null)[]>([]);
+
 const closeOtherMenus = (id: number) => {
-  disclosure.value.filter((d, i) => i !== id).forEach((close) => close());
+  disclosureButtons.value.filter((d, i) => i !== id).forEach((disclosureButton) => disclosureButton.close());
+  
+  // Focus on the first item in disclosurePanels when opening, on the disclosureButton when closing
+  if (disclosurePanels.value[id]?.childNodes) {
+    disclosurePanels.value[id]?.childNodes[0].focus();
+  } else {
+    disclosureButtons.value[id]?.el?.$el.focus();
+  }
 };
 const sidebar = useSidebar();
 </script>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -110,6 +110,11 @@ export default defineNuxtConfig({
       global: true,
     },
   ],
+  vue: {  
+    compilerOptions: {
+      isCustomElement: (tag) => ['swiper-slide', 'swiper-container'].includes(tag),
+    },
+  },
   app: {
     head: {
       charset: "utf-8",


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

1. `SidebarLeftFooter`: fixes tab control order misbehaviour, now pressing enter key on the DisclosureButton will move focus to the first child element in DisclosurePanel.
2. `HeaderAppPage`: fixes TS props error where props `header` and `tagline` was required before, but the normal use case is that either `organization`, or `event`, or `header + tagline` is passed into this component.
3. `nuxt.config.ts`: fixes console error messages about our `swiper-container` and `swiper-slide` custom html elements in `MediaImageCarousel` component. See this [StackOverflow thread](https://stackoverflow.com/questions/71601714/how-to-set-compileroptions-iscustomelement-for-vuejs-3-in-laravel-project). The error messages in console was like this [one](https://laracasts.com/discuss/channels/vue/how-to-set-compileroptionsiscustomelement-for-vuejs-3-in-laravel-project).

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #291 
