### PR TITLE
added directions on split dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -229,7 +229,7 @@ DATABASE_HOST=db
 DATABASE_HOST=localhost
 ```
 
-Now we can run the server in another terminal with:
+Now you can open up a new terminal to apply database migrations and start the local server:
 
 > [!NOTE]
 > Make sure to install the dependencies first. Best practice is to create a virtual enviroment first and then install the dependencies. Our dependencies are inside the `requirements.txt` file and can be install via `pip install -r requirements-dev.txt`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,13 +214,35 @@ You can then visit http://localhost:3000/ to see the development frontend build 
 
 **Backend: Python**
 
+Our backend depends on a connection to a postgres DB, therefore we need to setup the database first. Here our best opition is to still use docker to create a postgres DB with the following command:
+
+```bash
+docker compose up db
+```
+
+In order to connect to the DB, we need to change the `DATABASE_HOST` environment variable inside the `.env` file first.
+
+```bash
+# Current
+DATABASE_HOST=db
+# Changed
+DATABASE_HOST=localhost
+```
+
+Now we can run the server in another terminal with:
+
+> [!NOTE]
+> Make sure to install the dependencies first. Best practice is to create a virtual enviroment first and then install the dependencies. Our dependencies are inside the `requirements.txt` file and can be install via `pip install -r requirements-dev.txt`
+
 ```bash
 # In the root activist directory:
 cd backend
+pyhton manage.py makemigrations
+python manage.py migrate
 python manage.py runserver
 ```
 
-You can then visit http://localhost:3000/ to see the development frontend build once the server is up and running.
+You can then visit http://localhost:8000/ to see the development backend build once the server is up and running.
 
 <a id="style-guide"></a>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,31 @@ git remote add upstream https://github.com/activist-org/activist.git
 > [!NOTE]
 > Feel free to contact the team in the [Development room on Matrix](https://matrix.to/#/!CRgLpGeOBNwxYCtqmK:matrix.org?via=matrix.org&via=acter.global&via=chat.0x7cd.xyz) if you're having problems getting your environment setup!
 
+### Using Yarn or Python
+
+Dockerized environments are resource intensive and may take a very long time to load. Specifically for many Windows users, Docker requires a Linux environment running in the background that makes the entire process take way too long. If you would like to get just the frontend or backend up and running, please follow the steps below:
+
+**Frontend: Yarn**
+
+```bash
+# In the root activist directory:
+cd frontend
+yarn install
+yarn run dev
+```
+
+You can then visit http://localhost:3000/ to see the development frontend build once the server is up and running.
+
+**Backend: Python**
+
+```bash
+# In the root activist directory:
+cd backend
+python manage.py runserver
+```
+
+You can then visit http://localhost:3000/ to see the development frontend build once the server is up and running.
+
 <a id="style-guide"></a>
 
 ## Style guide [`⇧`](#contents)

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ git remote add upstream https://github.com/activist-org/activist.git
 5. You can then visit <http://localhost:3000> to see the development frontend build once the container is up and running.
 
 > [!NOTE]
-> Feel free to contact the team in the [Development room on Matrix](https://matrix.to/#/!CRgLpGeOBNwxYCtqmK:matrix.org?via=matrix.org&via=acter.global&via=chat.0x7cd.xyz) if you're having problems getting your environment setup!
+> Feel free to contact the team in the [Development room on Matrix](https://matrix.to/#/!CRgLpGeOBNwxYCtqmK:matrix.org?via=matrix.org&via=acter.global&via=chat.0x7cd.xyz) if you're having problems getting your environment setup! If you're having issues with Docker and just want to get the frontend or backend up and running, please see [the section on this in the contributing guide.](./CONTRIBUTING.md#using-yarn-or-python)
 
 <a id="tech-stack"></a>
 


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Add documentation on splitting front and back-end environments. ### Using Yarn or Python section added
to CONTRIBUTING.md at line 200. Link to this section added to README..md at line 192.

Made sure the link properly moves user to correct section.

### Related issue

- #617 
