### PR TITLE
 Fix Routing Logic for Non-Localized Routes and Ensure Robust Locale Handling

### DIFF
--- a/frontend/utils/routeUtils.ts
+++ b/frontend/utils/routeUtils.ts
@@ -1,15 +1,16 @@
-// A helper array for supported locales. Adjust as needed.
+// Define the supported locales. Adjust as needed to match your project.
 const LOCALES = ['en', 'fr', 'de'];
 
 /**
- * Removes leading and trailing slashes from a path.
+ * Normalize a given path by removing leading and trailing slashes.
  */
 function normalizePath(path: string): string {
   return path.replace(/^\/|\/$/g, '');
 }
 
 /**
- * If the first segment of the given segments is a known locale, remove it.
+ * Remove the leading locale segment from the given route segments if present.
+ * For example, ['en', 'organizations'] -> ['organizations'].
  */
 function removeLocaleSegment(segments: string[]): string[] {
   if (segments.length > 0 && LOCALES.includes(segments[0])) {
@@ -19,8 +20,8 @@ function removeLocaleSegment(segments: string[]): string[] {
 }
 
 /**
- * Remove locale prefix from a routeName if it follows the pattern like `en___something`.
- * If there's no locale segment, this function returns the routeName unchanged.
+ * Remove locale prefixes from route names that follow the pattern "locale___restOfTheRoute".
+ * For example, "en___organizations" -> "organizations".
  */
 function removeLocaleFromRouteName(routeName: string): string {
   const parts = routeName.split('___');
@@ -43,7 +44,12 @@ export function isRouteActive(routePath: string): boolean {
   currentSegments = removeLocaleSegment(currentSegments);
   targetSegments = removeLocaleSegment(targetSegments);
 
-  // Check if the target segments match the corresponding ending segments of the current path
+  // If current route is shorter than the target, it cannot match
+  if (currentSegments.length < targetSegments.length) {
+    return false;
+  }
+
+  // Check if the target segments match the end of the current segments
   return targetSegments.every(
     (segment, index) =>
       currentSegments[currentSegments.length - targetSegments.length + index] === segment
@@ -51,22 +57,19 @@ export function isRouteActive(routePath: string): boolean {
 }
 
 export function isCurrentRoutePathSubpageOf(path: string, routeName: string): boolean {
-  // Remove locale info from the routeName first
   const baseName = removeLocaleFromRouteName(routeName);
 
-  // After removing locale, we expect something like "projects-subpage"
-  // Splitting by `path + '-'` should isolate the subpage if it exists
+  // Split the baseName on `path + '-'` to find a subpage if one exists
+  // For example, if path = 'organizations' and routeName = 'organizations-subpage',
+  // splitting on 'organizations-' gives ['', 'subpage'].
   const segments = baseName.split(`${path}-`);
   const subpage = segments.length > 1 ? segments[1] : "";
 
-  // Check that the subpage is neither "search" nor "create" and that it has some length
+  // Check that this subpage is valid and not one of the excluded routes
   return subpage !== "search" && subpage !== "create" && subpage.length > 0;
 }
 
 export function currentRoutePathIncludes(path: string, routeName: string): boolean {
-  // Remove locale info from the routeName
   const baseName = removeLocaleFromRouteName(routeName);
-
-  // Check if the cleaned route name includes the given path
   return baseName.includes(path);
 }

--- a/frontend/utils/routeUtils.ts
+++ b/frontend/utils/routeUtils.ts
@@ -1,34 +1,72 @@
+// A helper array for supported locales. Adjust as needed.
+const LOCALES = ['en', 'fr', 'de'];
+
+/**
+ * Removes leading and trailing slashes from a path.
+ */
+function normalizePath(path: string): string {
+  return path.replace(/^\/|\/$/g, '');
+}
+
+/**
+ * If the first segment of the given segments is a known locale, remove it.
+ */
+function removeLocaleSegment(segments: string[]): string[] {
+  if (segments.length > 0 && LOCALES.includes(segments[0])) {
+    return segments.slice(1);
+  }
+  return segments;
+}
+
+/**
+ * Remove locale prefix from a routeName if it follows the pattern like `en___something`.
+ * If there's no locale segment, this function returns the routeName unchanged.
+ */
+function removeLocaleFromRouteName(routeName: string): string {
+  const parts = routeName.split('___');
+  if (parts.length > 1 && LOCALES.includes(parts[0])) {
+    return parts.slice(1).join('___');
+  }
+  return routeName;
+}
+
 export function isRouteActive(routePath: string): boolean {
   const route = useRoute();
-
-  // Helper function to remove leading and trailing slashes
-  const normalizePath = (path: string) => path.replace(/^\/|\/$/g, '');
 
   const currentPath = normalizePath(route.path);
   const targetPath = normalizePath(routePath);
 
-  // Handle prefixed routes by ignoring the base path
-  // Split paths into segments and compare relative paths
-  const currentSegments = currentPath.split('/');
-  const targetSegments = targetPath.split('/');
+  let currentSegments = currentPath.split('/');
+  let targetSegments = targetPath.split('/');
 
-  // Check if the target segments match the corresponding end of current segments
+  // Remove locale segments from both current and target paths
+  currentSegments = removeLocaleSegment(currentSegments);
+  targetSegments = removeLocaleSegment(targetSegments);
+
+  // Check if the target segments match the corresponding ending segments of the current path
   return targetSegments.every(
     (segment, index) =>
       currentSegments[currentSegments.length - targetSegments.length + index] === segment
   );
 }
 
-export function isCurrentRoutePathSubpageOf(path: string, routeName: string) {
-  // The first split is to remove the localization path.
-  const segments = routeName.split("___")[0].split(path + "-");
+export function isCurrentRoutePathSubpageOf(path: string, routeName: string): boolean {
+  // Remove locale info from the routeName first
+  const baseName = removeLocaleFromRouteName(routeName);
+
+  // After removing locale, we expect something like "projects-subpage"
+  // Splitting by `path + '-'` should isolate the subpage if it exists
+  const segments = baseName.split(`${path}-`);
   const subpage = segments.length > 1 ? segments[1] : "";
+
+  // Check that the subpage is neither "search" nor "create" and that it has some length
   return subpage !== "search" && subpage !== "create" && subpage.length > 0;
 }
 
-export function currentRoutePathIncludes(
-  path: string,
-  routeName: string
-): boolean {
-  return routeName.includes(path);
+export function currentRoutePathIncludes(path: string, routeName: string): boolean {
+  // Remove locale info from the routeName
+  const baseName = removeLocaleFromRouteName(routeName);
+
+  // Check if the cleaned route name includes the given path
+  return baseName.includes(path);
 }

--- a/frontend/utils/routeUtils.ts
+++ b/frontend/utils/routeUtils.ts
@@ -1,7 +1,22 @@
 export function isRouteActive(routePath: string): boolean {
   const route = useRoute();
-  // TODO: Needs to account for prefixed routes as well.
-  return route.path.split("/")[1] === routePath.substring(1, routePath.length);
+
+  // Helper function to remove leading and trailing slashes
+  const normalizePath = (path: string) => path.replace(/^\/|\/$/g, '');
+
+  const currentPath = normalizePath(route.path);
+  const targetPath = normalizePath(routePath);
+
+  // Handle prefixed routes by ignoring the base path
+  // Split paths into segments and compare relative paths
+  const currentSegments = currentPath.split('/');
+  const targetSegments = targetPath.split('/');
+
+  // Check if the target segments match the corresponding end of current segments
+  return targetSegments.every(
+    (segment, index) =>
+      currentSegments[currentSegments.length - targetSegments.length + index] === segment
+  );
 }
 
 export function isCurrentRoutePathSubpageOf(path: string, routeName: string) {

--- a/frontend/utils/routeUtils.ts
+++ b/frontend/utils/routeUtils.ts
@@ -1,9 +1,24 @@
 
+// Define the supported locales. Adjust as needed to match your project.
+const LOCALES = ['en', 'fr', 'de'];
+
 /**
  * Normalize a given path by removing leading and trailing slashes.
  */
 function normalizePath(path: string): string {
   return path.replace(/^\/|\/$/g, '');
+}
+
+
+/**
+ * Remove the leading locale segment from the given route segments if present.
+ * For example, ['en', 'organizations'] -> ['organizations'].
+ */
+function removeLocaleSegment(segments: string[]): string[] {
+  if (segments.length > 0 && LOCALES.includes(segments[0])) {
+    return segments.slice(1);
+  }
+  return segments;
 }
 
 export function isRouteActive(routePath: string): boolean {
@@ -12,12 +27,19 @@ export function isRouteActive(routePath: string): boolean {
   const currentPath = normalizePath(route.path);
   const targetPath = normalizePath(routePath);
 
-  // Handle prefixed routes by ignoring the base path
-  // Split paths into segments and compare relative paths
-  const currentSegments = currentPath.split('/');
-  const targetSegments = targetPath.split('/');
+  let currentSegments = currentPath.split('/');
+  let targetSegments = targetPath.split('/');
 
-  // Check if the target segments match the corresponding end of current segments
+  // Remove locale segments from both current and target paths
+  currentSegments = removeLocaleSegment(currentSegments);
+  targetSegments = removeLocaleSegment(targetSegments);
+
+  // If current route is shorter than the target, it cannot match
+  if (currentSegments.length < targetSegments.length) {
+    return false;
+  }
+
+  // Check if the target segments match the end of the current segments
   return targetSegments.every(
     (segment, index) =>
       currentSegments[currentSegments.length - targetSegments.length + index] === segment

--- a/frontend/utils/routeUtils.ts
+++ b/frontend/utils/routeUtils.ts
@@ -1,11 +1,13 @@
-export function isRouteActive(routePath: string): boolean {
-  const route = useRoute();
+
 /**
  * Normalize a given path by removing leading and trailing slashes.
  */
 function normalizePath(path: string): string {
   return path.replace(/^\/|\/$/g, '');
 }
+
+export function isRouteActive(routePath: string): boolean {
+  const route = useRoute();
 
   const currentPath = normalizePath(route.path);
   const targetPath = normalizePath(routePath);

--- a/frontend/utils/routeUtils.ts
+++ b/frontend/utils/routeUtils.ts
@@ -1,6 +1,5 @@
-// Define the supported locales. Adjust as needed to match your project.
-const LOCALES = ['en', 'fr', 'de'];
-
+export function isRouteActive(routePath: string): boolean {
+  const route = useRoute();
 /**
  * Normalize a given path by removing leading and trailing slashes.
  */
@@ -8,68 +7,31 @@ function normalizePath(path: string): string {
   return path.replace(/^\/|\/$/g, '');
 }
 
-/**
- * Remove the leading locale segment from the given route segments if present.
- * For example, ['en', 'organizations'] -> ['organizations'].
- */
-function removeLocaleSegment(segments: string[]): string[] {
-  if (segments.length > 0 && LOCALES.includes(segments[0])) {
-    return segments.slice(1);
-  }
-  return segments;
-}
-
-/**
- * Remove locale prefixes from route names that follow the pattern "locale___restOfTheRoute".
- * For example, "en___organizations" -> "organizations".
- */
-function removeLocaleFromRouteName(routeName: string): string {
-  const parts = routeName.split('___');
-  if (parts.length > 1 && LOCALES.includes(parts[0])) {
-    return parts.slice(1).join('___');
-  }
-  return routeName;
-}
-
-export function isRouteActive(routePath: string): boolean {
-  const route = useRoute();
-
   const currentPath = normalizePath(route.path);
   const targetPath = normalizePath(routePath);
 
-  let currentSegments = currentPath.split('/');
-  let targetSegments = targetPath.split('/');
+  // Handle prefixed routes by ignoring the base path
+  // Split paths into segments and compare relative paths
+  const currentSegments = currentPath.split('/');
+  const targetSegments = targetPath.split('/');
 
-  // Remove locale segments from both current and target paths
-  currentSegments = removeLocaleSegment(currentSegments);
-  targetSegments = removeLocaleSegment(targetSegments);
-
-  // If current route is shorter than the target, it cannot match
-  if (currentSegments.length < targetSegments.length) {
-    return false;
-  }
-
-  // Check if the target segments match the end of the current segments
+  // Check if the target segments match the corresponding end of current segments
   return targetSegments.every(
     (segment, index) =>
       currentSegments[currentSegments.length - targetSegments.length + index] === segment
   );
 }
 
-export function isCurrentRoutePathSubpageOf(path: string, routeName: string): boolean {
-  const baseName = removeLocaleFromRouteName(routeName);
-
-  // Split the baseName on `path + '-'` to find a subpage if one exists
-  // For example, if path = 'organizations' and routeName = 'organizations-subpage',
-  // splitting on 'organizations-' gives ['', 'subpage'].
-  const segments = baseName.split(`${path}-`);
+export function isCurrentRoutePathSubpageOf(path: string, routeName: string) {
+  // The first split is to remove the localization path.
+  const segments = routeName.split("___")[0].split(path + "-");
   const subpage = segments.length > 1 ? segments[1] : "";
-
-  // Check that this subpage is valid and not one of the excluded routes
   return subpage !== "search" && subpage !== "create" && subpage.length > 0;
 }
 
-export function currentRoutePathIncludes(path: string, routeName: string): boolean {
-  const baseName = removeLocaleFromRouteName(routeName);
-  return baseName.includes(path);
+export function currentRoutePathIncludes(
+  path: string,
+  routeName: string
+): boolean {
+  return routeName.includes(path);
 }


### PR DESCRIPTION
This pull request addresses issue #963, where routes were not being handled properly. Previously, isRouteActive assumed a localized route structure. Switching between localized and non-localized routes led to unexpected behavior in terms of resulting pages.

**Changes:**

1. **Locale Stripping Logic:**

Introduced helper functions to strip locale segments from path-based routes and route names. Ensures that core functionality (checking active routes and checking subpages) is stable, regardless of locale prefix. 

2. **Normalized Path Comparisons:**
Updated isRouteActive and related functions to first remove any leading/trailing slashes and locale prefixes before performing comparisons. This makes the logic more resilient to both localized (/en/events) and non-localized (/events) routes.

**Benefits:**
Ensures that tab switching and route comparisons work consistently, even after multiple interactions.
Simplifies maintenance by centralizing locale removal logic.

**Testing:**
Verified that switching between /en/organizations and en/events (as well as in other languages) now correctly reflects the active route and subpages.
Confirmed that non-localized routes (e.g., /organizations) are handled without errors.
Checked that existing localized functionalities remain intact.