### PR TITLE
added the mobile-header id back to fix breaking tests; update workflow

### DIFF
--- a/.github/workflows/pr_ci_playwright_e2e.yaml
+++ b/.github/workflows/pr_ci_playwright_e2e.yaml
@@ -58,11 +58,11 @@ jobs:
           MAX_ATTEMPTS=3
           WAIT_TIME=30
           ATTEMPT=1
-          while [[ $ATTEMPT -le $MAX_ATTEMPTS ]]
-          do
+          while [[ $ATTEMPT -le $MAX_ATTEMPTS ]]; do
             echo "Attempt $ATTEMPT of $MAX_ATTEMPTS"
             yarn wait-on http://localhost:3000 --timeout ${WAIT_TIME}000
-            if [[ $? -eq 0 ]]; then
+            STATUS=$?
+            if [[ $STATUS -eq 0 ]]; then
               echo "Server is ready!"
               break
             else

--- a/frontend/components/header/HeaderWebsite.vue
+++ b/frontend/components/header/HeaderWebsite.vue
@@ -10,7 +10,7 @@
     }"
   >
     <!-- MARK: Mobile Header -->
-    <div v-if="!aboveMediumBP" id="#mobile-header" class="flex px-4 py-3">
+    <div v-if="!aboveMediumBP" id="mobile-header" class="flex px-4 py-3">
       <div class="z-0 mx-auto">
         <div
           class="absolute left-0 top-0 z-0 flex h-full w-full items-center justify-center"

--- a/frontend/components/header/HeaderWebsite.vue
+++ b/frontend/components/header/HeaderWebsite.vue
@@ -10,7 +10,7 @@
     }"
   >
     <!-- MARK: Mobile Header -->
-    <div v-if="!aboveMediumBP" class="flex px-4 py-3">
+    <div v-if="!aboveMediumBP" id="#mobile-header" class="flex px-4 py-3">
       <div class="z-0 mx-auto">
         <div
           class="absolute left-0 top-0 z-0 flex h-full w-full items-center justify-center"

--- a/frontend/tests/specs/landing-page.spec.ts
+++ b/frontend/tests/specs/landing-page.spec.ts
@@ -36,7 +36,9 @@ test.describe("Landing Page", () => {
   /* *********************************************************** */
 
   // Test that the correct Header is visible on mobile or desktop.
-  test("The correct header element should be visible on mobile and desktop", async ({ landingPage }) => {
+  test("The correct header element should be visible on mobile and desktop", async ({
+    landingPage,
+  }) => {
     const header = (await landingPage.isMobile())
       ? landingPage.header.mobileHeader
       : landingPage.header.desktopHeader;

--- a/frontend/tests/specs/landing-page.spec.ts
+++ b/frontend/tests/specs/landing-page.spec.ts
@@ -11,18 +11,39 @@ test.describe("Landing Page", () => {
   });
 
   /* *********************************************************** */
+  /* ACCESSIBILITY TESTS */
+  /* *********************************************************** */
+
+  // Test accessibility of the landing page (skip this test for now).
+  // Note: Check to make sure that this is eventually done for light and dark modes.
+  test.skip("There are no detectable accessibility issues", async ({
+    landingPage,
+  }, testInfo) => {
+    const results = await new AxeBuilder({ page: landingPage.getPage })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+      .analyze();
+
+    await testInfo.attach("accessibility-scan-results", {
+      body: JSON.stringify(results, null, 2),
+      contentType: "application/json",
+    });
+
+    expect(results.violations).toEqual([]);
+  });
+
+  /* *********************************************************** */
   /* HEADER TESTS */
   /* *********************************************************** */
 
-  // Test that the Header is visible on both mobile and desktop.
-  test("Header visibility on mobile and desktop", async ({ landingPage }) => {
+  // Test that the correct Header is visible on mobile or desktop.
+  test("The correct header element should be visible on mobile and desktop", async ({ landingPage }) => {
     const header = (await landingPage.isMobile())
       ? landingPage.header.mobileHeader
       : landingPage.header.desktopHeader;
     await expect(header).toBeVisible();
   });
 
-  // Test that the Roadmap button is visible and clickable only on Desktop.
+  // Test that the Roadmap button is visible and clickable only on Desktop Header.
   test("Roadmap button should be visible and clickable only on Desktop", async ({
     landingPage,
   }) => {
@@ -36,7 +57,7 @@ test.describe("Landing Page", () => {
     }
   });
 
-  // Test that the Get In Touch button is visible and clickable on Desktop.
+  // Test that the Get In Touch button is visible and clickable only on Desktop Header.
   test("Get In Touch button is functional", async ({ landingPage }) => {
     if (!(await landingPage.isMobile())) {
       await expect(landingPage.header.getInTouchButton).toBeVisible();
@@ -78,35 +99,16 @@ test.describe("Landing Page", () => {
   });
 
   /* *********************************************************** */
-  /* ACCESSIBILITY TESTS */
-  /* *********************************************************** */
-
-  // Test accessibility of the landing page (skip this test for now).
-  // Note: Check to make sure that this is eventually done for light and dark modes.
-  test.skip("There are no detectable accessibility issues", async ({
-    landingPage,
-  }, testInfo) => {
-    const results = await new AxeBuilder({ page: landingPage.getPage })
-      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-      .analyze();
-
-    await testInfo.attach("accessibility-scan-results", {
-      body: JSON.stringify(results, null, 2),
-      contentType: "application/json",
-    });
-
-    expect(results.violations).toEqual([]);
-  });
-
-  /* *********************************************************** */
   /* LANDING PAGE TESTS */
   /* *********************************************************** */
 
+  // Test that the title of the landing page contains "activist".
   test('Title should contain "activist"', async ({ landingPage }) => {
     const pageTitle = await landingPage.getPage.title();
     expect(pageTitle).toContain("activist");
   });
 
+  // Test that the landing page contains the request access link.
   test("Splash should contain the request access link", async ({
     landingPage,
   }) => {
@@ -116,6 +118,7 @@ test.describe("Landing Page", () => {
     );
   });
 
+  // Test that all important links are visible on the landing page.
   test("All important links should be visible on the landing page", async ({
     landingPage,
   }) => {

--- a/frontend/tests/specs/landing-page.spec.ts
+++ b/frontend/tests/specs/landing-page.spec.ts
@@ -14,23 +14,12 @@ test.describe("Landing Page", () => {
   /* HEADER TESTS */
   /* *********************************************************** */
 
-  // Test that Header is visible if the viewport is large enough.
-  test("Header should be visible", async ({ landingPage }) => {
-    if (!(await landingPage.isMobile())) {
-      const { desktopHeader } = landingPage.header;
-      await expect(desktopHeader).toBeVisible();
-    } else {
-      const { mobileHeader } = landingPage.header;
-      await expect(mobileHeader).toBeVisible();
-    }
-  });
-
   // Test that the Header is visible on both mobile and desktop.
   test("Header visibility on mobile and desktop", async ({ landingPage }) => {
-    const headerVisibility = (await landingPage.isMobile())
+    const header = (await landingPage.isMobile())
       ? landingPage.header.mobileHeader
       : landingPage.header.desktopHeader;
-    await expect(headerVisibility).toBeVisible();
+    await expect(header).toBeVisible();
   });
 
   // Test that the Roadmap button is visible and clickable only on Desktop.


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

- `#mobile-header` id was removed in `HeaderWebsite.vue` and caused tests to break, added it back
- added an update to e2e workflow file to attempt solving failing retries

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
