### PR TITLE
dev: Resolve dependencies & generate types when compose starts up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,9 @@ services:
     build:
       context: ./frontend
     container_name: nuxt_frontend
+    command: sh -c "yarn install && yarn dev"
     volumes:
       - ./frontend:/app
-      - /app/node_modules
     ports:
       - "${FRONTEND_PORT}:${FRONTEND_PORT}"
       - "24678:24678"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,13 +3,5 @@ FROM node:19-alpine
 # Set work dir for relative paths
 WORKDIR /app
 
-# Install dependencies
-COPY ./package*.json .
-COPY ./yarn.lock .
-RUN yarn install && yarn cache clean
-
 # Copy code from context to image
 COPY . .
-
-RUN npm rebuild esbuild
-CMD yarn dev


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

I believe I may have found an option that addresses the issues we've been seeing with setting up the development environment.
- Removing the `/app/node_modules` volume we were using before to isolate the local `node_modules` and the `node_modules` in the container (they are now the same).
- Moving the `yarn install` and the `yarn dev` to outside the `Dockerfile` and into the `docker-compose.yml` so that the dependency resolution and the types generation happen when the stack starts up, as opposed to when the image is built. 

The two changes above make it so that the latest dependencies and types get resolved simply by starting up the stack, but also "stores" them locally. 

P.S.
- Retrospective - the previous setup was used to isolate the volume, since the `node_modules` in the container could get overwritten with a faulty/stale/empty local `node_modules` before. However, I believe this is now addressed with this change to do the dependency resolution in the `docker-compose.yml` instead.
- Also tried removing the legacy `npm rebuild esbuild` like we discussed, and it appears to be fine? 

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #568
