### PR TITLE
Issue 676

### DIFF
--- a/frontend/pages/events/[id]/about.vue
+++ b/frontend/pages/events/[id]/about.vue
@@ -44,6 +44,7 @@
       >
         <CardAbout
           @expand-reduce-text="expandReduceText"
+          class="mb-6 lg:mb-0"
           :class="{
             'lg:col-span-2': !textExpanded,
             'lg:col-span-3': textExpanded,

--- a/frontend/pages/events/[id]/about.vue
+++ b/frontend/pages/events/[id]/about.vue
@@ -37,7 +37,7 @@
     </HeaderAppPage>
     <div class="pb-6 space-y-6">
       <div
-        class="lg:grid space-y-6 lg:grid-cols-3 lg:grid-rows-1 lg:space-y-0"
+        class="lg:grid lg:grid-cols-3 lg:grid-rows-1 lg:space-y-0"
         :class="{
           'lg:space-x-6 lg:mr-6': !textExpanded,
         }"

--- a/frontend/pages/events/[id]/about.vue
+++ b/frontend/pages/events/[id]/about.vue
@@ -37,7 +37,7 @@
     </HeaderAppPage>
     <div class="pb-6 space-y-6">
       <div
-        class="lg:grid lg:grid-cols-3 lg:grid-rows-1 lg:space-y-0"
+        class="lg:grid lg:grid-cols-3 lg:grid-rows-1"
         :class="{
           'lg:space-x-6 lg:mr-6': !textExpanded,
         }"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

the space-y-6 styling adds a 24px margin to the top of the &lt;MediaMap /&gt; element which is supposed to be there when the map is not in fullscreen, however when the map is in fullscreen the top margin is still there. 

I removed space-y-6 and added a bottom margin to the &lt;CardAbout /&gt; element instead. 

On large screens the bottom margin is not needed as the &lt;CardAbout /&gt; and &lt;MediaMap /&gt; elements are side by side.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #676
