### PR TITLE
reload drf api settings to solve Swagger UI bug

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -14,6 +14,7 @@ import django_stubs_ext
 import dotenv
 from django.core.management.utils import get_random_secret_key
 from rest_framework import viewsets
+from rest_framework.settings import api_settings
 
 django_stubs_ext.monkeypatch(extra_classes=(viewsets.ModelViewSet,))
 dotenv.load_dotenv()
@@ -157,3 +158,6 @@ SPECTACULAR_SETTINGS = {
     "VERSION": "0.1.0",
     "SERVE_INCLUDE_SCHEMA": False,
 }
+
+# Workaround #471 / monkeypatch() is overriding the REST_FRAMEWORK dict.
+api_settings.reload()


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR solves the bug that breaks the Swagger UI endpoint `/v1/schema/swagger-ui/`. This can be considered  a workaround, since we are reloading the drf api_settings after calling the monkeypatch function.  

There is currently a open issue on djangorestframework-stubs that is related to this bug. Let's keep the issue #471 open to keep track of the changes.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
I have tested the endpoint to make sure it works.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #471
