### PR TITLE
feat(ui): #321 Add right sidebar transition

### DIFF
--- a/frontend/components/sidebar/right/SidebarRight.vue
+++ b/frontend/components/sidebar/right/SidebarRight.vue
@@ -8,11 +8,11 @@
   <div
     ref="target"
     id="drawer-navigation"
-    class="fixed top-0 right-0 z-40 w-64 h-screen px-4 pt-12 overflow-y-auto border-l transition-transform bg-light-distinct border-light-section-div dark:bg-dark-distinct dark:border-dark-section-div shadow-sm shadow-zinc-700"
-    :class="{ 'hidden translate-x-full': !isMenuOpen }"
+    class="fixed top-0 right-0 z-40 w-64 h-screen pt-12 overflow-y-auto overflow-x-hidden box-content border-l transition-[max-width] duration-200 bg-light-distinct border-light-section-div dark:bg-dark-distinct dark:border-dark-section-div shadow-sm shadow-zinc-700"
+    :class="!isMenuOpen ? 'max-w-0 px-0' : 'max-w-[16rem] px-4'"
     tabindex="-1"
-  >
-    <div class="h-full py-4">
+    >
+    <div class="w-64 h-full py-4">
       <slot></slot>
     </div>
   </div>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

According to #321, the [right sidebar](https://github.com/activist-org/activist/blob/main/frontend/components/sidebar/right/SidebarRight.vue) for mobile that houses the theme and language selectors doesn't have a transition when toggled. I have added a transition similar to the [left sidebar component](https://github.com/activist-org/activist/blob/main/frontend/components/sidebar/left/SidebarLeft.vue).

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #321 
