### PR TITLE
added flex-wrap to breadcrumb component so li's go on to the next line

### DIFF
--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -1,6 +1,6 @@
 <template>
   <nav :aria-label="$t('components.page-breadcrumbs.aria-label')">
-    <ul class="flex flex-row text-sm md:text-base">
+    <ul class="flex flex-row flex-wrap text-sm md:text-base">
       <li
         v-for="(breadcrumb, index) in displayBreadcrumbs"
         :key="index"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Added a flex-wrap so the li's wrap to the next line when hitting the full width, I tested it by manually adding items in the html. See attached screenshot.

<img width="841" alt="Screenshot 2023-10-18 at 21 56 42" src="https://github.com/activist-org/activist/assets/5328578/54e21b94-94a9-4051-b53a-767799db1f10">


### Related issue

- #475
