### PR TITLE
Regex routing for Organization in PageBreadCrumbs.vue

### DIFF
--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -100,6 +100,8 @@ const organizationRegex = /^(http:\/\/localhost:\d+|https?:\/\/[\w.-]+)(\/[a-z]{
 
 if (organizationRegex.test(url)) {
   pageType = "organization";
+  // Extract the UUID from the URL using regex
+  const match = url.match(organizationRegex);
   await organizationStore.fetchById(id);
   organization = organizationStore.organization;
 } else if (url.includes("/organizations/") && url.includes("/groups/")) {

--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -96,6 +96,7 @@ const eventStore = useEventStore();
 let organization: Organization;
 let group: Group;
 let event: Event;
+const organizationRegex = /^\/organizations\/[0-9a-fA-F-]+(\/about)?$/;
 
 if (
   url.includes("/organizations/") &&

--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -96,7 +96,7 @@ const eventStore = useEventStore();
 let organization: Organization;
 let group: Group;
 let event: Event;
-const organizationRegex = /^\/organizations\/[0-9a-fA-F-]+(\/about)?$/;
+const organizationRegex = /^(http:\/\/localhost:\d+|https?:\/\/[\w.-]+)(\/[a-z]{2})?\/organizations\/[0-9a-fA-F-]+(\/about)?$/;
 
 if (organizationRegex.test(url)) {
   pageType = "organization";

--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -102,6 +102,7 @@ if (organizationRegex.test(url)) {
   pageType = "organization";
   // Extract the UUID from the URL using regex
   const match = url.match(organizationRegex);
+  const uuid = match ? match[3] : null; // Adjust group index as needed
   await organizationStore.fetchById(id);
   organization = organizationStore.organization;
 } else if (url.includes("/organizations/") && url.includes("/groups/")) {

--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -98,12 +98,7 @@ let group: Group;
 let event: Event;
 const organizationRegex = /^\/organizations\/[0-9a-fA-F-]+(\/about)?$/;
 
-if (
-  url.includes("/organizations/") &&
-  !url.includes("/groups/") &&
-  !url.includes("/organizations/create") &&
-  !url.includes("/organizations/search")
-) {
+if (organizationRegex.test(url)) {
   pageType = "organization";
   await organizationStore.fetchById(id);
   organization = organizationStore.organization;

--- a/frontend/tests/specs/organizationLogic.test.ts
+++ b/frontend/tests/specs/organizationLogic.test.ts
@@ -3,3 +3,9 @@ import { describe, it, expect, jest } from '@jest/globals';
 // Mock fetchById function and organization data directly
 const mockFetchById = jest.fn();
 const mockOrganization = { id: 'test-uuid', name: 'Test Organization' };
+
+// Mock PageBreadcrumbs logic
+jest.mock('@/components/page/PageBreadcrumbs.vue', () => ({
+    fetchById: mockFetchById,
+    organization: mockOrganization,
+  }));

--- a/frontend/tests/specs/organizationLogic.test.ts
+++ b/frontend/tests/specs/organizationLogic.test.ts
@@ -1,0 +1,5 @@
+import { describe, it, expect, jest } from '@jest/globals';
+
+// Mock fetchById function and organization data directly
+const mockFetchById = jest.fn();
+const mockOrganization = { id: 'test-uuid', name: 'Test Organization' };


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have not run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This pull request enhances the route check mechanisms in PageBreadcrumbs.vue by introducing a new organizationRegex to validate routes with the formats /organizations/{UUID} and optionally /organizations/{UUID}/about. This update ensures precise page type determination and improves the logic for fetching organization details by ID from the organizationStore.

Additionally, the regex logic now includes support for the base URL and an optional ISO route. This enhancement makes the implementation more robust by dynamically handling routes depending on the environment (e.g., localhost:3000 for development or the production URL) and optional language prefixes like /en. The assertion on the URL now ensures it adheres to a specific shape while maintaining flexibility for localized and non-localized routes.
Testing for the backend and frontend has not yet been conducted.

### Related issue

- partially resolves #920
