### PR TITLE
fix(backend): Add 'CSRF_TRUSTED_ORIGINS' django setting

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -4,6 +4,7 @@ VITE_API_URL="http://localhost:8000/v1"
 ADMIN_PATH="admin/"
 BACKEND_PORT="8000"
 DJANGO_ALLOWED_HOSTS="localhost *"
+DJANGO_CSRF_TRUSTED_ORIGINS="http://localhost"
 
 # DB port should always be set to 5432.
 DATABASE_PORT="5432"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,12 @@
 FROM python:3.11-alpine3.16
 
-# Set work dir for relative paths
+# Set work dir for relative paths.
 WORKDIR /app
 
-# Install dependencies
+# Install dependencies.
 COPY ./requirements-dev.txt .
 RUN pip install --upgrade pip
 RUN pip install -r requirements-dev.txt
 
-# Copy code from context to image
+# Copy code from context to image.
 COPY . .

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -41,6 +41,10 @@ DEBUG = int(os.environ.get("DEBUG", default=0))
 
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(" ")
 
+CSRF_TRUSTED_ORIGINS = os.environ.get(
+    "DJANGO_CSRF_TRUSTED_ORIGINS", "http://localhost"
+).split(" ")
+
 # Application definition
 
 INSTALLED_APPS = [

--- a/backend/deploy.Dockerfile
+++ b/backend/deploy.Dockerfile
@@ -1,12 +1,15 @@
 FROM python:3.11-alpine3.16
 
-# Set work dir for relative paths
+# Set work dir for relative paths.
 WORKDIR /app
 
-# Install dependencies
+# Install dependencies.
 COPY ./requirements.txt .
 RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
-# Copy code from context to image
+# Copy code from context to image.
 COPY . .
+
+# Collect the Django static files.
+RUN python manage.py collectstatic --no-input


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

- Add `CSRF_TRUSTED_ORIGINS` django setting
   - Needed in addition to `ALLOWED_HOSTS` so `POST` requests are not blocked ([ref](https://www.reddit.com/r/django/comments/s6daj0/csrf_verification_failed_django_nginx_docker/))
- Add command `python manage.py collectstatic --no-input` already to the `deploy.Dockerfile` so Docker image already has static files prepped 

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- :rocket: 
