### PR TITLE
Split API documentation

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -21,14 +21,55 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("v1/auth/", include("authentication.urls", namespace="authentication")),
+    path("v1/content/", include("content.urls", namespace="content")),
+    path("v1/entities/", include("entities.urls", namespace="entities")),
+    path("v1/events/", include("events.urls", namespace="events")),
+    # API DOCUMENTATION
     path("v1/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "v1/schema/auth/",
+        SpectacularAPIView.as_view(urlconf="authentication.urls"),
+        name="schema-auth",
+    ),
+    path(
+        "v1/schema/content/",
+        SpectacularAPIView.as_view(urlconf="content.urls"),
+        name="schema-content",
+    ),
+    path(
+        "v1/schema/entities/",
+        SpectacularAPIView.as_view(urlconf="entities.urls"),
+        name="schema-entities",
+    ),
+    path(
+        "v1/schema/events/",
+        SpectacularAPIView.as_view(urlconf="events.urls"),
+        name="schema-events",
+    ),
     path(
         "v1/schema/swagger-ui/",
         SpectacularSwaggerView.as_view(url_name="schema"),
         name="swagger-ui",
     ),
-    path("v1/auth/", include("authentication.urls", namespace="authentication")),
-    path("v1/content/", include("content.urls", namespace="content")),
-    path("v1/entities/", include("entities.urls", namespace="entities")),
-    path("v1/events/", include("events.urls", namespace="events")),
+    path(
+        "v1/schema/swagger-ui/auth/",
+        SpectacularSwaggerView.as_view(url_name="schema-auth"),
+        name="swagger-ui-auth",
+    ),
+    path(
+        "v1/schema/swagger-ui/content/",
+        SpectacularSwaggerView.as_view(url_name="schema-content"),
+        name="swagger-ui-content",
+    ),
+    path(
+        "v1/schema/swagger-ui/entities/",
+        SpectacularSwaggerView.as_view(url_name="schema-entities"),
+        name="swagger-ui-entities",
+    ),
+    path(
+        "v1/schema/swagger-ui/events/",
+        SpectacularSwaggerView.as_view(url_name="schema-events"),
+        name="swagger-ui-events",
+    ),
 ]

--- a/backend/entities/serializers.py
+++ b/backend/entities/serializers.py
@@ -42,7 +42,6 @@ class OrganizationSerializer(serializers.ModelSerializer[Organization]):
             "status_updated": {"read_only": True},
             "acceptance_date": {"read_only": True},
         }
-        fields = "__all__"
 
 
 class OrganizationApplicationStatusSerializer(


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

I split the API documentation (Swagger UI) by the django apps:

- auth
- content
- entities
- events

There is still an overview of all endpoints. 

I thought about splitting it up while manual testing a API endpoint via Swagger UI, it seemed to cluttered to me 😄.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

No related issue