### PR TITLE
Fixed bug with slash hotkey getting picked up by firefox

### DIFF
--- a/frontend/components/SearchBar.vue
+++ b/frontend/components/SearchBar.vue
@@ -84,7 +84,12 @@ const sidebar = useSidebar();
 const input = ref();
 const hotkeyIndicators = ref();
 const isInputFocused = ref(false);
-const keys = useMagicKeys();
+const { slash } = useMagicKeys({
+  passive: false,
+  onEventFired(e) {
+    if (e.key === "/" && e.type === "keydown") e.preventDefault();
+  },
+});
 
 export interface Props {
   location: "sidebar" | "header";
@@ -95,9 +100,11 @@ withDefaults(defineProps<Props>(), {
   expanded: false,
 });
 
-whenever(keys.slash, () => {
+whenever(slash, () => {
   setTimeout(() => {
-    input.value.focus();
+    if (input.value) {
+      input.value.focus();
+    }
   }, 0);
   if (sidebar.collapsed == true && sidebar.collapsedSwitch == true) {
     sidebar.collapsed = false;


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

- Used a custom event handler to hijack what happens when slash is pressed
- Added an if statement around input focus as it was throwing an error even prior to the above change

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #510
