### PR TITLE
feat/protect frontend routes

### DIFF
--- a/frontend/middleware/adminOnly.ts
+++ b/frontend/middleware/adminOnly.ts
@@ -1,7 +1,15 @@
 export default defineNuxtRouteMiddleware(async () => {
-  const { roles } = useUser();
+  const { userIsAdmin, userIsSignedIn } = useUser();
+  const localePath = useLocalePath();
 
-  if (!roles.includes("admin")) {
+  // if (!roles.includes("admin")) {
+  //   return alert("Hey! No!");
+  // }
+
+  if (!userIsAdmin) {
+    if (userIsSignedIn) {
+      return navigateTo(localePath("/home"));
+    }
     return alert("Hey! No!");
   }
 });

--- a/frontend/middleware/adminOnly.ts
+++ b/frontend/middleware/adminOnly.ts
@@ -2,14 +2,7 @@ export default defineNuxtRouteMiddleware(async () => {
   const { userIsAdmin, userIsSignedIn } = useUser();
   const localePath = useLocalePath();
 
-  // if (!roles.includes("admin")) {
-  //   return alert("Hey! No!");
-  // }
-
-  if (!userIsAdmin) {
-    if (userIsSignedIn) {
-      return navigateTo(localePath("/home"));
-    }
-    return alert("Hey! No!");
+  if (!userIsAdmin && userIsSignedIn) {
+    return navigateTo(localePath("/home"));
   }
 });

--- a/frontend/pages/events/create.vue
+++ b/frontend/pages/events/create.vue
@@ -19,3 +19,8 @@
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+  middleware: ["user-only"],
+});

--- a/frontend/pages/events/create.vue
+++ b/frontend/pages/events/create.vue
@@ -24,3 +24,4 @@
 definePageMeta({
   middleware: ["user-only"],
 });
+</script>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

I just implemented the middleware in the events create route as I think most of the others are done. I also added a check in the admin guard as there's already a userIsAdmin variable in the store.

A few questions,
1. Is it better if we make the guard a global middleware instead of the current implementation where we put the metadata into each file that we want to protect? If we change it into a global middleware I think we can just put in the route name in the middleware file instead.
2. I don't understand the part where the signed-in user accesses the URL directly. Does this mean that the user is authenticated but is not an admin, so he will be redirected to the /home page or anyone who accesses the auth pages directly through the URL?

I might have missed it if it was discussed in the dev sync, sorry in advance and thanks!

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #876
- https://github.com/activist-org/activist/commit/3cf5fb2c25159194f0ba354489bd690f6ee5b4a1
