### PR TITLE
Initial Resource API setup 🎅🎁🎄 

### DIFF
--- a/backend/content/factories.py
+++ b/backend/content/factories.py
@@ -15,8 +15,9 @@ class ResourceFactory(factory.django.DjangoModelFactory):
     url = factory.Faker("url")
     total_flags = factory.Faker("random_int", min=0, max=100)
     private = factory.Faker("boolean")
+    created_by = factory.SubFactory("authentication.factories.UserFactory")
     creation_date = factory.LazyFunction(datetime.datetime.now)
-    deletion_date = factory.LazyFunction(datetime.datetime.now)
+    last_updated = factory.LazyFunction(datetime.datetime.now)
 
 
 class TaskFactory(factory.django.DjangoModelFactory):

--- a/backend/content/models.py
+++ b/backend/content/models.py
@@ -18,7 +18,7 @@ from django.db import models
 from backend.mixins.models import CreationDeletionMixin
 
 
-class Resource(CreationDeletionMixin):
+class Resource(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
     name = models.CharField(max_length=255)
     description = models.TextField(max_length=500)
@@ -27,6 +27,8 @@ class Resource(CreationDeletionMixin):
     url = models.URLField(max_length=255)
     total_flags = models.IntegerField(default=0)
     private = models.BooleanField(default=True)
+    created_by = models.ForeignKey("authentication.User", on_delete=models.CASCADE)
+    creation_date = models.DateTimeField(auto_now_add=True)
     last_updated = models.DateTimeField(auto_now=True)
 
     def __str__(self) -> str:

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any, Dict, Union
 
 from django.utils.translation import gettext as _
@@ -9,7 +8,6 @@ from utils.utils import (
     validate_creation_and_deletion_dates,
     validate_creation_and_deprecation_dates,
     validate_empty,
-    validate_flags_number,
     validate_object_existence,
 )
 
@@ -19,28 +17,22 @@ from .models import Resource, ResourceTopic, Task, Topic, TopicFormat
 class ResourceSerializer(serializers.ModelSerializer[Resource]):
     class Meta:
         model = Resource
-        fields = "__all__"
+        fields = [
+            "name",
+            "description",
+            "topics",
+            "category",
+            "url",
+            "private",
+            "total_flags",
+        ]
 
     def validate(self, data: Dict[str, Union[str, Any]]) -> Dict[str, Union[str, Any]]:
-        validate_empty(data["name"], "name")
-        validate_empty(data["description"], "description")
-        validate_empty(data["url"], "url")
-        validate_empty(data["topics"], "topics")
-        validate_empty(data["location"], "location")
-
-        if not isinstance(data["total_flags"], int):
-            data["total_flags"] = int(data["total_flags"])
-
-        validate_flags_number(data)
-
-        if not re.match(r"https?://\S+", data["url"]):
-            raise serializers.ValidationError(
-                _("The field url must have a valid format - https://www.example.com."),
-                code="invalid_url",
-            )
-
-        validate_creation_and_deletion_dates(data)
-
+        if total_flags := data.get("total_flags") is not None:
+            if not isinstance(total_flags, int):
+                raise serializers.ValidationError(
+                    _("Total flags must be an integer value.")
+                )
         return data
 
 

--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -1,4 +1,9 @@
-from rest_framework import viewsets
+# mypy: disable-error-code="override"
+from django.db.models import Q
+from rest_framework import status, viewsets
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
 from backend.paginator import CustomPagination
@@ -18,6 +23,76 @@ class ResourceViewSet(viewsets.ModelViewSet[Resource]):
     serializer_class = ResourceSerializer
     pagination_class = CustomPagination
     throttle_classes = [AnonRateThrottle, UserRateThrottle]
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def create(self, request: Request) -> Response:
+        if request.user.is_authenticated:
+            serializer = self.get_serializer(data=request.data)
+            serializer.is_valid(raise_exception=True)
+            serializer.save(created_by=request.user)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+        return Response(
+            {"error": "You are not allowed to create a resource."},
+            status=status.HTTP_403_FORBIDDEN,
+        )
+
+    def retrieve(self, request: Request, pk: str | None = None) -> Response:
+        if request.user.is_authenticated:
+            query = self.queryset.filter(
+                Q(private=False) | Q(private=True, created_by=request.user), id=pk
+            )
+        else:
+            query = self.queryset.filter(Q(private=False), id=pk)
+
+        serializer = self.get_serializer(query)
+        return Response(serializer.data)
+
+    def list(self, request: Request) -> Response:
+        if request.user.is_authenticated:
+            query = self.queryset.filter(
+                Q(private=False) | Q(private=True, created_by=request.user)
+            )
+        else:
+            query = self.queryset.filter(private=False)
+
+        serializer = self.get_serializer(query, many=True)
+        return self.get_paginated_response(self.paginate_queryset(serializer.data))
+
+    def update(self, request: Request, pk: str | None = None) -> Response:
+        item = self.get_object()
+        if not item.created_by == request.user:
+            return Response(
+                {"error": "You are not allowed to update this resource."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        serializer = self.get_serializer(item, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def partial_update(self, request: Request, pk: str | None = None) -> Response:
+        item = self.get_object()
+        if not item.created_by == request.user:
+            return Response(
+                {"error": "You are not allowed to update this resource."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        serializer = self.get_serializer(item, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def destroy(self, request: Request, pk: str | None = None) -> Response:
+        item = self.get_object()
+        if not item.created_by == request.user:
+            return Response(
+                {"error": "You are not allowed to delete this resource."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        self.perform_destroy(item)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class TaskViewSet(viewsets.ModelViewSet[Task]):
@@ -29,6 +104,7 @@ class TaskViewSet(viewsets.ModelViewSet[Task]):
 class TopicViewSet(viewsets.ModelViewSet[Topic]):
     queryset = Topic.objects.all()
     serializer_class = TopicSerializer
+
     pagination_class = CustomPagination
 
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

In this PR, I have started implementing the first API for the Resource table. I had to make some changes to the table in order to make the privat field useful. I added the created_by to implement the logic for GET requests. 

In case a user is the creator for a resource and the privat field is set to True, the creator should still be able to retrieve the resource. Permissions are set to `IsAuthenticatedOrReadOnly`. 

Additionally, I have deleted a few validation utility functions inside the serializer, because the model itself already provided sufficient validation.

`GET, POST, PUT, PATCH` methods are setup with the viewset methods. I used the  

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
Tests have been manually via swagger for all the methods and endpoints that are covered by the ResourceViewSet. I would suggest to create unit tests for API later on, when we think it is stable. 

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #624
