### PR TITLE
fix: make footer copyright year dynamic

### DIFF
--- a/frontend/components/footer/flex/FooterFlex.vue
+++ b/frontend/components/footer/flex/FooterFlex.vue
@@ -51,7 +51,9 @@
         {{ $t("components.footer._global.powered-by-netlify") }}
       </a>
       <div class="mt-2 text-light-text dark:text-dark-text">
-        {{ $t("components._global.copyright") }}
+        {{
+          $t("components._global.copyright", { year: new Date().getFullYear() })
+        }}
       </div>
     </div>
     <!-- Note: Content Sections Right -->

--- a/frontend/components/footer/flex/FooterFlexCol.vue
+++ b/frontend/components/footer/flex/FooterFlexCol.vue
@@ -134,7 +134,9 @@
         {{ $t("components.footer._global.powered-by-netlify") }}
       </a>
       <div class="mt-2 text-light-text dark:text-dark-text">
-        {{ $t("components._global.copyright") }}
+        {{
+          $t("components._global.copyright", { year: new Date().getFullYear() })
+        }}
       </div>
     </div>
   </div>

--- a/frontend/i18n/en-US.json
+++ b/frontend/i18n/en-US.json
@@ -68,7 +68,7 @@
   "_global.topics.women": "Women's Rights",
   "_global.trademark-policy": "Trademark policy",
   "components._global.connect": "Connect",
-  "components._global.copyright": "Copyright \u00a9 2023 activist.",
+  "components._global.copyright": "Copyright \u00a9 {year} activist.",
   "components._global.donate": "Donate",
   "components._global.enter-password": "Enter your password",
   "components._global.github": "GitHub",


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
Change the footer year based on current year.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #726
