### PR TITLE
feat: on events/CardAbout changing organizations to an array of strings 

### DIFF
--- a/frontend/components/card/CardAbout.vue
+++ b/frontend/components/card/CardAbout.vue
@@ -13,12 +13,9 @@
         <div v-if="event" class="flex-col space-y-3">
           <MarkerTopic :topic="event.topic" />
           <div class="flex items-center gap-3">
-            <div
-              class="flex items-center justify-center w-6 h-6 rounded-md fill-light-text dark:fill-dark-text"
-            >
-              <Icon name="IconOrganization" size="1.75em" />
-            </div>
-            <p class="font-semibold">{{ event.organizer }}</p>
+            <MetaTagOrganization
+              :organizations="event.organizations"
+            ></MetaTagOrganization>
           </div>
           <div class="flex flex-col gap-3 md:gap-8 sm:flex-row sm:items-center">
             <div class="flex items-center gap-2">

--- a/frontend/components/meta-tag/MetaTagOrganization.vue
+++ b/frontend/components/meta-tag/MetaTagOrganization.vue
@@ -1,9 +1,7 @@
 <template>
-  <MetaTag
-    v-for="organization in organizations"
-    iconName="IconOrganization"
-    :value="organization"
-  />
+  <div v-for="organization in organizations">
+    <MetaTag iconName="IconOrganization" :value="organization" />
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/components/meta-tag/MetaTagOrganization.vue
+++ b/frontend/components/meta-tag/MetaTagOrganization.vue
@@ -1,9 +1,13 @@
 <template>
-  <MetaTag iconName="IconOrganization" :value="organization" />
+  <MetaTag
+    v-for="organization in organizations"
+    iconName="IconOrganization"
+    :value="organization"
+  />
 </template>
 
 <script setup lang="ts">
 defineProps<{
-  organization: string;
+  organizations: string[];
 }>();
 </script>

--- a/frontend/pages/events/[id]/about.vue
+++ b/frontend/pages/events/[id]/about.vue
@@ -92,7 +92,7 @@ definePageMeta({
 const event: Event = {
   name: "Brandenburg Gate Climate Demo",
   tagline: "There is no Planet B",
-  organizer: "Berlin Climate Org",
+  organizations: ["Berlin Climate Org", "Testing Corp"],
   type: "action",
   topic: "Environment",
   description:

--- a/frontend/types/event.d.ts
+++ b/frontend/types/event.d.ts
@@ -1,7 +1,7 @@
 export interface Event {
   name: string;
   tagline: string;
-  organizer: string;
+  organizations: string[];
   type: string;
   topic: string;
   description: string;


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

On page Events at Card About adding the possibilite to have more than 1 organization.

### Related issue

When I was making the changes I've notice an error in pages/events/[id]/about.vue at line [80](https://github.com/activist-org/activist/blob/51787568ebbb6eb9045b0b172cfc86ae3b68ca79/frontend/pages/events/%5Bid%5D/about.vue#L80C6-L80C6)
the prop social-links was showing: Type 'string[] | undefined' is not assignable to type 'string[]'.
  Type 'undefined' is not assignable to type 'string[]'.

I didn't change it because was not the purpose of this issue and someone could already been working on it

- #557 
