### PR TITLE
1025: Added vue-18n.d.ts file

### DIFF
--- a/frontend/types/vue-i18n.d.ts
+++ b/frontend/types/vue-i18n.d.ts
@@ -1,5 +1,5 @@
 declare module "vue" {
   interface ComponentCustomProperties {
-    $t: (key: string) => string
+    $t: (key: string) => string;
   }
 }

--- a/frontend/types/vue-i18n.d.ts
+++ b/frontend/types/vue-i18n.d.ts
@@ -1,0 +1,5 @@
+declare module "vue" {
+  interface ComponentCustomProperties {
+    $t: (key: string) => string
+  }
+}

--- a/frontend/types/vue-i18n.d.ts
+++ b/frontend/types/vue-i18n.d.ts
@@ -1,4 +1,8 @@
-declare module "vue" {
+import 'vue'
+
+export { }
+
+declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
     $t: (key: string) => string;
   }


### PR DESCRIPTION
Cleans up numerous warnings about $t variable.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

In VS Code, in the 'Problems' panel, there are numerous warnings along the lines of:
"Property '$t' does not exist on type ...". It looks like these warnings are related to the i18n functionality.

There is no negative performance impact from these warnings, but the cause of these warnings should be resolved, so that the warnings stop appearing.

These warnings can be eliminated by adding type declarations / creating a vue-i18n.d.ts file in the projects '.../types' folder. The contents of the file look like so:

declare module "vue" {
interface ComponentCustomProperties {
$t: (key: string) => string
}
}

This should eliminate these numerous "Property '$t' does not exist on type ..." warnings.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1025 
