### PR TITLE
fix(dev): Add FRONTEND_PORT env to configure port on compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ./frontend
     container_name: nuxt_frontend
-    command: sh -c "yarn install && yarn dev"
+    command: sh -c "yarn install && yarn dev --port ${FRONTEND_PORT}"
     volumes:
       - ./frontend:/app
     ports:


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Coming out of the [discussion](https://matrix.to/#/!CRgLpGeOBNwxYCtqmK:matrix.org/$5OLIJ-4DHZHS4U3DrDfkHrfkunWkiCsdEV9IcTxBInI?via=matrix.org&via=acter.global&via=chat.0x7cd.xyz) in the Matrix, decided to look into why trying to set a different front-end port was not working. Seems that we were missing configuring it in the command when starting up the stack. 

Before, `FRONTEND_PORT` was only being used for exposing the container ports.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- N/A
