### PR TITLE
refac: Remove unnecessary triggers and steps in GitHub Actions

### DIFF
--- a/.github/workflows/pr_ci_backend.yaml
+++ b/.github/workflows/pr_ci_backend.yaml
@@ -4,10 +4,6 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize]
-  workflow_run:
-    workflows: [pr_maintainer_checklist]
-    types:
-      - completed
 
 jobs:
   backend:

--- a/.github/workflows/pr_ci_frontend.yaml
+++ b/.github/workflows/pr_ci_frontend.yaml
@@ -4,10 +4,6 @@ on:
     branches:
       - main
     types: [opened, reopened, synchronize]
-  workflow_run:
-    workflows: [pr_maintainer_checklist]
-    types:
-      - completed
 
 jobs:
   frontend:

--- a/.github/workflows/pr_maintainer_checklist.yaml
+++ b/.github/workflows/pr_maintainer_checklist.yaml
@@ -13,9 +13,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v2
         with:


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Working on #429 , I noticed a couple points in our existing workflows:
- Was wondering if the `Checkout` step was necessary in the `pr_maintainer_checklist.yaml`, since the workflow doesn't perform any steps actually involving the source code. Tried removing this step and tested in my fork:
   - Test PR: https://github.com/wkyoshida/activist/pull/1
   - Notice in the [logs](https://github.com/wkyoshida/activist/actions/runs/6714205076/job/18247071592) that the workflow does not perform the `Checkout` step and still succeeds :rocket: 

- Also, the `workflow_run` triggers in the `pr_ci_backend.yaml` and the `pr_ci_frontend.yaml` appear to be redundant, since there is already a trigger for when the `pull_request` is `opened`. The `pr_maintainer_checklist` workflow is `completed` mere seconds after the `pull_request` is `opened`, so this simply causes an unnecessary duplicate CI run.
   - Notice the duplicate `pr_ci_backend` and `pr_ci_frontend` runs for the PR yesterday created for :herb:  
      ![image](https://github.com/activist-org/activist/assets/15043193/e25cb3de-43b3-4882-8b1c-059a406936cf)
   - Notice in the test PR from above, no duplicate CI runs occur :grin: 
      ![image](https://github.com/activist-org/activist/assets/15043193/a62ddd32-309d-4084-95f8-b2a773a3d032)


<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER ? 
   - Unsure... #429 ? As I was working on that when uncovered these items.. or another issue can be created. Either or
