### PR TITLE
Redirecting to /about after resizing to a medium device

### DIFF
--- a/frontend/pages/events/[id]/index.vue
+++ b/frontend/pages/events/[id]/index.vue
@@ -136,11 +136,11 @@ const handleResize = () => {
 }
 
 onMounted(() => {
-  // Verify that the user is on a mobile device
-  handleResize()
-
   // Add event listener to handle resizing
   window.addEventListener('resize', handleResize)
+
+  // Verify that the user is on a mobile device
+  handleResize()
 })
 
 

--- a/frontend/pages/events/[id]/index.vue
+++ b/frontend/pages/events/[id]/index.vue
@@ -130,6 +130,7 @@ const eventButtons: MenuSelector[] = [
 
 const handleResize = () => {
   if (window.innerWidth > 640) {
+    window.removeEventListener('resize', handleResize)
     navigateTo(`${id}/about`);
   }
 }
@@ -142,9 +143,5 @@ onMounted(() => {
   window.addEventListener('resize', handleResize)
 })
 
-onBeforeUnmount(() => {
-  // Remove event listener before unmounting
-  window.removeEventListener('resize', handleResize)
-})
 
 </script>

--- a/frontend/pages/events/[id]/index.vue
+++ b/frontend/pages/events/[id]/index.vue
@@ -127,13 +127,24 @@ const eventButtons: MenuSelector[] = [
   // },
 ];
 
-onMounted(() => {
-  redirectBasedOnScreenSize();
-});
 
-function redirectBasedOnScreenSize() {
+const handleResize = () => {
   if (window.innerWidth > 640) {
     navigateTo(`${id}/about`);
   }
 }
+
+onMounted(() => {
+  // Verify that the user is on a mobile device
+  handleResize()
+
+  // Add event listener to handle resizing
+  window.addEventListener('resize', handleResize)
+})
+
+onBeforeUnmount(() => {
+  // Remove event listener before unmounting
+  window.removeEventListener('resize', handleResize)
+})
+
 </script>

--- a/frontend/pages/organizations/[id]/index.vue
+++ b/frontend/pages/organizations/[id]/index.vue
@@ -146,13 +146,22 @@ const organizationButtons: MenuSelector[] = [
   // },
 ];
 
-onMounted(() => {
-  redirectBasedOnScreenSize();
-});
-
-function redirectBasedOnScreenSize() {
+const handleResize = () => {
   if (window.innerWidth > 640) {
     navigateTo(`${id}/about`);
   }
 }
+
+onMounted(() => {
+  // Verify that the user is on a mobile device
+  handleResize()
+
+  // Add event listener to handle resizing
+  window.addEventListener('resize', handleResize)
+})
+
+onBeforeUnmount(() => {
+  // Remove event listener before unmounting
+  window.removeEventListener('resize', handleResize)
+})
 </script>

--- a/frontend/pages/organizations/[id]/index.vue
+++ b/frontend/pages/organizations/[id]/index.vue
@@ -148,6 +148,7 @@ const organizationButtons: MenuSelector[] = [
 
 const handleResize = () => {
   if (window.innerWidth > 640) {
+    window.removeEventListener('resize', handleResize)
     navigateTo(`${id}/about`);
   }
 }
@@ -158,10 +159,5 @@ onMounted(() => {
 
   // Add event listener to handle resizing
   window.addEventListener('resize', handleResize)
-})
-
-onBeforeUnmount(() => {
-  // Remove event listener before unmounting
-  window.removeEventListener('resize', handleResize)
 })
 </script>

--- a/frontend/pages/organizations/[id]/index.vue
+++ b/frontend/pages/organizations/[id]/index.vue
@@ -154,10 +154,10 @@ const handleResize = () => {
 }
 
 onMounted(() => {
-  // Verify that the user is on a mobile device
-  handleResize()
-
   // Add event listener to handle resizing
   window.addEventListener('resize', handleResize)
+
+  // Verify that the user is on a mobile device
+  handleResize()
 })
 </script>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
Regarding the /events/[id] and /organizations/[id] pages, I made an improvement for the user experience. Now, when the user views these pages in a window with a width smaller than or equal to 640px and then resizes it to a larger width, I've implemented an event listener to track the size change.

This way, if the user resizes the screen to a width greater than 640px, they will be automatically redirected to the /about page. This ensures a smooth and intuitive transition for the user when they enlarge the window, maintaining the consistency and usability of the website.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #365 
