### PR TITLE
refac(map): Update attribution text to condensed version and change profile on key press [p]

### DIFF
--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -90,6 +90,7 @@ const routeProfileMap: RouteProfile[] = [
 
 const walkingRouteProfileControl = `
   <div
+    title="Change profile [p]"
     id=${routeProfileOptions.FOOT}
     style="
     background-image: url(${walkDirectionsIcon});
@@ -105,6 +106,7 @@ const walkingRouteProfileControl = `
 
 const bikeRouteProfileControl = `
   <div
+    title="Change profile [p]"
     id=${routeProfileOptions.BIKE}
     style="
     background-image: url(${bikeDirectionsIcon});
@@ -362,7 +364,7 @@ onMounted(() => {
                 } else {
                   div.addEventListener("click", updateSelectedProfile);
                   document.addEventListener("keydown", (event) => {
-                    if (event.key === "x") {
+                    if (event.key === "p") {
                       updateSelectedProfile();
                     }
                   });

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -177,7 +177,7 @@ onMounted(() => {
                 tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
                 tileSize: 256,
                 attribution:
-                  '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>',
+                  '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap</a>',
               },
               "cycle-raster-tiles": {
                 type: "raster",
@@ -188,7 +188,7 @@ onMounted(() => {
                 ],
                 tileSize: 256,
                 attribution:
-                  '<a href="https://www.cyclosm.org" target="_blank">CyclOSM</a> tiles hosted by <a href="https://openstreetmap.fr" target="_blank">OpenStreetMap France</a>',
+                  '<a href="https://www.cyclosm.org" target="_blank">CyclOSM</a> hosted by <a href="https://openstreetmap.fr" target="_blank">OSM France</a>',
               },
             },
             layers: [


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Slowly but surely chipping away at some map stuff..
- Was confused by the `keydown` event on `[x]` causing both the clearing of directions and toggling the route profile. Modified so that the route profile is changed instead on `keydown` events on `[p]`. Let me know if there was a reason though for having both actions caused by the same event - wasn't sure
- As per part of the discussion in #961, modified the attribution texts to be more condensed. Went with:
   - `© OpenStreetMap` as that is also a fairly common alternative ([ref](https://osmfoundation.org/wiki/Licence/Attribution_Guidelines#Attribution_text)).
   - `CyclOSM hosted by OSM France` as opposed to `CyclOSM tiles by OSM France` from https://github.com/activist-org/activist/issues/961#issuecomment-2323958279 , given that I'm actually unsure if the CyclOSM styles are officially an OSM France project. However, the tiles themselves are definitely hosted by their infrastructure - so that seemed more appropriate. 

Also - as I was looking at this, thought about how eventually using localized strings for the map controls/interactions would be a good idea actually - created #968 for it.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- Part of #961
