### PR TITLE
Added Regex for Groups and Events in PageBreadcrumbs.vue 

### DIFF
--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -109,14 +109,26 @@ if (
   pageType = "organization";
   await organizationStore.fetchById(id);
   organization = organizationStore.organization;
-} else if (groupRegex.test(url))  {
+} else if (groupRegex.test(url)) {
   pageType = "group";
-  await groupStore.fetchById(idGroup);
-  group = groupStore.group;
+
+  const match = url.match(groupRegex);
+  const groupId = match ? match[4] : null;
+
+  if (groupId) {
+    await groupStore.fetchById(groupId);
+    group = groupStore.group;
+  }
 } else if (eventRegex.test(url)) {
   pageType = "event";
-  await eventStore.fetchById(id);
-  event = eventStore.event;
+
+  const match = url.match(eventRegex);
+  const eventId = match ? match[3] : null;
+
+  if (eventId) {
+    await eventStore.fetchById(eventId);
+    event = eventStore.event;
+  }
 }
 
 const breadcrumbs = ref<string[]>([]);

--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -97,8 +97,8 @@ let organization: Organization;
 let group: Group;
 let event: Event;
 
-const groupRegex = /^\/organizations\/[0-9a-fA-F-]+\/groups\/[0-9a-fA-F-]+(\/about)?$/;
-const eventRegex = /^\/events\/[0-9a-fA-F-]+(\/about)?$/;
+const groupRegex = /^(http:\/\/localhost:\d+|https?:\/\/[\w.-]+)(\/[a-z]{2})?\/organizations\/[0-9a-fA-F-]+\/groups\/([0-9a-fA-F-]+)(\/about)?$/;
+const eventRegex = /^(http:\/\/localhost:\d+|https?:\/\/[\w.-]+)(\/[a-z]{2})?\/events\/([0-9a-fA-F-]+)(\/about)?$/;
 
 if (
   url.includes("/organizations/") &&
@@ -109,7 +109,7 @@ if (
   pageType = "organization";
   await organizationStore.fetchById(id);
   organization = organizationStore.organization;
-} else if (groupRegex.test(url)) {
+} else if (groupRegex.test(url))  {
   pageType = "group";
   await groupStore.fetchById(idGroup);
   group = groupStore.group;

--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -119,7 +119,6 @@ if (
   event = eventStore.event;
 }
 
-
 const breadcrumbs = ref<string[]>([]);
 
 function setBreadcrumbs() {

--- a/frontend/components/page/PageBreadcrumbs.vue
+++ b/frontend/components/page/PageBreadcrumbs.vue
@@ -97,6 +97,9 @@ let organization: Organization;
 let group: Group;
 let event: Event;
 
+const groupRegex = /^\/organizations\/[0-9a-fA-F-]+\/groups\/[0-9a-fA-F-]+(\/about)?$/;
+const eventRegex = /^\/events\/[0-9a-fA-F-]+(\/about)?$/;
+
 if (
   url.includes("/organizations/") &&
   !url.includes("/groups/") &&
@@ -106,21 +109,16 @@ if (
   pageType = "organization";
   await organizationStore.fetchById(id);
   organization = organizationStore.organization;
-} else if (url.includes("/organizations/") && url.includes("/groups/")) {
+} else if (groupRegex.test(url)) {
   pageType = "group";
   await groupStore.fetchById(idGroup);
   group = groupStore.group;
-} else if (
-  url.includes("/events/") &&
-  !url.includes("/organizations/") &&
-  !url.includes("/groups/") &&
-  !url.includes("/events/create") &&
-  !url.includes("/events/search")
-) {
+} else if (eventRegex.test(url)) {
   pageType = "event";
   await eventStore.fetchById(id);
   event = eventStore.event;
 }
+
 
 const breadcrumbs = ref<string[]>([]);
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This pull request enhances the route-checking logic in PageBreadcrumbs.vue by introducing robust mechanisms for handling group and event routes.
- groupRegex validates routes with the format /organizations/{UUID}/groups/{UUID} and optionally /about. This ensures accurate identification of "group" page types and triggers fetching group details from the groupStore using the fetchById method. This addition enables seamless navigation and dynamic content updates for group-related pages.
- eventRegex validates routes with the format /events/{UUID} and optionally /about. This allows for precise identification of "event" page types and ensures event details are fetched from the eventStore using the fetchById method.

Testing for this feature has not yet been conducted. I have reached out to one of the repository owners (@cquinn540) for further guidance, as there were several issues that fell beyond the scope of my expertise. These challenges need resolution to proceed with comprehensive validation and testing.

### Related issue
partially resolves #920 

