### PR TITLE
#767/Added event disabling interaction on map marker.

### DIFF
--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -145,6 +145,14 @@ onMounted(() => {
 
           directions.interactive = true;
 
+          marker.getElement().addEventListener("mouseenter", () => {
+            directions.interactive = false;
+          });
+
+          marker.getElement().addEventListener("mouseleave", () => {
+            directions.interactive = true;
+          });
+
           document.addEventListener("keydown", (event) => {
             if (event.key === "x") {
               directions.clear();


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Added two event listeners to the MediaMap.vue file, one that disables directions interactivity when entering the marker, and one enabling it when leaving the marker.

### Related issue

- #767
