### PR TITLE
populating the database with dummy data

### DIFF
--- a/backend/authentication/factories.py
+++ b/backend/authentication/factories.py
@@ -35,6 +35,7 @@ class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = UserModel
         exclude = ("plaintext_password",)
+        django_get_or_create = ("username",)
 
     username = factory.Faker("user_name")
     name = factory.Faker("name")

--- a/backend/backend/management/commands/populate_db.py
+++ b/backend/backend/management/commands/populate_db.py
@@ -1,0 +1,31 @@
+from argparse import ArgumentParser
+from typing import TypedDict, Unpack
+
+from django.core.management.base import BaseCommand
+
+from authentication.factories import UserFactory
+
+
+class Options(TypedDict):
+    users: int
+
+
+class Command(BaseCommand):
+    help = "Populate the database with dummy data"
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument("--users", type=int, default=100)
+
+    def handle(self, *args: str, **options: Unpack[Options]) -> None:
+        number_of_users = options["users"]
+        try:
+            UserFactory.create_batch(number_of_users)
+            self.stdout.write(
+                self.style.ERROR(f"Number of users created: {number_of_users}")
+            )
+        except Exception as error:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"An error occured during the creation of dummy data: {error}"
+                )
+            )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       python manage.py loaddata fixtures/superuser.json &&
       python manage.py loaddata fixtures/status_types.json &&
       python manage.py loaddata fixtures/iso_code_map.json &&
+      python manage.py populate_db --users=100 &&
       python manage.py runserver 0.0.0.0:${BACKEND_PORT}"
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
We have been talking about populating the database with dummy data @andrewtavis @aasimsyed. I have added a custom management command to django `populate_db` with the option to specifiy the number of users via the `--users` flag. 

The file populate_db can be extend to load more dummy data (events, orgs).
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- No related issue
