### PR TITLE
Add html lang attribute

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
   alias: {
     "@": resolve(__dirname, "./"),
   },
-  plugins: [],
+  plugins: ["~/plugins/i18n-head.ts"],
   modules: [
     "@nuxt/content",
     "nuxt-icon",

--- a/frontend/plugins/i18n-head.ts
+++ b/frontend/plugins/i18n-head.ts
@@ -1,0 +1,8 @@
+// Injects the lang attribute in all nuxt <Head></Head> components
+export default defineNuxtPlugin((nuxtApp) => {
+  const router = nuxtApp.vueApp.config.globalProperties.$router;
+  router.afterEach((to) => {
+    const languageCode = to.fullPath.split("/")[1] || "en";
+    document.documentElement.setAttribute("lang", languageCode);
+  });
+});


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
This addresses the missing lang attribute to the html element for all pages.
The attribute is injected via a plugin created under `/plugins/i18n-head.ts`
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #703
