### PR TITLE
Fix: Menu tooltip close fix

### DIFF
--- a/frontend/components/menu/MenuSearchResult.vue
+++ b/frontend/components/menu/MenuSearchResult.vue
@@ -1,7 +1,7 @@
 <template>
-  <div @mouseleave="showTooltip = false" class="p-2">
+  <div @mouseleave="showTooltip = false" class="p-2" ref="tooltip">
     <button
-      @click="showTooltip = !showTooltip"
+      @click="toggleTooltip"
       @keydown.shift.tab="onShiftTab"
       class="relative flex items-center justify-center w-8 h-8 rounded-full style-cta md:w-6 md:h-6 elem-shadow-sm"
     >
@@ -12,7 +12,6 @@
         @blur="showTooltip = false"
         @tab="onTab"
         @keydown.shift.tab.stop
-        ref="tooltip"
         class="absolute max-md:top-8 max-md:right-0 lg:bottom-6 lg:left-4"
       />
       <TooltipMenuSearchResultOrganization
@@ -21,7 +20,6 @@
         @blur="showTooltip = false"
         @tab="onTab"
         @keydown.shift.tab.stop
-        ref="tooltip"
         class="absolute max-md:top-8 max-md:right-0 lg:bottom-6 lg:left-4"
       />
       <TooltipMenuSearchResultResource
@@ -30,7 +28,6 @@
         @blur="showTooltip = false"
         @tab="onTab"
         @keydown.shift.tab.stop
-        ref="tooltip"
         class="absolute max-md:top-8 max-md:right-0 lg:bottom-6 lg:left-4"
       />
       <TooltipMenuSearchResultUser
@@ -39,7 +36,6 @@
         @blur="showTooltip = false"
         @tab="onTab"
         @keydown.shift.tab.stop
-        ref="tooltip"
         class="absolute max-md:top-8 max-md:right-0 lg:bottom-6 lg:left-4"
       />
     </button>
@@ -52,7 +48,11 @@ defineProps<{
 }>();
 
 const showTooltip = ref(false);
-const tooltip = ref();
+const tooltip = ref(); 
+
+const toggleTooltip = () => {
+  showTooltip.value = !showTooltip.value;
+};
 
 const closeTooltip = () => {
   showTooltip.value = false;

--- a/frontend/components/menu/MenuSearchResult.vue
+++ b/frontend/components/menu/MenuSearchResult.vue
@@ -48,7 +48,7 @@ defineProps<{
 }>();
 
 const showTooltip = ref(false);
-const tooltip = ref(); 
+const tooltip = ref();
 
 const toggleTooltip = () => {
   showTooltip.value = !showTooltip.value;

--- a/frontend/components/menu/MenuSearchResult.vue
+++ b/frontend/components/menu/MenuSearchResult.vue
@@ -1,5 +1,5 @@
 <template>
-  <div @mouseleave="showTooltip = false" class="p-2" ref="tooltip">
+  <div @mouseleave="showTooltip = false" ref="tooltip" class="p-2">
     <button
       @click="toggleTooltip"
       @keydown.shift.tab="onShiftTab"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This pull request fixed the MenuSearchResult tooltip functionality. Previously, it would not close on menu button click due to an `onClickOutside` event firing, therefore preventing `showTooltip` from being set to false in the menu button click. 

This was solved by reassigning  the `tooltip` reference to the `div` of the menu button and tooltip components. This will allow the `onClickOutside` function to correctly handle the visibility of these components appearing. 

I additionally added a `toggleToolTip` function for future readability/debugging purposes. Finally, I removed the `tooltip` references from the TooltipMenuSearchResult components themselves, as the `tooltip` reference is now handled by the parent div. 

I tested this by logging the value of the `showTooltip`, and it now correctly toggles between true/false on every click, instead of being constantly reset to true as it was before. This allows users to also click the menu buttons again to close the tooltip. 

Fixed showTooltip updating properly: 

![image](https://github.com/activist-org/activist/assets/66581240/d4f298ae-21f1-4729-b64e-2e1c628d34ae)

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #634
