### PR TITLE
Add BaseTooltip component and update it to the search bar

### DIFF
--- a/frontend/components/SearchBar.vue
+++ b/frontend/components/SearchBar.vue
@@ -27,11 +27,10 @@
         <div
           class="flex px-2 py-[0.125rem] text-sm text-center rounded-md has-tooltip bg-light-highlight dark:bg-dark-highlight text-light-special-text dark:text-dark-special-text"
         >
-          <span
-            class="invisible px-2 py-1 -mt-8 rounded shadow-md shadow-zinc-700 bg-light-menu-selection dark:bg-dark-menu-selection w-max text-light-content dark:text-dark-content tooltip"
-          >
-            {{ $t("components.search-bar.slash-tooltip-label") }}
-          </span>
+        <BaseTooltip 
+        class="invisible -mt-8"
+        :text="$t('components.search-bar.slash-tooltip-label')"
+        />
           <p class="-mt-[0.075rem]">/</p>
         </div>
         <!-- <div
@@ -80,6 +79,7 @@
 <script setup lang="ts">
 import { useMagicKeys, whenever } from "@vueuse/core";
 import { ref } from "vue";
+import BaseTooltip from "./tooltip/BaseTooltip.vue"
 
 const route = useRoute();
 

--- a/frontend/components/tooltip/BaseTooltip.vue
+++ b/frontend/components/tooltip/BaseTooltip.vue
@@ -1,0 +1,21 @@
+<template>
+    <div class="flex flex-col responsive-px-2 responsive-py-1 rounded shadow-md shadow-zinc-700 bg-light-distinct dark:bg-dark-distinct w-max text-light-content dark:text-dark-content tooltip">
+        <slot name="header">
+          <div class="responsive-h4 text-light-text dark:text-dark-text" v-if="header">{{ header }}</div>
+        </slot>
+        <slot name="text">
+          <div class="responsive-h5 text-light-text dark:text-dark-text" v-if="text">{{ text }}</div>
+        </slot>
+        <slot name="button" class="block"></slot>
+    </div>
+  </template>
+  
+  <script setup lang="ts">
+  import { defineProps } from 'vue';
+  
+  defineProps<{
+    header: string | null;
+    text: string | null;
+  }>();
+  </script>
+  


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---
![Screenshot 2023-10-08 150810](https://github.com/activist-org/activist/assets/123856266/7c158411-5d7c-41ad-b811-72ded396d000)
![Screenshot 2023-10-08 150841](https://github.com/activist-org/activist/assets/123856266/b49d6106-b1e1-4631-9cab-eb2ee17ccda6)

### Description


Add a BaseTooltip component.

Tested by adding into the search bar component.  I kept the styling classes invisible and mt-8 in the invocation of BaseTooltip in the SearchBar component, since I assume those styling features are specific to its location. I didn't mess with the control and command k tooltips that are commented out because I do not have a mac to test them on.

All other styling fits the designs on Figma except the text-color for dark mode. I could not find the exact color in the stylesheet. I removed the 'Header' placeholder before commiting the changes. Let me know if you need me to change anything or have any concerns!


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #400 
