### PR TITLE
eslint workflow added and contine-on-error added

### DIFF
--- a/.github/workflows/pr_ci_backend.yaml
+++ b/.github/workflows/pr_ci_backend.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   backend:
-    name: Run PR Backend Formatting Check
+    name: Run PR Backend Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,9 +32,11 @@ jobs:
         with:
           options: --check --verbose --exclude "migrations/"
           src: ./backend
+        continue-on-error: true
 
       - name: Run ruff - Linting and import sorting check
         run: ruff ./backend
+        continue-on-error: true
 
       - name: Run mypy - Static Type Checking
         run: mypy ./backend --config-file ./backend/mypy.ini

--- a/.github/workflows/pr_ci_frontend.yaml
+++ b/.github/workflows/pr_ci_frontend.yaml
@@ -11,16 +11,16 @@ on:
 
 jobs:
   frontend:
-    name: Run PR Frontend Formatting Check
+    name: Run PR Frontend Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node
+      - name: Setup Node environment
         uses: actions/setup-node@v3
 
-      - name: Yarn Install
+      - name: Install Yarn
         uses: borales/actions-yarn@v4
         with:
           cmd: install
@@ -29,7 +29,7 @@ jobs:
       - name: Install Prettier
         run: yarn add prettier
 
-      - name: Run Prettier
+      - name: Run Prettier - Formatting check
         working-directory: ./frontend
         run: |
           yarn prettier . --check --config ../.prettierrc --ignore-path ../.prettierignore
@@ -39,4 +39,11 @@ jobs:
         uses: borales/actions-yarn@v4
         with:
           cmd: nuxi typecheck
+          dir: "frontend"
+        continue-on-error: true
+
+      - name: Run eslint - Linting
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: eslint . --ext .js,.vue
           dir: "frontend"

--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -1,9 +1,10 @@
 import re
 from typing import Any, Dict, Union
 
-from content.models import Resource, Task, Topic
 from django.utils.translation import gettext as _
 from rest_framework import serializers
+
+from content.models import Resource, Task, Topic
 from utils.utils import (
     validate_creation_and_deletion_dates,
     validate_empty,

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -2,8 +2,9 @@ import re
 from typing import Any, Dict, Union
 
 from django.utils.translation import gettext as _
-from events.models import Format
 from rest_framework import serializers
+
+from events.models import Format
 from utils.utils import (
     validate_creation_and_deletion_dates,
     validate_creation_and_deprecation_dates,

--- a/backend/entities/serializers.py
+++ b/backend/entities/serializers.py
@@ -1,10 +1,11 @@
 from typing import Dict, Union
 
+from django.utils.translation import gettext as _
+from rest_framework import serializers
+
 from authentication.models import User
 from content.models import Resource, Task, Topic
-from django.utils.translation import gettext as _
 from events.models import Event
-from rest_framework import serializers
 from utils.utils import (
     validate_creation_and_deletion_dates,
     validate_empty,

--- a/backend/events/serializers.py
+++ b/backend/events/serializers.py
@@ -1,9 +1,10 @@
 from typing import Dict, Union
 
-from authentication.models import User
-from content.models import Resource, Task, Topic
 from django.utils.translation import gettext as _
 from rest_framework import serializers
+
+from authentication.models import User
+from content.models import Resource, Task, Topic
 from utils.utils import (
     validate_creation_and_deletion_dates,
     validate_creation_and_deprecation_dates,


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

In this PR, I added the eslint to the frontend check. I also realized that we have added continue-on-error to the frontend check but not to the backend check. That can be seen in the PR #465, where ruff fails due to import sorting and mypy will not be executed anymore.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

I tested ran the command in the frontend docker container.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #446
