### PR TITLE
chore: add animation to sidebar icon on toggle

### DIFF
--- a/frontend/components/sidebar/left/SidebarLeftHeader.vue
+++ b/frontend/components/sidebar/left/SidebarLeftHeader.vue
@@ -37,23 +37,14 @@
           "
           class="flex items-center justify-center transition duration-100 w-7 h-7 focus-brand outline-offset-0"
           :class="{
-            'pr-[2px]': sidebar.collapsedSwitch == false,
-            'pl-[2px]': sidebar.collapsedSwitch == true,
+            'pr-0.5 -rotate-180': sidebar.collapsedSwitch == false,
+            'pl-0.5': sidebar.collapsedSwitch == true,
           }"
           :aria-label="
             $t('components.sidebar-left-header.sidebar-collapse-aria-label')
           "
         >
-          <SidebarToggle
-            v-if="sidebar.collapsedSwitch == false"
-            chevronDirection="left"
-            iconSize="1.4em"
-          />
-          <SidebarToggle
-            v-if="sidebar.collapsedSwitch == true"
-            chevronDirection="right"
-            iconSize="1.4em"
-          />
+          <SidebarToggle chevronDirection="right" iconSize="1.4em" />
         </button>
       </div>
     </div>

--- a/frontend/components/sidebar/right/SidebarRightToggle.vue
+++ b/frontend/components/sidebar/right/SidebarRightToggle.vue
@@ -7,17 +7,15 @@
         $t('components.sidebar-right-toggle.sidebar-collapse-aria-label')
       "
     >
-      <div class="w-6 h-6">
-        <SidebarToggle
-          v-if="!menuOpen"
-          chevronDirection="left"
-          iconSize="1.4em"
-        />
-        <SidebarToggle
-          v-if="menuOpen"
-          chevronDirection="right"
-          iconSize="1.4em"
-        />
+      <div
+        :class="[
+          'w-6 h-6 transition-transform transform duration-100 motion-reduce:transition-none',
+          {
+            'rotate-180': menuOpen,
+          },
+        ]"
+      >
+        <SidebarToggle chevronDirection="left" iconSize="1.4em" />
       </div>
     </button>
   </div>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
Currently we are replacing the icon based on the open/close state for both left and right sidebars. Instead, this approach will avoid the icon re-render while at the same time, add a little animation. The left sidebar icon will be rotated -180deg while the right icon will be rotated 180deg to keep the animations consistent.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #729
