### PR TITLE
Remove unneeded organization_group table

### DIFF
--- a/frontend/components/feed/Feed.vue
+++ b/frontend/components/feed/Feed.vue
@@ -14,47 +14,26 @@
 
 <script setup lang="ts">
 import { BreakpointMap } from "~/types/breakpoint-map";
-import type { Group } from "~/types/entities/group";
-import type {
-  Organization,
-  OrganizationGroup,
-} from "~/types/entities/organization";
 
-const props = defineProps<{
-  organization: Organization;
-}>();
+const idParam = useRoute().params.id;
+const id = typeof idParam === "string" ? idParam : undefined;
 
-const resOrgGroups = await useAsyncData(
-  async () =>
-    await fetchWithToken(
-      `/entities/organization_group?org_id=${props.organization.id}`,
-      {}
-    )
-);
+const organizationStore = useOrganizationStore();
+await organizationStore.fetchByID(id);
 
-const orgGroups = resOrgGroups.data as unknown as OrganizationGroup[];
-
-const resGroups = await useAsyncData(
-  async () =>
-    await fetchWithToken(
-      `/entities/groups?group_id=${orgGroups.map((g) => g.groupID).join(",")}`,
-      {}
-    )
-);
-
-const groups = resGroups.data as unknown as Group[];
+const { organization } = organizationStore;
 
 const feedItemNames = computed<string[]>(() => {
-  if (props.organization && orgGroups) {
-    return groups.map((group) => group.name);
+  if (organization && organization.groups) {
+    return organization.groups.map((group) => group.name);
   } else {
     return [""];
   }
 });
 
 const feedItemURLs = computed<string[]>(() => {
-  if (props.organization && orgGroups) {
-    return groups.map(
+  if (organization && organization.groups) {
+    return organization.groups.map(
       (group) => `/organizations/${group.organization.id}/groups/${group.id}`
     );
   } else {

--- a/frontend/stores/group.ts
+++ b/frontend/stores/group.ts
@@ -87,5 +87,6 @@ export const useGroupStore = defineStore("group", {
 
       this.loading = false;
     },
+    async fetchAll() {},
   },
 });

--- a/frontend/stores/organization.ts
+++ b/frontend/stores/organization.ts
@@ -31,8 +31,6 @@ export const useOrganizationStore = defineStore("organization", {
       getInvolvedURL: "",
       socialLinks: [""],
       status: 1,
-
-      // organization_group
       groups: [],
 
       organization_text_id: "",

--- a/frontend/types/entities/organization.d.ts
+++ b/frontend/types/entities/organization.d.ts
@@ -28,7 +28,6 @@ export interface Organization {
   // faq
   faqEntries?: FaqEntry[];
 
-  // organization_group
   groups?: Group[];
 
   // organization_resource
@@ -55,11 +54,6 @@ export interface Organization {
 export interface OrganizationEvent {
   orgID: string;
   eventID: string;
-}
-
-export interface OrganizationGroup {
-  orgID: string;
-  groupID: string;
 }
 
 export interface OrganizationImage {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Minor changes to remove the `organization_group` table as we do not need it. All groups have one and only one organization, so we can just have this information in the `group` table.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- No issue
