### PR TITLE
style: replace focus with focus-visible

### DIFF
--- a/frontend/assets/css/tailwind.css
+++ b/frontend/assets/css/tailwind.css
@@ -48,7 +48,7 @@
   }
 
   .focus-brand {
-    @apply rounded-sm focus:ring-2 focus:ring-light-link-text dark:focus:ring-dark-link-text focus:outline-none focus:border-light-link-text dark:focus:border-dark-link-text;
+    @apply rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-light-link-text dark:focus-visible:ring-dark-link-text focus-visible:border-light-link-text dark:focus-visible:border-dark-link-text;
   }
 
   .focus-inside {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
This is both a slight UX imprvement and a fix for the issue mentioned below. Focus styles are generally not required when the user knows where they are focusing on, meaning if they use a touch screen or a mouse, it's not necessary to show the focus ring on the element you just pressed/clicked (a few exceptions, such as inputs), it is however absolutely necessary when using a keyboard. `focus-visible` is a viable replacement. Now we have a slightly cleaner design for users that use the mouse, and we still show a focus for things like inputs and textareas. A more detailed explanation can be found on [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible)
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #644
