### PR TITLE
feat: copy url and redirect to signal when share link is clicked

### DIFF
--- a/frontend/components/modal/ModalSharePage.vue
+++ b/frontend/components/modal/ModalSharePage.vue
@@ -94,10 +94,59 @@
               iconSize="1.5em"
             />
           </s-facebook>
-          <!-- <div class="flex h-full w-full cursor-pointer items-center gap-3">
-            <Icon :name="IconMap.SIGNAL" size="1.5em" />
-            <p>{{ $t("components.modal_share_page.signal") }}</p>
-          </div> -->
+          <div
+            @click="
+              copyToClipboardThenOpenURL(
+                props?.event?.name
+                  ? props?.event?.name
+                  : props?.organization?.name
+                    ? props?.organization?.name
+                    : '',
+                getCurrentUrl(),
+                'https://signal.me/#p'
+              )
+            "
+            @keypress.space="
+              copyToClipboardThenOpenURL(
+                props?.event?.name
+                  ? props?.event?.name
+                  : props?.organization?.name
+                    ? props?.organization?.name
+                    : '',
+                getCurrentUrl(),
+                'https://signal.me/#p'
+              )
+            "
+            @keypress.enter="
+              copyToClipboardThenOpenURL(
+                props?.event?.name
+                  ? props?.event?.name
+                  : props?.organization?.name
+                    ? props?.organization?.name
+                    : '',
+                getCurrentUrl(),
+                'https://signal.me/#p'
+              )
+            "
+            class="focus-brand"
+            tabindex="0"
+            role="button"
+          >
+            <MetaTagSocialMedia
+              v-if="!signalContentCopied"
+              class="dark:hover:dark-distinct-text text-light-text hover:text-light-distinct-text dark:text-dark-text"
+              :iconName="IconMap.SIGNAL"
+              :text="$t('components.modal_share_page.signal')"
+              iconSize="1.5em"
+            />
+            <MetaTagSocialMedia
+              v-if="signalContentCopied"
+              class="text-light-accepted-green hover:text-light-accepted-green dark:text-dark-accepted-green dark:hover:text-dark-accepted-green"
+              :iconName="IconMap.SQUARE_CHECK"
+              :text="$t('components.modal_share_page.copied')"
+              iconSize="1.5em"
+            />
+          </div>
           <div
             @click="
               copyToClipboard(
@@ -283,6 +332,7 @@ const shareOptions = {
 
 const useNativeBehavior = false;
 const contentCopied = ref(false);
+const signalContentCopied = ref(false);
 
 // No specific actions should be taken on these events, but we can customize the behavior if needed.
 const nativeBehaviorOptions = {
@@ -304,6 +354,26 @@ const copyToClipboard = async (name: string, url: string) => {
   } catch (error) {
     console.error(`Could not copy text: ${error}`);
     contentCopied.value = false;
+  }
+};
+
+const copyToClipboardThenOpenURL = async (
+  name: string,
+  url: string,
+  redirectURL?: string
+) => {
+  try {
+    await navigator.clipboard.writeText(url);
+    signalContentCopied.value = true;
+    setTimeout(() => {
+      signalContentCopied.value = false;
+      if (redirectURL) {
+        window.open(redirectURL, "_blank");
+      }
+    }, 2000);
+  } catch (error) {
+    console.error(`Could not copy text: ${error}`);
+    signalContentCopied.value = false;
   }
 };
 </script>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
This is the same PR from the other signal additional PR. I have a problem with my git so I had to recreate the branch.

For the implementation, I feel like there is still improvement that can be made, especially with the duplicated copy URL code. Feel free to let me know if there are any ideas/comments.

Also, just an idea, maybe we could add in a "Redirecting to Signal" infobox or something to let the user know that it is redirecting to signal.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #694 
