### PR TITLE
Test setup and first tests inside content app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ __pycache__
 venv/
 .mypy_cache
 
+# Testing
+.coverage
+cov_html/
+
 # Nuxt dev/build outputs
 .output
 .nuxt

--- a/backend/content/factory.py
+++ b/backend/content/factory.py
@@ -1,0 +1,21 @@
+import datetime
+import random
+
+import factory
+
+from .models import Resource
+
+
+class ResourceFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Resource
+
+    name = factory.Faker("name")
+    description = factory.Faker("paragraph")
+    topics = factory.Faker("words", nb=1)
+    location = factory.Faker("address")
+    url = factory.Faker("url")
+    total_flags = random.randint(1, 100)
+    private = random.choice([True, False])
+    creation_date = factory.LazyFunction(datetime.datetime.now)
+    creation_date = factory.LazyFunction(datetime.datetime.now)

--- a/backend/content/factory.py
+++ b/backend/content/factory.py
@@ -28,7 +28,7 @@ class TaskFactory(factory.django.DjangoModelFactory):
     name = factory.Faker("word")
     description = factory.Faker("paragraph")
     location = factory.Faker("address")
-    tags = [factory.Faker("word") for _ in range(10)]
+    tags = factory.List([factory.Faker("word") for _ in range(10)])
     creation_date = factory.LazyFunction(datetime.datetime.now)
     deletion_date = factory.LazyFunction(datetime.datetime.now)
 

--- a/backend/content/factory.py
+++ b/backend/content/factory.py
@@ -3,7 +3,7 @@ import random
 
 import factory
 
-from .models import Resource
+from .models import Resource, ResourceTopic, Task, Topic
 
 
 class ResourceFactory(factory.django.DjangoModelFactory):
@@ -18,4 +18,45 @@ class ResourceFactory(factory.django.DjangoModelFactory):
     total_flags = random.randint(1, 100)
     private = random.choice([True, False])
     creation_date = factory.LazyFunction(datetime.datetime.now)
+    deletion_date = factory.LazyFunction(datetime.datetime.now)
+
+
+class TaskFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Task
+
+    name = factory.Faker("word")
+    description = factory.Faker("paragraph")
+    location = factory.Faker("address")
+    tags = [factory.Faker("word") for _ in range(10)]
     creation_date = factory.LazyFunction(datetime.datetime.now)
+    deletion_date = factory.LazyFunction(datetime.datetime.now)
+
+
+class TopicFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Topic
+
+    name = factory.Faker("word")
+    active = random.choice([True, False])
+    description = factory.Faker("paragraph")
+    creation_date = factory.LazyFunction(datetime.datetime.now)
+    creation_date = factory.LazyFunction(datetime.datetime.now)
+    deprecation_date = factory.Faker("date")
+
+
+class ResourceTopicFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ResourceTopic
+
+    resource_id = factory.SubFactory(ResourceFactory)
+    topic_id = factory.SubFactory(TopicFactory)
+
+
+class TopicFormatFactory(factory.django.DjangoModelFactory):
+    """Placeholder
+    We do not have Factory for events.Format, therefore can not use a Subfactory yet.
+    format_id = models.ForeignKey("events.Format", on_delete=models.CASCADE)
+    """
+
+    pass

--- a/backend/content/tests.py
+++ b/backend/content/tests.py
@@ -1,3 +1,11 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
+from .factory import ResourceFactory
 
-# Create your tests here.
+
+class TestStrMethod(SimpleTestCase):
+    # def setUp(self) -> None:
+    #     self.resource = ResourceFactory.build()
+
+    def test_str_methods(self) -> None:
+        # self.assertEqual(str(self.resource), self.resource.name)
+        self.assertEquals(1, 1)

--- a/backend/content/tests.py
+++ b/backend/content/tests.py
@@ -1,12 +1,14 @@
 from .factory import ResourceFactory, TaskFactory, TopicFactory, ResourceTopicFactory
+import pytest
 
 
+@pytest.mark.django_db
 def test_str_methods() -> None:
     resource = ResourceFactory.build()
     task = TaskFactory.build()
     topics = TopicFactory.build()
-    resource_topics = ResourceTopicFactory.build()
+    resource_topics = ResourceTopicFactory.create()
     assert str(resource) == resource.name
     assert str(task) == task.name
     assert str(topics) == topics.name
-    assert str(resource_topics) == resource_topics.id
+    assert str(resource_topics) == str(resource_topics.id)

--- a/backend/content/tests.py
+++ b/backend/content/tests.py
@@ -1,11 +1,12 @@
-from django.test import SimpleTestCase
-from .factory import ResourceFactory
+from .factory import ResourceFactory, TaskFactory, TopicFactory, ResourceTopicFactory
 
 
-class TestStrMethod(SimpleTestCase):
-    # def setUp(self) -> None:
-    #     self.resource = ResourceFactory.build()
-
-    def test_str_methods(self) -> None:
-        # self.assertEqual(str(self.resource), self.resource.name)
-        self.assertEquals(1, 1)
+def test_str_methods() -> None:
+    resource = ResourceFactory.build()
+    task = TaskFactory.build()
+    topics = TopicFactory.build()
+    resource_topics = ResourceTopicFactory.build()
+    assert str(resource) == resource.name
+    assert str(task) == task.name
+    assert str(topics) == topics.name
+    assert str(resource_topics) == resource_topics.id

--- a/backend/mypy.ini
+++ b/backend/mypy.ini
@@ -5,6 +5,10 @@ plugins =
     mypy_drf_plugin.main
 ignore_missing_imports = True
 strict = True
+exclude = content/factory.py
+
+[mypy-content.*]
+follow_imports = skip
 
 [mypy.plugins.django-stubs]
 django_settings_module = backend.settings

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -50,3 +50,8 @@ exclude = '''
     | migrations
 )/
 '''
+
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "backend.settings"
+python_files = "tests.py test_*.py *_tests.py"
+addopts = "-vv --nomigrations --cov=. --cov-report=html --cov-report=term"

--- a/backend/requirements-dev.in
+++ b/backend/requirements-dev.in
@@ -14,3 +14,7 @@ pre-commit==3.4.0
 ruff==0.0.292
 black==23.3.0
 pip-tools==7.3.0
+pytest==7.4.2
+pytest-cov==4.1.0
+pytest-django==4.5.2
+factory-boy===3.3.0

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -35,6 +35,9 @@ colorama==0.4.6
     # via
     #   build
     #   click
+    #   pytest
+coverage[toml]==7.3.2
+    # via pytest-cov
 distlib==0.3.7
     # via virtualenv
 django==4.2.6
@@ -63,6 +66,10 @@ djangorestframework-stubs==3.14.2
     # via -r requirements.txt
 drf-spectacular==0.26.4
     # via -r requirements.txt
+factory-boy===3.3.0
+    # via -r requirements-dev.in
+faker==19.11.0
+    # via factory-boy
 filelock==3.12.4
     # via virtualenv
 gunicorn==20.1.0
@@ -77,6 +84,8 @@ inflection==0.5.1
     # via
     #   -r requirements.txt
     #   drf-spectacular
+iniconfig==2.0.0
+    # via pytest
 jsonschema==4.19.1
     # via
     #   -r requirements.txt
@@ -101,6 +110,7 @@ packaging==23.2
     # via
     #   black
     #   build
+    #   pytest
 pathspec==0.11.2
     # via black
 pip-tools==7.3.0
@@ -109,12 +119,25 @@ platformdirs==3.11.0
     # via
     #   black
     #   virtualenv
+pluggy==1.3.0
+    # via pytest
 pre-commit==3.4.0
     # via -r requirements-dev.in
 psycopg2-binary==2.9.5
     # via -r requirements.txt
 pyproject-hooks==1.0.0
     # via build
+pytest==7.4.2
+    # via
+    #   -r requirements-dev.in
+    #   pytest-cov
+    #   pytest-django
+pytest-cov==4.1.0
+    # via -r requirements-dev.in
+pytest-django==4.5.2
+    # via -r requirements-dev.in
+python-dateutil==2.8.2
+    # via faker
 python-dotenv==1.0.0
     # via -r requirements.txt
 pytz==2023.3.post1
@@ -142,6 +165,8 @@ rpds-py==0.10.6
     #   referencing
 ruff==0.0.292
     # via -r requirements-dev.in
+six==1.16.0
+    # via python-dateutil
 sqlparse==0.4.4
     # via
     #   -r requirements.txt


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
In this PR, I added initial tests for the `content` app. The tests check the __str__ method of the models. A base setup for coverage is added to `pyproject.toml`.

In factory.py are all the models to create objects for models that can be used for tests. [factory_boy](https://factoryboy.readthedocs.io/en/stable/) uses the [faker](https://faker.readthedocs.io/en/master/) package to generate fake names, words, and so on. That let's us create tests without the use of fixtures.

<ins>Issues:</ins>
* Currently there is no support for generic types with factory_boy, therefore I excluded the factory.py file and its imports from being checked by mypy.
* I excluded TopicFormat, since it has a ForeignKey to another app (events). There is only a placeholder `TopicFormatFactory` at the moment. We can go back to this after creating tests for events app or find another solution.

  ```python
  class TopicFormatFactory(factory.django.DjangoModelFactory):
      """Placeholder
      We do not have Factory for events.Format, therefore can not use a Subfactory yet.
      format_id = models.ForeignKey("events.Format", on_delete=models.CASCADE)
      """
      pass
  ```

<ins>Added development dependecies:</ins>
Are added to requirements-dev.in and compiled in requirements-dev.txt
* pytest
* pytest-cov
* pytest-django
* factory_boy

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

I have tested the factories within the django shell. I also ran pytest locally and with docker. Some tests require database access and won't work outside of docker. We could use a sqllite database for local testing in the future, when we split settings.py into dev and prod.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #432 
