### PR TITLE
added login function and changed serializer to use username instead o…

### DIFF
--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -136,11 +136,11 @@ class SignupSerializer(serializers.ModelSerializer[User]):
 
 
 class LoginSerializer(serializers.Serializer[UserModel]):
-    email = serializers.EmailField()
+    username = serializers.CharField()
     password = serializers.CharField(write_only=True)
 
     def validate(self, data: Dict[str, Union[str, Any]]) -> Dict[str, Union[str, Any]]:
-        username = UserModel.objects.filter(email=data.get("email")).first()
+        username = UserModel.objects.filter(username=data.get("username")).first()
 
         if username is None:
             raise serializers.ValidationError(

--- a/frontend/pages/auth/sign-in.vue
+++ b/frontend/pages/auth/sign-in.vue
@@ -1,42 +1,26 @@
 <template>
   <div class="px-4 sm:px-6 md:px-8 xl:px-24 2xl:px-36">
-    <form class="space-y-4">
+    <form @submit.prevent="signIn" class="space-y-4">
       <div class="col">
-        <FormTextField
-          @update:model-value="userNameValue = $event"
-          :placeholder="$t('pages.auth.sign-in.index.enter-user-name')"
-          :model-value="userNameValue"
-        />
+        <FormTextField @update:model-value="userNameValue = $event"
+          :placeholder="$t('pages.auth.sign-in.index.enter-user-name')" :model-value="userNameValue" />
       </div>
       <div>
-        <FormTextField
-          @update:model-value="passwordValue = $event"
-          :placeholder="$t('components._global.enter-password')"
-          :is-icon-visible="true"
-          input-type="password"
-          :model-value="passwordValue"
-          :icons="['bi:eye-fill']"
-        />
+        <FormTextField @update:model-value="passwordValue = $event"
+          :placeholder="$t('components._global.enter-password')" :is-icon-visible="true" input-type="password"
+          :model-value="passwordValue" :icons="['bi:eye-fill']" />
       </div>
       <IndicatorPasswordStrength :password-value="passwordValue" />
       <div class="flex flex-col space-y-3">
         <FriendlyCaptcha />
-        <BtnAction
-          @click="signIn"
-          class="flex max-h-[48px] w-[116px] items-center justify-center truncate md:max-h-[40px] md:w-[96px]"
-          :label="$t('_global.sign-in')"
-          :cta="true"
-          fontSize="lg"
-          :ariaLabel="$t('components.btn-route-internal.sign-in-aria-label')"
-        />
+        <BtnAction class="flex max-h-[48px] w-[116px] items-center justify-center truncate md:max-h-[40px] md:w-[96px]"
+          :label="$t('_global.sign-in')" :cta="true" fontSize="lg"
+          :ariaLabel="$t('components.btn-route-internal.sign-in-aria-label')" />
       </div>
       <div class="flex pt-4 md:justify-center md:pt-6 lg:pt-8">
         <h6>{{ $t("pages.auth.sign-in.index.no-account") }}</h6>
-        <NuxtLink
-          :to="localePath('/auth/sign-up')"
-          class="link-text ml-2 font-extrabold"
-          >{{ $t("_global.sign-up") }}</NuxtLink
-        >
+        <NuxtLink :to="localePath('/auth/sign-up')" class="link-text ml-2 font-extrabold">{{ $t("_global.sign-up") }}
+        </NuxtLink>
       </div>
     </form>
   </div>
@@ -52,7 +36,25 @@ definePageMeta({
 const userNameValue = ref("");
 const passwordValue = ref("");
 
-const signIn = () => {
+const signIn = async () => {
   //
+  const { data: responseData } = await $fetch(`http://localhost:8000/v1/auth/login/`, {
+    method: "POST",
+    body: JSON.stringify({
+      username: userNameValue.value,
+      password: passwordValue.value,
+    }),
+    onResponse({ request, response, options }) {
+      // Handle the response
+      console.log(
+        "Response:",
+        response.status,
+        response.statusText,
+        response._data
+      );
+    },
+  })
+  console.log();
 };
+
 </script>

--- a/frontend/pages/auth/sign-in.vue
+++ b/frontend/pages/auth/sign-in.vue
@@ -2,24 +2,39 @@
   <div class="px-4 sm:px-6 md:px-8 xl:px-24 2xl:px-36">
     <form @submit.prevent="signIn" class="space-y-4">
       <div class="col">
-        <FormTextField @update:model-value="userNameValue = $event"
-          :placeholder="$t('pages.auth.sign-in.index.enter-user-name')" :model-value="userNameValue" />
+        <FormTextField
+          @update:model-value="userNameValue = $event"
+          :placeholder="$t('pages.auth.sign-in.index.enter-user-name')"
+          :model-value="userNameValue"
+        />
       </div>
       <div>
-        <FormTextField @update:model-value="passwordValue = $event"
-          :placeholder="$t('components._global.enter-password')" :is-icon-visible="true" input-type="password"
-          :model-value="passwordValue" :icons="['bi:eye-fill']" />
+        <FormTextField
+          @update:model-value="passwordValue = $event"
+          :placeholder="$t('components._global.enter-password')"
+          :is-icon-visible="true"
+          input-type="password"
+          :model-value="passwordValue"
+          :icons="['bi:eye-fill']"
+        />
       </div>
       <IndicatorPasswordStrength :password-value="passwordValue" />
       <div class="flex flex-col space-y-3">
         <FriendlyCaptcha />
-        <BtnAction class="flex max-h-[48px] w-[116px] items-center justify-center truncate md:max-h-[40px] md:w-[96px]"
-          :label="$t('_global.sign-in')" :cta="true" fontSize="lg"
-          :ariaLabel="$t('components.btn-route-internal.sign-in-aria-label')" />
+        <BtnAction
+          class="flex max-h-[48px] w-[116px] items-center justify-center truncate md:max-h-[40px] md:w-[96px]"
+          :label="$t('_global.sign-in')"
+          :cta="true"
+          fontSize="lg"
+          :ariaLabel="$t('components.btn-route-internal.sign-in-aria-label')"
+        />
       </div>
       <div class="flex pt-4 md:justify-center md:pt-6 lg:pt-8">
         <h6>{{ $t("pages.auth.sign-in.index.no-account") }}</h6>
-        <NuxtLink :to="localePath('/auth/sign-up')" class="link-text ml-2 font-extrabold">{{ $t("_global.sign-up") }}
+        <NuxtLink
+          :to="localePath('/auth/sign-up')"
+          class="link-text ml-2 font-extrabold"
+          >{{ $t("_global.sign-up") }}
         </NuxtLink>
       </div>
     </form>
@@ -38,23 +53,25 @@ const passwordValue = ref("");
 
 const signIn = async () => {
   //
-  const { data: responseData } = await $fetch(`http://localhost:8000/v1/auth/login/`, {
-    method: "POST",
-    body: JSON.stringify({
-      username: userNameValue.value,
-      password: passwordValue.value,
-    }),
-    onResponse({ request, response, options }) {
-      // Handle the response
-      console.log(
-        "Response:",
-        response.status,
-        response.statusText,
-        response._data
-      );
-    },
-  })
+  const { data: responseData } = await $fetch(
+    `http://localhost:8000/v1/auth/login/`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        username: userNameValue.value,
+        password: passwordValue.value,
+      }),
+      onResponse({ request, response, options }) {
+        // Handle the response
+        console.log(
+          "Response:",
+          response.status,
+          response.statusText,
+          response._data
+        );
+      },
+    }
+  );
   console.log();
 };
-
 </script>

--- a/frontend/pages/auth/sign-in.vue
+++ b/frontend/pages/auth/sign-in.vue
@@ -51,9 +51,12 @@ definePageMeta({
 const userNameValue = ref("");
 const passwordValue = ref("");
 
+interface LoginResponse {
+  data: {};
+}
+
 const signIn = async () => {
-  //
-  const { data: responseData } = await $fetch(
+  const { data: responseData } = await $fetch<LoginResponse>(
     `http://localhost:8000/v1/auth/login/`,
     {
       method: "POST",
@@ -62,7 +65,7 @@ const signIn = async () => {
         password: passwordValue.value,
       }),
       onResponse({ request, response, options }) {
-        // Handle the response
+        // Handle the response.
         console.log(
           "Response:",
           response.status,


### PR DESCRIPTION
…f email

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
In this PR, I have started working on the login. I have changed the serializer to use the `username` instead of the `email`. There are still some missing pieces:

* User input validation
* Error handling
* routing

<ins>Notes:</ins>
* I was thinking about the password indicator on login. Since the user already has an account and a password, it seems unnecessary to me.

* How are we showing login errors to the user? 

* I used the `$fetch` instead of `useFetch` because nuxt, displayed a suggestion in the console:

```
[nuxt] [useFetch] Component is already mounted, please use $fetch instead. See https://nuxt.com/docs/getting-started/data-fetching
```
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
I have tested a successful login and a bad request.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- No related issue
