### PR TITLE
fix(ci): correct event type "pull_request"

### DIFF
--- a/.github/workflows/pr_ci_backend.yaml
+++ b/.github/workflows/pr_ci_backend.yaml
@@ -1,6 +1,6 @@
 name: pr_ci_backend
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types: [opened, reopened, synchronize]

--- a/.github/workflows/pr_ci_frontend.yaml
+++ b/.github/workflows/pr_ci_frontend.yaml
@@ -1,6 +1,6 @@
 name: pr_ci_frontend
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
     types: [opened, reopened, synchronize]


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

If I'm understanding correctly, I think the trigger event type that we would want is `pull_request` rather than `pull_request_target`. 

From the [docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target):

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the `pull_request` event does. 

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #489 
