### PR TITLE
#608. Create 'onTab' Function for Tooltip Visibility Control

### DIFF
--- a/frontend/components/menu/MenuSearchResult.vue
+++ b/frontend/components/menu/MenuSearchResult.vue
@@ -47,6 +47,6 @@ const showTooltip = ref(false);
 // It sets the 'showTooltip' to false, making the tooltip invisible.
 // NOTE: If new elements are added to the tooltip, this function should be reviewed to ensure it correctly handles the visibility of the tooltip in response to Tab key actions.
 const onTab = () => {
-  showTooltip.value = false
-}
+  showTooltip.value = false;
+};
 </script>

--- a/frontend/components/menu/MenuSearchResult.vue
+++ b/frontend/components/menu/MenuSearchResult.vue
@@ -2,6 +2,7 @@
   <div @mouseleave="showTooltip = false" class="p-2">
     <button
       @click="showTooltip = showTooltip == true ? false : true"
+      ref="tooltipButton"
       class="relative flex items-center justify-center style-cta rounded-full w-6 h-6 elem-shadow-sm"
     >
       <Icon name="bi:three-dots-vertical" size="1.25em" />
@@ -9,24 +10,28 @@
         v-if="searchResultType === 'event'"
         v-show="showTooltip"
         @blur="showTooltip = false"
+        @tab="onTab"
         class="absolute bottom-6 left-4"
       />
       <TooltipMenuSearchResultOrganization
         v-if="searchResultType === 'organization'"
         v-show="showTooltip"
         @blur="showTooltip = false"
+        @tab="onTab"
         class="absolute bottom-6 left-4"
       />
       <TooltipMenuSearchResultResource
         v-if="searchResultType === 'resource'"
         v-show="showTooltip"
         @blur="showTooltip = false"
+        @tab="onTab"
         class="absolute bottom-6 left-4"
       />
       <TooltipMenuSearchResultUser
         v-if="searchResultType === 'user'"
         v-show="showTooltip"
         @blur="showTooltip = false"
+        @tab="onTab"
         class="absolute bottom-6 left-4"
       />
     </button>
@@ -38,4 +43,12 @@ defineProps<{
   searchResultType: "organization" | "event" | "resource" | "user";
 }>();
 const showTooltip = ref(false);
+const tooltipButton = ref(null)
+
+// The function is triggered when the Tab key is pressed on the last element of the tooltip.
+// It sets the 'showTooltip' to false, making the tooltip invisible.
+// NOTE: If new elements are added to the tooltip, this function should be reviewed to ensure it correctly handles the visibility of the tooltip in response to Tab key actions.
+const onTab = () => {
+  showTooltip.value = false
+}
 </script>

--- a/frontend/components/menu/MenuSearchResult.vue
+++ b/frontend/components/menu/MenuSearchResult.vue
@@ -42,7 +42,6 @@ defineProps<{
   searchResultType: "organization" | "event" | "resource" | "user";
 }>();
 const showTooltip = ref(false);
-const tooltipButton = ref(null)
 
 // The function is triggered when the Tab key is pressed on the last element of the tooltip.
 // It sets the 'showTooltip' to false, making the tooltip invisible.

--- a/frontend/components/menu/MenuSearchResult.vue
+++ b/frontend/components/menu/MenuSearchResult.vue
@@ -2,7 +2,6 @@
   <div @mouseleave="showTooltip = false" class="p-2">
     <button
       @click="showTooltip = showTooltip == true ? false : true"
-      ref="tooltipButton"
       class="relative flex items-center justify-center style-cta rounded-full w-6 h-6 elem-shadow-sm"
     >
       <Icon name="bi:three-dots-vertical" size="1.25em" />

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
@@ -1,6 +1,6 @@
 <template>
   <TooltipBase class="rounded-md">
-    <div ref="tooltip" class="space-y-2">
+    <div class="space-y-2">
       <BtnLabeled
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.support"

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
@@ -2,6 +2,7 @@
   <TooltipBase class="rounded-md">
     <div class="space-y-2">
       <BtnLabeled
+        @keydown="onTabPress(false, $event)"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.support"
         leftIcon="IconSupport"
@@ -18,7 +19,7 @@
         :ariaLabel="$t('components.btn-labeled.attend-aria-label')"
       />
       <BtnLabeled
-        @keydown.tab="$emit('tab')"
+        @keydown="onTabPress(true, $event)"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.share"
         leftIcon="bi:box-arrow-up"
@@ -31,9 +32,13 @@
 </template>
 
 <script setup lang="ts">
+import useTabNavigationEmit from "~/composables/useTabNavigationEmit";
+
 defineProps<{
   location?: string;
 }>();
 
-defineEmits(['tab'])
+const emit = defineEmits(['tab'])
+
+const { onTabPress } = useTabNavigationEmit(emit)
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
@@ -1,6 +1,6 @@
 <template>
   <TooltipBase class="rounded-md">
-    <div class="space-y-2">
+    <div ref="tooltip" class="space-y-2">
       <BtnLabeled
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.support"
@@ -18,6 +18,7 @@
         :ariaLabel="$t('components.btn-labeled.attend-aria-label')"
       />
       <BtnLabeled
+        @keydown.tab="$emit('tab')"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.share"
         leftIcon="bi:box-arrow-up"
@@ -33,4 +34,6 @@
 defineProps<{
   location?: string;
 }>();
+
+defineEmits(['tab'])
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
@@ -38,7 +38,7 @@ defineProps<{
   location?: string;
 }>();
 
-const emit = defineEmits(['tab'])
+const emit = defineEmits(["tab"]);
 
-const { onTabPress } = useTabNavigationEmit(emit)
+const { onTabPress } = useTabNavigationEmit(emit);
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultOrganization.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultOrganization.vue
@@ -40,7 +40,7 @@ defineProps<{
   location?: string;
 }>();
 
-const emit = defineEmits(['tab'])
+const emit = defineEmits(["tab"]);
 
-const { onTabPress } = useTabNavigationEmit(emit)
+const { onTabPress } = useTabNavigationEmit(emit);
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultOrganization.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultOrganization.vue
@@ -2,6 +2,7 @@
   <TooltipBase class="rounded-md">
     <div class="space-y-2">
       <BtnLabeled
+        @keydown="onTabPress(false, $event)"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.support"
         leftIcon="IconSupport"
@@ -20,7 +21,7 @@
         :ariaLabel="$t('components.btn-labeled.join-organization-aria-label')"
       />
       <BtnLabeled
-        @keydown.tab="$emit('tab')"
+        @keydown="onTabPress(true, $event)"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.share"
         leftIcon="bi:box-arrow-up"
@@ -33,9 +34,13 @@
 </template>
 
 <script setup lang="ts">
+import useTabNavigationEmit from "~/composables/useTabNavigationEmit";
+
 defineProps<{
   location?: string;
 }>();
 
-defineEmits(['tab'])
+const emit = defineEmits(['tab'])
+
+const { onTabPress } = useTabNavigationEmit(emit)
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultOrganization.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultOrganization.vue
@@ -20,6 +20,7 @@
         :ariaLabel="$t('components.btn-labeled.join-organization-aria-label')"
       />
       <BtnLabeled
+        @keydown.tab="$emit('tab')"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.share"
         leftIcon="bi:box-arrow-up"
@@ -35,4 +36,6 @@
 defineProps<{
   location?: string;
 }>();
+
+defineEmits(['tab'])
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultResource.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultResource.vue
@@ -10,6 +10,7 @@
         :ariaLabel="$t('components._global.star')"
       />
       <BtnLabeled
+        @keydown.tab="$emit('tab')"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.share"
         leftIcon="bi:box-arrow-up"
@@ -25,4 +26,6 @@
 defineProps<{
   location?: string;
 }>();
+
+defineEmits(['tab'])
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultResource.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultResource.vue
@@ -30,7 +30,7 @@ defineProps<{
   location?: string;
 }>();
 
-const emit = defineEmits(['tab'])
+const emit = defineEmits(["tab"]);
 
-const { onTabPress } = useTabNavigationEmit(emit)
+const { onTabPress } = useTabNavigationEmit(emit);
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultResource.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultResource.vue
@@ -2,6 +2,7 @@
   <TooltipBase class="rounded-md">
     <div class="space-y-2">
       <BtnLabeled
+        @keydown="onTabPress(false, $event)"
         class="flex truncate max-h-[40px] w-full"
         label="components._global.star"
         leftIcon="bi:star"
@@ -10,7 +11,7 @@
         :ariaLabel="$t('components._global.star')"
       />
       <BtnLabeled
-        @keydown.tab="$emit('tab')"
+        @keydown="onTabPress(true, $event)"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.share"
         leftIcon="bi:box-arrow-up"
@@ -23,9 +24,13 @@
 </template>
 
 <script setup lang="ts">
+import useTabNavigationEmit from "~/composables/useTabNavigationEmit";
+
 defineProps<{
   location?: string;
 }>();
 
-defineEmits(['tab'])
+const emit = defineEmits(['tab'])
+
+const { onTabPress } = useTabNavigationEmit(emit)
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultUser.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultUser.vue
@@ -2,6 +2,7 @@
   <TooltipBase class="rounded-md">
     <div class="space-y-2">
       <BtnLabeled
+        @keydown="onTabPress(false, $event)"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.support"
         leftIcon="IconSupport"
@@ -10,7 +11,7 @@
         :ariaLabel="$t('components.btn-labeled.support-user-aria-label')"
       />
       <BtnLabeled
-        @keydown.tab="$emit('tab')"
+        @keydown="onTabPress(true, $event)"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.share"
         leftIcon="bi:box-arrow-up"
@@ -23,9 +24,13 @@
 </template>
 
 <script setup lang="ts">
+import useTabNavigationEmit from "~/composables/useTabNavigationEmit";
+
 defineProps<{
   location?: string;
 }>();
 
-defineEmits(['tab'])
+const emit = defineEmits(['tab'])
+
+const { onTabPress } = useTabNavigationEmit(emit)
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultUser.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultUser.vue
@@ -30,7 +30,7 @@ defineProps<{
   location?: string;
 }>();
 
-const emit = defineEmits(['tab'])
+const emit = defineEmits(["tab"]);
 
-const { onTabPress } = useTabNavigationEmit(emit)
+const { onTabPress } = useTabNavigationEmit(emit);
 </script>

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultUser.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultUser.vue
@@ -10,6 +10,7 @@
         :ariaLabel="$t('components.btn-labeled.support-user-aria-label')"
       />
       <BtnLabeled
+        @keydown.tab="$emit('tab')"
         class="flex truncate max-h-[40px] w-full"
         label="components.btn-labeled.share"
         leftIcon="bi:box-arrow-up"
@@ -25,4 +26,6 @@
 defineProps<{
   location?: string;
 }>();
+
+defineEmits(['tab'])
 </script>

--- a/frontend/composables/useTabNavigationEmit.ts
+++ b/frontend/composables/useTabNavigationEmit.ts
@@ -19,7 +19,6 @@ export default function useTabNavigationEmit(emit: EmitType) {
       (!isLastItem && event.shiftKey && event.key === "Tab") ||
       (isLastItem && !event.shiftKey && event.key === "Tab")
     ) {
-      event.preventDefault();
       emit("tab");
     }
   };

--- a/frontend/composables/useTabNavigationEmit.ts
+++ b/frontend/composables/useTabNavigationEmit.ts
@@ -11,14 +11,17 @@
  *
  */
 
-type EmitType = (event: 'tab', payload?: string) => void;
+type EmitType = (event: "tab", payload?: string) => void;
 
 export default function useTabNavigationEmit(emit: EmitType) {
   const onTabPress = (isLastItem: boolean, event: KeyboardEvent) => {
-    if ((!isLastItem && event.shiftKey && event.key === 'Tab') || (isLastItem && !event.shiftKey && event.key === 'Tab')) {
-      event.preventDefault()
-      emit('tab')
+    if (
+      (!isLastItem && event.shiftKey && event.key === "Tab") ||
+      (isLastItem && !event.shiftKey && event.key === "Tab")
+    ) {
+      event.preventDefault();
+      emit("tab");
     }
-  }
-  return { onTabPress }
+  };
+  return { onTabPress };
 }

--- a/frontend/composables/useTabNavigationEmit.ts
+++ b/frontend/composables/useTabNavigationEmit.ts
@@ -1,8 +1,20 @@
+/**
+ * Creates a custom hook for managing tab navigation in a component.
+ * This hook provides a function to handle the 'Tab' key press event,
+ * ensuring that when the user reaches the last focusable item in a sequence,
+ * pressing the 'Tab' key will cycle back to the first item, and vice versa.
+ *
+ * @param {EmitType} emit - A function to emit custom events. In this case, it's used
+ *                           to emit a 'tab' event when the Tab key is pressed.
+ * @returns An object containing the `onTabPress` function that should be used as an event handler
+ *          for keyboard events to manage tab navigation.
+ *
+ */
+
 type EmitType = (event: 'tab', payload?: string) => void;
 
 export default function useTabNavigationEmit(emit: EmitType) {
   const onTabPress = (isLastItem: boolean, event: KeyboardEvent) => {
-    console.log('tab')
     if ((!isLastItem && event.shiftKey && event.key === 'Tab') || (isLastItem && !event.shiftKey && event.key === 'Tab')) {
       event.preventDefault()
       emit('tab')

--- a/frontend/composables/useTabNavigationEmit.ts
+++ b/frontend/composables/useTabNavigationEmit.ts
@@ -1,0 +1,12 @@
+type EmitType = (event: 'tab', payload?: string) => void;
+
+export default function useTabNavigationEmit(emit: EmitType) {
+  const onTabPress = (isLastItem: boolean, event: KeyboardEvent) => {
+    console.log('tab')
+    if ((!isLastItem && event.shiftKey && event.key === 'Tab') || (isLastItem && !event.shiftKey && event.key === 'Tab')) {
+      event.preventDefault()
+      emit('tab')
+    }
+  }
+  return { onTabPress }
+}


### PR DESCRIPTION
- Added 'onTab' function in MenuSearchResult.vue to close the tooltip when the Tab key is pressed on the last element.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #608 
