### PR TITLE
Added privacy marker icon

### DIFF
--- a/frontend/components/marker/MarkerPrivacy.vue
+++ b/frontend/components/marker/MarkerPrivacy.vue
@@ -1,0 +1,37 @@
+<template>
+  <div
+    class="flex items-center px-4 py-2 font-semibold text-center border select-none rounded-md xl:rounded-lg focus-brand w-fit shadow-sm shadow-zinc-700 text-light-text border-light-text dark:text-dark-cta-orange dark:border-dark-cta-orange fill-light-text dark:fill-dark-cta-orange bg-light-cta-orange dark:bg-dark-cta-orange/10 text-base sm:text-lg xl:text-xl xl:px-6 xl:py-3"
+    :class="{
+      'text-xs': fontSize == 'xs',
+      'text-sm': fontSize == 'sm',
+      'text-base': fontSize == 'base',
+      'text-lg': fontSize == 'lg',
+      'text-base sm:text-lg xl:text-xl xl:px-6 xl:py-3': fontSize == 'xl',
+      'text-base sm:text-lg xl:text-2xl xl:px-6 xl:py-3': fontSize == '2xl',
+      'text-base sm:text-lg xl:text-3xl xl:px-6 xl:py-3': fontSize == '3xl',
+    }"
+  >
+    <Icon
+      class="-my-1"
+      :name="type === 'group' ? 'IconGroup' : 'bi:eye-slash'"
+      :size="iconSize"
+    />
+    <span class="mx-auto hidden ml-2 md:block">{{
+      $t("components.marker-privacy.private")
+    }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+export interface Props {
+  fontSize: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl";
+  type?: "default" | "group";
+  iconSize?: string;
+  ariaLabel: string;
+}
+
+withDefaults(defineProps<Props>(), {
+  iconSize: "1em",
+  type: "default",
+});
+</script>

--- a/frontend/i18n/en-US.json
+++ b/frontend/i18n/en-US.json
@@ -290,6 +290,9 @@
     },
     "tooltip-sign-in": {
       "text": "You need to be signed in to see this content."
+    },
+    "marker-privacy": {
+      "private": "Private"
     }
   },
   "pages": {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Used a lot of the button code but removed the hover states and all the extra functionality for creating links. I've took some screenshots to show the possible examples. 

<img width="608" alt="Screenshot 2023-10-23 at 19 46 33" src="https://github.com/activist-org/activist/assets/5328578/dfd811f4-8c1e-4b91-9fd6-eb503e480e45">
<img width="564" alt="Screenshot 2023-10-23 at 19 46 16" src="https://github.com/activist-org/activist/assets/5328578/9d6cfd67-cedf-4b41-83b8-fe6a3853ec9c">
<img width="604" alt="Screenshot 2023-10-23 at 19 46 11" src="https://github.com/activist-org/activist/assets/5328578/98fc072c-5255-4039-b3b2-2763b397c2c7"
<img width="584" alt="Screenshot 2023-10-23 at 19 46 01" src="https://github.com/activist-org/activist/assets/5328578/3db5544e-a2ba-485d-bf6f-abd6e8729831">
<img width="640" alt="Screenshot 2023-10-23 at 19 45 55" src="https://github.com/activist-org/activist/assets/5328578/aed1bec0-f60e-4416-a397-91192591f587">
>

### Related issue

- #397
