### PR TITLE
Implemented the isHighRisk Component to Activist

### DIFF
--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -83,7 +83,7 @@
           />
         </div>
       </div>
-      <div class="w-full md:w-full" v-if="discussionInput.highRisk">
+      <div v-if="discussionInput.highRisk" class="w-full md:w-full">
         <textarea
           id="message"
           rows="4"
@@ -91,7 +91,7 @@
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>
-       <div class="w-full md:w-full" v-else>
+       <div v-else class="w-full md:w-full">
         <textarea
               id="message"
               rows="4"
@@ -105,7 +105,7 @@
           <Icon class="mx-1" name="bi:markdown" size="1.25em"></Icon>
         </p>
         <div class="flex space-x-3 items-center">
-          <div class="w-full md:w-full" v-if="discussionInput.highRisk">
+          <div v-if="discussionInput.highRisk" class="w-full md:w-full">
             <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -104,7 +104,10 @@
           {{ $t("components.card-discussion-input.markdown-support") }}
           <Icon class="mx-1" name="bi:markdown" size="1.25em"></Icon>
         </p>
-        <div class="flex space-x-1">
+        <div class="flex space-x-3 items-center">
+          <div class="cursor-pointer rounded-lg p-1 text-light-text bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
+            <Icon name="bi:exclamation-octagon" size="1.4em" />
+          </div>          
           <BtnLabeled
             class="inline-flex justify-center items-center w-small"
             :cta="true"

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -169,3 +169,8 @@ const listol = () => {
   console.log("click on listol");
 };
 </script>
+<style>
+  .red-text::placeholder {
+    color: red;
+  }
+</style>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -106,7 +106,7 @@
         </p>
         <div class="flex space-x-3 items-center">
           <div class="w-full md:w-full" v-if="discussionInput.highRisk">
-            <div class="cursor-pointer rounded-lg p-1 text-light-text bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
+            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>
           </div>         

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -117,6 +117,7 @@
             fontSize="sm"
             iconSize="1.25em"
             ariaLabel="components.btn-labeled.support-organization-aria-label"
+            style="background-color: light-action-red; border: 1px solid light-text;"
           />
         </div>
       </div>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -91,6 +91,14 @@
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>
+       <div class="w-full md:w-full" v-else>
+        <textarea
+              id="message"
+              rows="4"
+              class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-light-section-div placeholder-light-special-text  focus-brand"
+              :placeholder="$t('components.card-discussion-input.leave-comment')"
+        ></textarea>
+    </div>
       <div class="flex items-center justify-between px-1">
         <p class="inline-flex items-center">
           {{ $t("components.card-discussion-input.markdown-support") }}

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -105,9 +105,11 @@
           <Icon class="mx-1" name="bi:markdown" size="1.25em"></Icon>
         </p>
         <div class="flex space-x-3 items-center">
-          <div class="cursor-pointer rounded-lg p-1 text-light-text bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
-            <Icon name="bi:exclamation-octagon" size="1.4em" />
-          </div>          
+          <div class="w-full md:w-full" v-if="discussionInput.highRisk">
+            <div class="cursor-pointer rounded-lg p-1 text-light-text bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
+              <Icon name="bi:exclamation-octagon" size="1.4em" />
+            </div>
+          </div>         
           <BtnLabeled
             class="inline-flex justify-center items-center w-small"
             :cta="true"

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -95,7 +95,7 @@
         <textarea
               id="message"
               rows="4"
-              class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-light-section-div placeholder-light-special-text  focus-brand"
+              class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-light-section-div placeholder-light-special-text dark:placeholder-dark-special-text dark:text-dark-text  dark:bg-dark-distinct focus-brand"
               :placeholder="$t('components.card-discussion-input.leave-comment')"
         ></textarea>
     </div>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -87,7 +87,7 @@
         <textarea
           id="message"
           rows="4"
-          class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-red-500 placeholder-light-special-text focus-brand  dark:bg-dark-distinct font-bold red-text"
+          class="block p-2.5 w-full text-sm rounded-lg border border-light-action-red dark:border-dark-action-red placeholder-light-special-text focus-brand  dark:bg-dark-distinct font-bold text-light-action-red dark:text-dark-action-red dark:text-dark-text"
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>
@@ -169,8 +169,4 @@ const listol = () => {
   console.log("click on listol");
 };
 </script>
-<style>
-  .red-text::placeholder {
-    color: red;
-  }
-</style>
+

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -87,7 +87,7 @@
         <textarea
           id="message"
           rows="4"
-          class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-red-500 placeholder-light-special-text focus-brand font-bold red-text"
+          class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-red-500 placeholder-light-special-text focus-brand  dark:bg-dark-distinct font-bold red-text"
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -87,7 +87,7 @@
         <textarea
           id="message"
           rows="4"
-          class="block p-2.5 w-full text-sm rounded-lg border border-light-action-red dark:border-dark-action-red placeholder-light-special-text focus-brand  dark:bg-dark-distinct font-bold text-light-action-red dark:text-dark-action-red dark:text-dark-text"
+          class="block p-2.5 w-full text-sm rounded-lg border border-light-action-red dark:border-dark-action-red placeholder-light-special-text focus-brand font-bold placeholder:text-light-action-red  dark:placeholder:text-dark-action-red dark:text-dark-text bg-light-content dark:bg-dark-content"
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>
@@ -106,7 +106,7 @@
         </p>
         <div class="flex space-x-3 items-center">
           <div v-if="discussionInput.highRisk" class="w-full md:w-full">
-            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
+            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand w-16 h-10 flex justify-center items-center">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>
           </div>         
@@ -117,7 +117,6 @@
             fontSize="sm"
             iconSize="1.25em"
             ariaLabel="components.btn-labeled.support-organization-aria-label"
-            style="background-color: light-action-red; border: 1px solid light-text;"
           />
         </div>
       </div>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -83,12 +83,12 @@
           />
         </div>
       </div>
-      <div class="w-full md:w-full">
+      <div class="w-full md:w-full" v-if="discussionInput.highRisk">
         <textarea
           id="message"
           rows="4"
-          class="block p-2.5 w-full text-sm text-light-text bg-light-content rounded-lg border border-light-section-div dark:bg-dark-content dark:border-dark-section-div placeholder-light-special-text dark:placeholder-dark-special-text dark:text-dark-text focus-brand"
-          :placeholder="$t('components.card-discussion-input.leave-comment')"
+          class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-red-500 placeholder-light-special-text focus-brand font-bold red-text"
+          :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>
       <div class="flex items-center justify-between px-1">

--- a/frontend/i18n/en-US.json
+++ b/frontend/i18n/en-US.json
@@ -127,7 +127,7 @@
   "components.card-danger-zone.username-label": "Your username",
   "components.card-danger-zone.username-placeholder": "Enter your username",
   "components.card-discussion-input.comment": "Comment",
-  "components.card-discussion-input.leave-comment": "Leave a comment",
+  "components.card-discussion-input.leave-comment": "Leave a public comment",
   "components.card-discussion-input.leave-comment-highRisk": "You are a member of a high risk organization. Please be careful what you write.",
   "components.card-discussion-input.markdown-support": "This editor supports Markdown",
   "components.card-discussion-input.preview": "Preview",

--- a/frontend/i18n/en-US.json
+++ b/frontend/i18n/en-US.json
@@ -128,6 +128,7 @@
   "components.card-danger-zone.username-placeholder": "Enter your username",
   "components.card-discussion-input.comment": "Comment",
   "components.card-discussion-input.leave-comment": "Leave a comment",
+  "components.card-discussion-input.leave-comment-highRisk": "You are a member of a high risk organization. Please be careful what you write.",
   "components.card-discussion-input.markdown-support": "This editor supports Markdown",
   "components.card-discussion-input.preview": "Preview",
   "components.card-discussion-input.write": "Write",

--- a/frontend/pages/events/[id]/discussion.vue
+++ b/frontend/pages/events/[id]/discussion.vue
@@ -71,5 +71,6 @@ const discussionInput: DiscussionInput = {
   supporters: 123,
   description: "I love to test!",
   category: "Category",
+  highRisk: true,
 };
 </script>

--- a/frontend/types/card-discussion-input.d.ts
+++ b/frontend/types/card-discussion-input.d.ts
@@ -4,4 +4,6 @@ export interface DiscussionInput {
   supporters: number;
   description: string;
   category: string;
+  highRisk: boolean;
+
 }

--- a/frontend/types/card-discussion-input.d.ts
+++ b/frontend/types/card-discussion-input.d.ts
@@ -4,6 +4,4 @@ export interface DiscussionInput {
   supporters: number;
   description: string;
   category: string;
-  highRisk: boolean;
-
 }


### PR DESCRIPTION
- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

**Description**
This pull request introduces the isHighRisk property to the CardDiscussionInput component in the activist project. The feature aims to increase safety for users who are part of or interacting with high-risk organizations. It modifies the user interface to display warnings and different styles when the isHighRisk flag is true.

**Testing**
The feature was tested in a local development environment. The UI changes were verified for both high-risk and non-high-risk scenarios. Additionally, the feature was tested in dark mode to ensure visual consistency and accessibility

**Proof of output:**
_Light Mode:_
<img width="1284" alt="Screenshot 2023-11-28 at 10 00 01 pm" src="https://github.com/activist-org/activist/assets/122262442/bc67a24c-5c6c-42c5-b6b4-1c3ed848e55e">


_Dark Mode:_
<img width="1304" alt="Screenshot 2023-11-28 at 9 59 11 pm" src="https://github.com/activist-org/activist/assets/122262442/177f879c-f756-4167-ad1c-2f80413eae59">

**Issue Number**
This pull request Closes Issue #558: ["Add isHighRisk prop to CardDiscussionInput"](https://github.com/activist-org/activist/issues/558), which was opened to enhance the safety features of the activist platform's discussion component.

**Team Members:**
Shahad Astaneh, Al Maha Al Jabor, Ali Al-Quradaghi, and Fatima Johar