### PR TITLE
fix: closes menu on click outside

### DIFF
--- a/frontend/components/sidebar/right/SidebarRight.vue
+++ b/frontend/components/sidebar/right/SidebarRight.vue
@@ -29,20 +29,13 @@
 <script setup lang="ts">
 import { onClickOutside } from "@vueuse/core";
 
-const target = ref();
+const target = ref<HTMLElement | null>(null);
 const menuOpen = ref(false);
-const ignoreElRef = ref();
+const ignoreElRef = ref<HTMLElement | null>(null);
 
 const toggleMenuState = () => {
   menuOpen.value = !menuOpen.value;
 };
 
-onClickOutside(
-  target.value,
-  () => {
-    if (!menuOpen.value) return;
-    toggleMenuState();
-  },
-  { ignore: [ignoreElRef.value] }
-);
+onClickOutside(target, toggleMenuState, { ignore: [ignoreElRef] });
 </script>

--- a/frontend/components/sidebar/right/SidebarRight.vue
+++ b/frontend/components/sidebar/right/SidebarRight.vue
@@ -21,6 +21,26 @@
         hidden: !menuOpen,
       }"
     >
+      <button
+        @click="toggleMenuState"
+        class="absolute left-3 top-3 w-6 h-6"
+        :aria-label="$t('components.btn-action.close-navigation-aria-label')"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="stroke-dark-distinct dark:stroke-light-distinct"
+          fill="currentColor"
+          stroke="currentColor"
+          stroke-width="1.5"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M6 18 18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
       <slot></slot>
     </div>
   </div>

--- a/frontend/i18n/en-US.json
+++ b/frontend/i18n/en-US.json
@@ -86,6 +86,7 @@
   "components.btn-action-dropdown.qr-code-options-aria-label": "View format options for downloading a QR code",
   "components.btn-action.attend": "Attend",
   "components.btn-action.attend-aria-label": "Attend this event",
+  "components.btn-action.close-navigation-aria-label": "Close navigation",
   "components.btn-action.downvote-application-aria-label": "Vote to not support the organization joining activist",
   "components.btn-action.filter-discussion-category-aria-label": "Filter for the type of discussion",
   "components.btn-action.invite-someone": "Invite someone",


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
SidebarRight is not closing when an option is selected. This can be seed from the mobile view on any page where the burger menu is used to open the sidebar, and then once a new localization, color mode or another option is selected the sidebar is still open. 

❗ Should check UX flow if the desired behaviour above is correct. For now the fix only addresses click/press outside the menu
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #711
