### PR TITLE
Change activity type in workflows

### DIFF
--- a/.github/workflows/pr_backend_formatting_check.yaml
+++ b/.github/workflows/pr_backend_formatting_check.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     types:
-      - opened
+      - [opened, reopened, synchronize]
   workflow_run:
     workflows: [pr_maintainer_checklist]
     types:

--- a/.github/workflows/pr_frontend_formatting_check.yaml
+++ b/.github/workflows/pr_frontend_formatting_check.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     types:
-      - opened
+      - [opened, reopened, synchronize]
   workflow_run:
     workflows: [pr_maintainer_checklist]
     types:

--- a/.github/workflows/pr_ts_typecheck.yaml
+++ b/.github/workflows/pr_ts_typecheck.yaml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     types:
-      - opened
+      - [opened, reopened, synchronize]
   workflow_run:
     workflows: [pr_maintainer_checklist]
     types:


### PR DESCRIPTION
This will make the workflows run when there are new commits and if the PR is reoppened

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Applying this will make all workflows (except pr_maintener_checklist) run when a new commit is added to the PR and also if the pr is reopenned.
pr_maintener_checklist is not modified as I believe it must only be performed on "open" activity

### Related issue


- #364 
