### PR TITLE
Implementation of isHighrisk Disscusion Warning Tooltip

### DIFF
--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -83,7 +83,7 @@
           />
         </div>
       </div>
-      <div class="w-full md:w-full" v-if="discussionInput.highRisk">
+      <div v-if="discussionInput.highRisk" class="w-full md:w-full">
         <textarea
           id="message"
           rows="4"
@@ -91,7 +91,7 @@
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>
-       <div class="w-full md:w-full" v-else>
+       <div v-else class="w-full md:w-full">
         <textarea
               id="message"
               rows="4"
@@ -105,7 +105,7 @@
           <Icon class="mx-1" name="bi:markdown" size="1.25em"></Icon>
         </p>
         <div class="flex space-x-3 items-center">
-          <div class="w-full md:w-full" v-if="discussionInput.highRisk">
+          <div v-if="discussionInput.highRisk" class="w-full md:w-full">
             <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -106,7 +106,7 @@
         </p>
         <div class="flex space-x-3 items-center">
           <div class="w-full md:w-full" v-if="discussionInput.highRisk">
-            <div class="cursor-pointer rounded-lg p-1 text-light-text bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
+            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>
           </div>         

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -1,3 +1,4 @@
+
 <template>
   <div class="flex flex-col w-full md:flex-row card-style px-3 py-4">
     <div class="flex-col pt-3 space-y-3 md:pl-2 md:space-y-4 md:grow md:pt-0">
@@ -105,12 +106,12 @@
           <Icon class="mx-1" name="bi:markdown" size="1.25em"></Icon>
         </p>
         <div class="flex space-x-3 items-center">
-          <div v-if="discussionInput.highRisk" @mouseenter="showTooltip = true" @mouseleave="showTooltip = false" class="relative w-full md:w-full">            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand w-16 h-10 flex justify-center items-center">
+          <div v-if="discussionInput.highRisk" @mouseenter="showTooltip = true" @mouseleave="showTooltip = false" class="relative w-full md:w-full">
+            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand w-16 h-10 flex justify-center items-center">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>
-          </div> 
-        <TooltipDiscussionWarning v-show="showTooltip" />
-        
+            <TooltipDiscussionWarning v-show="showTooltip" />
+          </div>         
           <BtnLabeled
             class="inline-flex justify-center items-center w-small"
             :cta="true"
@@ -124,7 +125,6 @@
     </div>
   </div>
 </template>
-
 <script setup lang="ts">
 import type { DiscussionInput } from "~/types/card-discussion-input";
 import TooltipDiscussionWarning from '@/components/tooltip/TooltipDiscussionWarning.vue';
@@ -132,42 +132,32 @@ const showTooltip = ref(false);
 defineProps<{
   discussionInput: DiscussionInput;
 }>();
-
 const at = () => {
   console.log("click on at");
 };
-
 const heading = () => {
   console.log("click on heading");
 };
-
 const bold = () => {
   console.log("click on bold");
 };
-
 const italic = () => {
   console.log("click on italic");
 };
-
 const blockquote = () => {
   console.log("click on blockquote");
 };
-
 const link = () => {
   console.log("click on link");
 };
-
 // There is as of now no plan to add in attachments.
 // const attach = () => {
 //   console.log("click on attach");
 // };
-
 const listul = () => {
   console.log("click on listul");
 };
-
 const listol = () => {
   console.log("click on listol");
 };
 </script>
-

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -108,7 +108,9 @@
           <div v-if="discussionInput.highRisk" @mouseenter="showTooltip = true" @mouseleave="showTooltip = false" class="relative w-full md:w-full">            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand w-16 h-10 flex justify-center items-center">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>
-          </div>         
+          </div> 
+        <TooltipDiscussionWarning v-show="showTooltip" />
+        
           <BtnLabeled
             class="inline-flex justify-center items-center w-small"
             :cta="true"

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -105,8 +105,7 @@
           <Icon class="mx-1" name="bi:markdown" size="1.25em"></Icon>
         </p>
         <div class="flex space-x-3 items-center">
-          <div v-if="discussionInput.highRisk" class="w-full md:w-full">
-            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand w-16 h-10 flex justify-center items-center">
+          <div v-if="discussionInput.highRisk" @mouseenter="showTooltip = true" @mouseleave="showTooltip = false" class="relative w-full md:w-full">            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand w-16 h-10 flex justify-center items-center">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>
           </div>         

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -127,7 +127,8 @@
 
 <script setup lang="ts">
 import type { DiscussionInput } from "~/types/card-discussion-input";
-
+import TooltipDiscussionWarning from '@/components/tooltip/TooltipDiscussionWarning.vue';
+const showTooltip = ref(false);
 defineProps<{
   discussionInput: DiscussionInput;
 }>();

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -95,7 +95,7 @@
         <textarea
               id="message"
               rows="4"
-              class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-light-section-div placeholder-light-special-text  focus-brand"
+              class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-light-section-div placeholder-light-special-text dark:placeholder-dark-special-text dark:text-dark-text  dark:bg-dark-distinct focus-brand"
               :placeholder="$t('components.card-discussion-input.leave-comment')"
         ></textarea>
     </div>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -87,7 +87,7 @@
         <textarea
           id="message"
           rows="4"
-          class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-red-500 placeholder-light-special-text focus-brand  dark:bg-dark-distinct font-bold red-text"
+          class="block p-2.5 w-full text-sm rounded-lg border border-light-action-red dark:border-dark-action-red placeholder-light-special-text focus-brand  dark:bg-dark-distinct font-bold text-light-action-red dark:text-dark-action-red dark:text-dark-text"
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>
@@ -169,8 +169,4 @@ const listol = () => {
   console.log("click on listol");
 };
 </script>
-<style>
-  .red-text::placeholder {
-    color: red;
-  }
-</style>
+

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -87,7 +87,7 @@
         <textarea
           id="message"
           rows="4"
-          class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-red-500 placeholder-light-special-text focus-brand font-bold red-text"
+          class="block p-2.5 w-full text-sm text-light-text rounded-lg border border-red-500 placeholder-light-special-text focus-brand  dark:bg-dark-distinct font-bold red-text"
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -87,7 +87,7 @@
         <textarea
           id="message"
           rows="4"
-          class="block p-2.5 w-full text-sm rounded-lg border border-light-action-red dark:border-dark-action-red placeholder-light-special-text focus-brand  dark:bg-dark-distinct font-bold text-light-action-red dark:text-dark-action-red dark:text-dark-text"
+          class="block p-2.5 w-full text-sm rounded-lg border border-light-action-red dark:border-dark-action-red placeholder-light-special-text focus-brand font-bold placeholder:text-light-action-red  dark:placeholder:text-dark-action-red dark:text-dark-text bg-light-content dark:bg-dark-content"
           :placeholder="$t('components.card-discussion-input.leave-comment-highRisk')"
         ></textarea>
       </div>
@@ -106,7 +106,7 @@
         </p>
         <div class="flex space-x-3 items-center">
           <div v-if="discussionInput.highRisk" class="w-full md:w-full">
-            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand" style="width: 3.3em; height: 2.4em; display: flex; justify-content: center; align-items: center;">
+            <div class="cursor-pointer rounded-lg p-1 text-light-text dark:text-light-action-red dark:bg-dark-action-red/20 dark:border-dark-action-red bg-light-action-red border border-light-text focus-brand w-16 h-10 flex justify-center items-center">
               <Icon name="bi:exclamation-octagon" size="1.4em" />
             </div>
           </div>         
@@ -117,7 +117,6 @@
             fontSize="sm"
             iconSize="1.25em"
             ariaLabel="components.btn-labeled.support-organization-aria-label"
-            style="background-color: light-action-red; border: 1px solid light-text;"
           />
         </div>
       </div>

--- a/frontend/components/tooltip/TooltipDiscussionWarning.vue
+++ b/frontend/components/tooltip/TooltipDiscussionWarning.vue
@@ -1,0 +1,23 @@
+<template>
+  <Tooltip
+    :text="text"
+    class="w-80 lg:right-0"
+    >
+    <ul class="list-disc pl-4 space-y-1">
+      <li>Names</li>
+      <li>Home addresses</li>
+      <li>Phone numbers</li>
+      <li>Email addresses</li>
+    </ul>
+  </Tooltip>
+</template>
+
+<script setup lang="ts">
+import Tooltip from './tooltip.vue';
+
+const props = withDefaults(defineProps<{
+  text?: string;
+}>(), {
+  text: 'Please use usernames and do NOT write any personal information including:'
+});
+</script>

--- a/frontend/components/tooltip/TooltipDiscussionWarning.vue
+++ b/frontend/components/tooltip/TooltipDiscussionWarning.vue
@@ -1,7 +1,7 @@
 <template>
   <Tooltip
     :text="text"
-    class="w-80 lg:right-0"
+    class="w-96 lg:right-0"
     >
     <ul class="list-disc pl-4 space-y-1">
       <li>Names</li>

--- a/frontend/components/tooltip/TooltipDiscussionWarning.vue
+++ b/frontend/components/tooltip/TooltipDiscussionWarning.vue
@@ -13,7 +13,8 @@
 </template>
 
 <script setup lang="ts">
-import Tooltip from './tooltip.vue';
+import Tooltip from './Tooltip.vue';
+
 
 const props = withDefaults(defineProps<{
   text?: string;

--- a/frontend/i18n/en-US.json
+++ b/frontend/i18n/en-US.json
@@ -127,7 +127,7 @@
   "components.card-danger-zone.username-label": "Your username",
   "components.card-danger-zone.username-placeholder": "Enter your username",
   "components.card-discussion-input.comment": "Comment",
-  "components.card-discussion-input.leave-comment": "Leave a comment",
+  "components.card-discussion-input.leave-comment": "Leave a public comment",
   "components.card-discussion-input.leave-comment-highRisk": "You are a member of a high risk organization. Please be careful what you write.",
   "components.card-discussion-input.markdown-support": "This editor supports Markdown",
   "components.card-discussion-input.preview": "Preview",


### PR DESCRIPTION
- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This pull request builds upon the existing `isHighRisk` feature within the `CardDiscussionInput` component of the Activist project. It introduces the `TooltipDiscussionWarning` component, which is designed to provide contextual information and guidelines to users when interacting with high-risk organizations or discussions. This addition enhances the user interface by offering more detailed warnings and guidance when the `isHighRisk` flag is active. The implementation of this tooltip aims to further support user safety and awareness in high-risk scenarios, complementing the objectives of the original issue #586.

### Testing
After integration, the tooltip's appearance and position and functionality were manually checked against the design specifications in Figma. This was to ensure visual consistency and alignment with the required principles. 


### Related issue
This pull request serves as an extension to the previously addressed issue:
[Implemented the isHighRisk Component to Activist #586](https://github.com/activist/project/issues/586)

This pull request resolves issue #588

### Output:
<img width="451" alt="Screenshot 2023-12-02 at 4 09 56 am" src="https://github.com/activist-org/activist/assets/122262442/9aa5002e-6504-4a87-bf23-6c036d03713b">

