### PR TITLE
fix: translations and aria-labels display in theme menu

### DIFF
--- a/frontend/components/dropdown/DropdownTheme.vue
+++ b/frontend/components/dropdown/DropdownTheme.vue
@@ -5,7 +5,9 @@
     :menuButtonIcon="menuButtonIcon"
     :menuButtonLabel="$t(`components.dropdown_theme.label`)"
     :isMenuButtonUppercase="false"
-    menuButtonAriaLabel="components.dropdown_theme.open_dropdown_aria_label"
+    :menuButtonAriaLabel="
+      $t(`components.dropdown_theme.open_dropdown_aria_label`)
+    "
   >
     <div class="px-2 py-2">
       <MenuItem
@@ -17,9 +19,9 @@
           :isButton="true"
           :handlerClick="() => handlerClick(opt.optColorMode)"
           :iconName="opt.iconName"
-          :label="$t(`${opt.label}`)"
+          :label="$t(opt.label)"
           :active="active"
-          :ariaLabel="opt.ariaLabel"
+          :ariaLabel="$t(opt.ariaLabel)"
         />
       </MenuItem>
     </div>
@@ -51,19 +53,19 @@ const labelsOpt = [
     optColorMode: "system",
     iconName: `${IconMap.COLOR_MODE_SYSTEM}`,
     label: "components.dropdown_theme.system",
-    ariaLabel: "$t('components.dropdown_theme.system_aria_label')",
+    ariaLabel: "components.dropdown_theme.system_aria_label",
   },
   {
     optColorMode: "light",
     iconName: `${IconMap.COLOR_MODE_LIGHT}`,
     label: "components.dropdown_theme.light",
-    ariaLabel: "$t('components.dropdown_theme.light_aria_label')",
+    ariaLabel: "components.dropdown_theme.light_aria_label",
   },
   {
     optColorMode: "dark",
     iconName: `${IconMap.COLOR_MODE_DARK}`,
     label: "components.dropdown_theme.dark",
-    ariaLabel: "$t('components.dropdown_theme.dark_aria_label')",
+    ariaLabel: "components.dropdown_theme.dark_aria_label",
   },
 ];
 

--- a/frontend/components/menu/MenuItemLabel.vue
+++ b/frontend/components/menu/MenuItemLabel.vue
@@ -55,7 +55,7 @@ const infoComponent = computed(() => {
     ? {
         is: "button",
         onclick: props.handlerClick,
-        ariaLabel: props.ariaLabel,
+        "aria-label": props.ariaLabel,
       }
     : {
         is: "li",

--- a/frontend/test/components/dropdown/DropdownTheme.spec.ts
+++ b/frontend/test/components/dropdown/DropdownTheme.spec.ts
@@ -1,0 +1,37 @@
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import render from "@/test/render";
+
+import DropdownTheme from "@/components/dropdown/DropdownTheme.vue";
+
+mockNuxtImport("useColorMode", () => useColorModeMock);
+
+// Theme switching should be tested in the e2e tests.
+// Mocking theme switching to make it work in component tests is too complicated.
+describe("DropdownTheme", () => {
+  it("shows translated options", async () => {
+    await render(DropdownTheme);
+
+    const menuButton = screen.getByRole("button", {
+      name: /open the dropdown to select another theme/i,
+    });
+    expect(menuButton.textContent).toMatch(/^theme$/i);
+
+    await fireEvent.click(menuButton);
+
+    const systemOption = await screen.findByRole("menuitem", {
+      name: /switch to the system color mode/i,
+    });
+    expect(systemOption.textContent).toMatch(/^system$/i);
+
+    const lightOption = screen.getByRole("menuitem", {
+      name: /switch to light mode/i,
+    });
+    expect(lightOption.textContent).toMatch(/^light$/i);
+
+    const darkOption = screen.getByRole("menuitem", {
+      name: /switch to dark mode/i,
+    });
+    expect(darkOption.textContent).toMatch(/^dark$/i);
+  });
+});


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This fixes a bug where the aria-labels were showing raw translation keys.  Also, the `aria-label` attribute was being set as `arialabel` in menu options causing it not to work.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1022 
