### PR TITLE
fix: close sidebar on route change

### DIFF
--- a/frontend/components/sidebar/right/SidebarRight.vue
+++ b/frontend/components/sidebar/right/SidebarRight.vue
@@ -28,6 +28,7 @@
 
 <script setup lang="ts">
 import { onClickOutside } from "@vueuse/core";
+import { watch } from "vue";
 
 const target = ref<HTMLElement | null>(null);
 const menuOpen = ref(false);
@@ -40,6 +41,9 @@ const toggleMenuState = () => {
 const closeMenuState = () => {
   menuOpen.value = false;
 };
+
+const route = useRoute();
+watch(() => route.path, closeMenuState);
 
 onClickOutside(target, closeMenuState, { ignore: [ignoreElRef] });
 </script>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
This addresses the discussion/decision to close the sidebar when the language option is selected (route change). This approach I decided on, would entail the least amount of changes, simply watching for route changes and then triggering the close function. 

#### ⚠️This should ideally be tested in terms of UX to ensure that it is the right approach.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #711
