### PR TITLE
Bug: 980 (Cannot read properties of undefined (reading 'isOpen') in MediaImageCarousel.vue)

### DIFF
--- a/frontend/components/modal/ModalBase.vue
+++ b/frontend/components/modal/ModalBase.vue
@@ -96,8 +96,11 @@ const closeModal = () => {
   modals.closeModal(modalName);
 };
 
-// If the user changes the route while the modal is open, close the modal.
+// Check if the user is navigating to another resource.
+// If a modal exists, close close it.
 watch(route, () => {
-  closeModal();
+  if (modals.modals[modalName]) {
+    closeModal();
+  }
 });
 </script>


### PR DESCRIPTION
Added if statement to watch(route) so that closeModal() is called only when modals are present.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR attempts to correct an error that occurs when a user navigates the app and there are no modals in the modal Pinia store. It is part of a larger effort to make the modal implementation more consistent.

### Related issue

- #ISSUE_NUMBER 980
