### PR TITLE
feat: topics loop selection and tabbing A11y

### DIFF
--- a/frontend/components/card/CardTopicSelection.vue
+++ b/frontend/components/card/CardTopicSelection.vue
@@ -93,7 +93,7 @@ const emit = defineEmits(["update:modelValue"]);
 
 const keydownEvent = (index: number, e: KeyboardEvent) => {
   const topics: HTMLElement[] = Array.from(document.querySelectorAll(".topic"));
-  
+
   const upTop = topics[index].getBoundingClientRect().top - 38;
   const upLeft = topics[index].getBoundingClientRect().left - 38;
   const downTop = topics[index].getBoundingClientRect().top + 38;

--- a/frontend/components/card/CardTopicSelection.vue
+++ b/frontend/components/card/CardTopicSelection.vue
@@ -108,86 +108,19 @@ let index = 0;
 const keydownEvent = (e: KeyboardEvent) => {
   const topics: HTMLElement[] = Array.from(document.querySelectorAll(".topic"));
 
-  const upTop = topics[index].getBoundingClientRect().top - 38;
-  const upLeft = topics[index].getBoundingClientRect().left - 38;
-  const downTop = topics[index].getBoundingClientRect().top + 38;
-  const downLeft = topics[index].getBoundingClientRect().left - 38;
-  const upResult = topics.filter(
-    (topic) =>
-      topic.getBoundingClientRect().top == upTop &&
-      topic.getBoundingClientRect().left >= upLeft
-  );
-  const downResult = topics.filter(
-    (topic) =>
-      topic.getBoundingClientRect().top == downTop &&
-      topic.getBoundingClientRect().left >= downLeft
-  );
-
   switch (e.code) {
     case "ArrowUp":
-      e.preventDefault();
-      if (upResult.length != 0) {
-        index = topics.indexOf(upResult[0]);
-      } else {
-        const lastTopicInRow = topics.filter(
-          (topic) => topic.getBoundingClientRect().top == upTop
-        );
-
-        if (lastTopicInRow.length == 0) {
-          const sameTopicInRow = topics.filter(
-            (topic) =>
-              topic.getBoundingClientRect().top ==
-                topics[index].getBoundingClientRect().top &&
-              topic.getBoundingClientRect().left <
-                topics[index].getBoundingClientRect().left
-          );
-
-          if (sameTopicInRow.length != 0) {
-            index = topics.indexOf(sameTopicInRow[sameTopicInRow.length - 1]);
-          } else {
-            index = topics.length - 1;
-          }
-        } else {
-          index = topics.indexOf(lastTopicInRow[lastTopicInRow.length - 1]);
-        }
-      }
-      break;
-    case "ArrowDown":
-      e.preventDefault();
-      if (downResult.length != 0) {
-        index = topics.indexOf(downResult[0]);
-      } else {
-        const lastTopicInRow = topics.filter(
-          (topic) => topic.getBoundingClientRect().top == downTop
-        );
-
-        if (lastTopicInRow.length == 0) {
-          const sameTopicInRow = topics.filter(
-            (topic) =>
-              topic.getBoundingClientRect().top ==
-                topics[index].getBoundingClientRect().top &&
-              topic.getBoundingClientRect().left >
-                topics[index].getBoundingClientRect().left
-          );
-
-          if (sameTopicInRow.length != 0) {
-            index = topics.indexOf(sameTopicInRow[0]);
-          } else {
-            index = 0;
-          }
-        } else {
-          index = topics.indexOf(lastTopicInRow[lastTopicInRow.length - 1]);
-        }
-      }
-      break;
     case "ArrowLeft":
+      e.preventDefault()
       if (index > 0) {
         index--;
       } else {
         index = topics.length - 1;
       }
       break;
+    case "ArrowDown":
     case "ArrowRight":
+      e.preventDefault()
       if (index < topics.length - 1) {
         index++;
       } else {

--- a/frontend/components/card/CardTopicSelection.vue
+++ b/frontend/components/card/CardTopicSelection.vue
@@ -111,7 +111,7 @@ const keydownEvent = (e: KeyboardEvent) => {
   switch (e.code) {
     case "ArrowUp":
     case "ArrowLeft":
-      e.preventDefault()
+      e.preventDefault();
       if (index > 0) {
         index--;
       } else {
@@ -120,7 +120,7 @@ const keydownEvent = (e: KeyboardEvent) => {
       break;
     case "ArrowDown":
     case "ArrowRight":
-      e.preventDefault()
+      e.preventDefault();
       if (index < topics.length - 1) {
         index++;
       } else {

--- a/frontend/components/form/checkbox/FormCheckbox.vue
+++ b/frontend/components/form/checkbox/FormCheckbox.vue
@@ -3,7 +3,7 @@
     <input
       @keydown="tabToFirstTopic($event)"
       :id="uuid"
-      class="connect cursor-pointer mb-0 peer appearance-none w-[1.375rem] h-[1.375rem] border border-light-menu-selection rounded-sm bg-light-button dark:bg-dark-button dark:border-dark-menu-selection focus-brand"
+      class="cursor-pointer mb-0 peer appearance-none w-[1.375rem] h-[1.375rem] border border-light-menu-selection rounded-sm bg-light-button dark:bg-dark-button dark:border-dark-menu-selection focus-brand"
       type="checkbox"
       v-bind="{ ...$attrs, onChange: updateValue }"
       :checked="modelValue"
@@ -30,21 +30,6 @@ export interface Props {
   modelValue?: boolean;
   error?: string;
 }
-
-const tabToFirstTopic = (e: KeyboardEvent) => {
-  let firstTopic: HTMLElement | null;
-  if (window.matchMedia("(min-width: 640px)").matches) {
-    firstTopic = document.querySelector(".topic");
-  } else {
-    firstTopic = document.querySelector(".mobileTopic");
-  }
-
-  if (e.shiftKey && e.key == "Tab") {
-    e.preventDefault();
-    firstTopic?.focus();
-    return;
-  }
-};
 
 const props = withDefaults(defineProps<Props>(), {
   label: "",


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
This should allow the selection of topics to loop while navigating using arrow keys.

This PR also fixes the problem where tabbing will go to the next component instead of a fixed component.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #527 
