### PR TITLE
Fix: Sidebar hover blur now covers footer at md and lg breakpoints

### DIFF
--- a/frontend/layouts/sidebar.vue
+++ b/frontend/layouts/sidebar.vue
@@ -27,6 +27,10 @@
           sidebar.collapsed == false || sidebar.collapsedSwitch == false,
         'md:pl-24 xl:pl-24':
           sidebar.collapsed == true && sidebar.collapsedSwitch == true,
+        'blur-sm xl:blur-none':
+          sidebar.collapsedSwitch == true &&
+          sidebar.collapsed == false &&
+          sidebarHover == true,
       }"
     />
   </div>


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

I resolved the issue with the sidebar blur not appearing over the footer at medium and small view widths. It was a simple fix. I just copied the code that applied blur to the rest of the page and added it to the footer in [frontend/layouts/sidebar.vue](https://github.com/activist-org/activist/blob/main/frontend/layouts/sidebar.vue). I ran a Docker container with the updated code and it seemed to resolve the issue at the desired breakpoints. 

Let me know if there is anything I can do to improve my workflow or communication for future contributions. I'm still very new to open source contributions such as this, and advice is always appreciated. 

### Related issue

- [Issue355
](https://github.com/activist-org/activist/issues/355)