### PR TITLE
#835 Close Safari buttom bar for fullscreen map

### DIFF
--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -30,7 +30,10 @@ const isTouchDevice =
   navigator.maxTouchPoints > 0;
 
 const applyMaxWindowHeight = () => {
-  window.scrollTo(0, 1);
+  const container = document.getElementById("container");
+  if (container) {
+    container.requestFullscreen();
+  }
 };
 
 function isWebglSupported() {

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -30,13 +30,9 @@ const isTouchDevice =
   navigator.maxTouchPoints > 0;
 
 const applyMaxWindowHeight = () => {
-  addEventListener(
-    "load",
-    function () {
-      window.scrollTo(1, 0);
-    },
-    false
-  );
+  setTimeout(function () {
+    window.scrollTo(0, 1);
+  }, 1000);
 };
 
 function isWebglSupported() {

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -236,7 +236,6 @@ onMounted(() => {
           }),
           "top-left"
         );
-        map.addControl(new maplibregl.FullscreenControl());
         map.addControl(
           new maplibregl.GeolocateControl({
             positionOptions: {
@@ -245,8 +244,8 @@ onMounted(() => {
             trackUserLocation: true,
           })
         );
-
-        map.on("fullscreenstart", applyMaxWindowHeight);
+        map.addControl(new maplibregl.FullscreenControl());
+        map.on("resize", () => applyMaxWindowHeight());
 
         const popup = new maplibregl.Popup({
           offset: 25,

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -29,6 +29,13 @@ const isTouchDevice =
   "ontouchstart" in window ||
   navigator.maxTouchPoints > 0;
 
+const applyMaxWindowHeight = () => {
+  document.documentElement.style.setProperty(
+    "--app-height",
+    `${window.innerHeight}px`
+  );
+};
+
 function isWebglSupported() {
   if (window.WebGLRenderingContext) {
     const canvas = document.createElement("canvas");
@@ -242,6 +249,8 @@ onMounted(() => {
           })
         );
 
+        map.on("fullscreenchange", applyMaxWindowHeight);
+
         const popup = new maplibregl.Popup({
           offset: 25,
         }).setHTML(
@@ -433,3 +442,18 @@ onMounted(() => {
     });
 });
 </script>
+
+<style scoped>
+:root {
+  --app-height: 100%;
+}
+html,
+body {
+  padding: 0;
+  margin: 0;
+  overflow: hidden;
+  width: 100vw;
+  height: 100vh;
+  height: var(--app-height);
+}
+</style>

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -30,10 +30,7 @@ const isTouchDevice =
   navigator.maxTouchPoints > 0;
 
 const applyMaxWindowHeight = () => {
-  document.documentElement.style.setProperty(
-    "--app-height",
-    `${window.innerHeight}px`
-  );
+  window.scrollTo(0, 1);
 };
 
 function isWebglSupported() {
@@ -249,7 +246,7 @@ onMounted(() => {
           })
         );
 
-        map.on("fullscreenchange", applyMaxWindowHeight);
+        map.on("fullscreenstart", applyMaxWindowHeight);
 
         const popup = new maplibregl.Popup({
           offset: 25,
@@ -277,12 +274,9 @@ onMounted(() => {
         map
           .loadImage("/icons/from_library/bootstrap_arrow_right.png")
           .then((image) => {
-            console.log("Here1");
             if (image) {
               map.addImage("route-direction-arrow", image.data);
             }
-
-            console.log("Here2", image.data);
           });
 
         map.on("load", () => {
@@ -442,18 +436,3 @@ onMounted(() => {
     });
 });
 </script>
-
-<style scoped>
-:root {
-  --app-height: 100%;
-}
-html,
-body {
-  padding: 0;
-  margin: 0;
-  overflow: hidden;
-  width: 100vw;
-  height: 100vh;
-  height: var(--app-height);
-}
-</style>

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -30,10 +30,13 @@ const isTouchDevice =
   navigator.maxTouchPoints > 0;
 
 const applyMaxWindowHeight = () => {
-  const container = document.getElementById("container");
-  if (container) {
-    container.requestFullscreen();
-  }
+  addEventListener(
+    "load",
+    function () {
+      window.scrollTo(1, 0);
+    },
+    false
+  );
 };
 
 function isWebglSupported() {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Sending along a PR so this can be checked on Mobile via Netlify previews. Goal is that when the user clicks fullscreen on the map that the bottom bar on Safari will automatically close. Without this, on smaller iPhones the map can be a bit small in the fullscreen mode.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #835
