### PR TITLE
#546 Base i18n map object and process to create it

### DIFF
--- a/frontend/components/SearchBar.vue
+++ b/frontend/components/SearchBar.vue
@@ -16,7 +16,7 @@
           v-if="sidebar.collapsed == false || sidebar.collapsedSwitch == false"
         >
           <label for="input-search" class="sr-only">{{
-            $t("_global.search")
+            $t(i18nMap._global.search)
           }}</label>
           <input
             @focus="onFocus"
@@ -26,7 +26,7 @@
             class="h-5 w-16 bg-transparent outline-none"
             :class="{ 'focus:w-5/6': isInputFocused }"
             type="text"
-            :placeholder="$t('_global.search')"
+            :placeholder="$t(i18nMap._global.search)"
           />
         </div>
       </Transition>
@@ -82,14 +82,14 @@
       size="1em"
     />
     <label for="input-search" class="hidden md:block">{{
-      $t("_global.search")
+      $t(i18nMap._global.search)
     }}</label>
     <input
       id="input-search"
       class="bg-transparent focus:outline-none"
       :class="{ hidden: !expanded }"
       type="text"
-      :placeholder="$t('_global.search')"
+      :placeholder="$t(i18nMap._global.search)"
     />
     <Icon v-if="expanded" class="absolute right-3" :name="IconMap.FILTER" />
   </div>
@@ -99,6 +99,7 @@
 import { useMagicKeys, whenever } from "@vueuse/core";
 import { IconMap } from "~/types/icon-map";
 import { SearchBarLocation } from "~/types/location";
+import { i18nMap } from "~/types/i18n-map";
 
 export interface Props {
   location: SearchBarLocation;

--- a/frontend/i18n/check/i18n_check_key_identifiers.py
+++ b/frontend/i18n/check/i18n_check_key_identifiers.py
@@ -27,6 +27,7 @@ directories_to_skip = [
     str((frontend_directory / ".nuxt").resolve()),
     str((frontend_directory / "node_modules").resolve()),
 ]
+files_to_skip = ["i18n-map.ts"]
 file_types_to_check = [".vue", ".ts", ".js"]
 
 with open(json_file_directory / "en-US.json", encoding="utf-8") as f:
@@ -39,6 +40,7 @@ for root, dirs, files in os.walk(frontend_directory):
         for file in files
         if all(root[: len(d)] != d for d in directories_to_skip)
         and any(file[-len(t) :] == t for t in file_types_to_check)
+        and file not in files_to_skip
     )
 
 file_to_check_contents = {}

--- a/frontend/i18n/check/i18n_check_map_object.py
+++ b/frontend/i18n/check/i18n_check_map_object.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Checks the i18nMap object to make sure that it's in sync with the base localization file.
+
+Usage:
+    python3 frontend/i18n/check/i18n_check_map_object.py
+"""
+
+import json
+from collections.abc import MutableMapping
+from pathlib import Path
+
+# MARK: Load Base i18n
+
+i18n_check_dir = Path(__file__).parent.parent.resolve()
+with open(i18n_check_dir / "en-US.json", encoding="utf-8") as f:
+    en_us_json_dict = json.loads(f.read())
+
+flat_en_us_json_dict = {k: k for k, _ in en_us_json_dict.items()}
+
+# MARK: Load i18n Map
+
+frontend_types_dir = (Path(__file__).parent.parent.parent / "types").resolve()
+with open(frontend_types_dir / "i18n-map.ts", encoding="utf-8") as f:
+    i18n_object_list = f.readlines()
+
+    i18n_object_list_with_key_quotes = []
+    for i, line in enumerate(i18n_object_list):
+        if i != 0 or i != len(i18n_object_list):
+            if line.strip()[0] != '"':
+                i18n_object_list_with_key_quotes.append(
+                    f'"{line.replace(":", '":').strip()}'
+                )
+
+            else:
+                i18n_object_list_with_key_quotes.append(
+                    f"{line.replace(':', '":').strip()}"
+                )
+
+    i18n_object = (
+        "".join(i18n_object_list_with_key_quotes)
+        .replace("export const i18nMap = ", "")
+        .replace("};", "}")
+        .replace('"{', "{")
+        .replace('"}', "}")
+        .replace(",}", "}")
+    )
+    i18n_object_dict = json.loads(i18n_object)
+
+
+# MARK: Flatten i18n Obj
+
+
+def flatten_nested_dict(
+    dictionary: MutableMapping, parent_key: str = "", sep: str = "."
+) -> MutableMapping:
+    """
+    Flattens a nested dictionary.
+
+    Parameters
+    ----------
+    d : MutableMapping
+        The nested dictionary to flatten.
+
+    parent_key : str
+        The key of the current value being flattened.
+
+    sep : str
+        The separator to be used to join the nested keys.
+
+    Returns
+    -------
+    MutableMapping
+        The flattened version of the given nested dictionary.
+    """
+    items = []
+    for k, v in dictionary.items():
+        new_key = parent_key + sep + k if parent_key else k
+        if isinstance(v, MutableMapping):
+            items.extend(flatten_nested_dict(v, new_key, sep=sep).items())
+
+        else:
+            items.append((new_key, v))
+
+    return dict(items)
+
+
+flat_i18n_object_dict = flatten_nested_dict(i18n_object_dict)
+
+# MARK: Compare Dicts
+
+assert (
+    flat_en_us_json_dict == flat_i18n_object_dict
+), "\nThe current i18nMap object doesn't match the base i18n JSON file. Please re-generate the i18nMap object.\n"
+
+print("\nSuccess: The current i18nMap object matches the base i18n JSON file.\n")

--- a/frontend/i18n/check/i18n_generate_map_object.py
+++ b/frontend/i18n/check/i18n_generate_map_object.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Generates a TypeScript file with the object i18nMap that maps all i18n keys as properties.
+This allows type checking of all i18n keys to assure that they've been entered correctly.
+
+Usage:
+    python3 frontend/i18n/check/i18n_generate_map_object.py
+"""
+
+import json
+import re
+from pathlib import Path
+
+# MARK: Paths / Files
+
+i18n_check_dir = Path(__file__).parent.parent.resolve()
+
+with open(i18n_check_dir / "en-US.json", encoding="utf-8") as f:
+    en_us_json_dict = json.loads(f.read())
+
+# MARK: Create Map
+
+
+def _recursively_nest_dict(k: str, v: str | dict, output_dict: dict):
+    """
+    Recursively nests dictionaries.
+
+    Parameters
+    ----------
+    k : str
+        The key of a sub dictionary.
+
+    v : str | dict
+        The value of a nested dictionary.
+
+    output_dict | dict
+        The output_dict dictionary or sub-dictionary.
+    """
+    k, *rest = k.split(".", 1)
+    if rest:
+        _recursively_nest_dict(rest[0], v, output_dict.setdefault(k, {}))
+
+    else:
+        output_dict[k] = v
+
+
+def nest_flat_dict(flat_dict: dict) -> dict:
+    """
+    Nest a flat dictionary.
+
+    Parameters
+    ----------
+    flat_dict : dict
+        A flattened dictionary that should be nested.
+
+    Returns
+    -------
+    nested_dict : dict
+        The nested version of the original flat dictionary.
+    """
+    nested_dict = {}
+    for k, v in flat_dict.items():
+        _recursively_nest_dict(k=k, v=v, output_dict=nested_dict)
+
+    return nested_dict
+
+
+i18n_map_dict = nest_flat_dict({k: k for k, _ in en_us_json_dict.items()})
+
+# MARK: Write Map
+
+frontend_types_dir = (Path(__file__).parent.parent.parent / "types").resolve()
+
+with open(frontend_types_dir / "i18n-map.ts", encoding="utf-8", mode="w") as f:
+    f.write(f"export const i18nMap = {json.dumps(i18n_map_dict, indent=2)}")
+
+# Rewrite to format the keys to not have quotes.
+with open(frontend_types_dir / "i18n-map.ts", encoding="utf-8", mode="r") as f:
+    i18n_object = f.readlines()
+
+with open(frontend_types_dir / "i18n-map.ts", encoding="utf-8", mode="w") as f:
+    for line in i18n_object:
+        f.write(re.sub(r'"([^"]*)":', r"\1:", line))

--- a/frontend/i18n/check/run_i18n_checks.py
+++ b/frontend/i18n/check/run_i18n_checks.py
@@ -41,6 +41,7 @@ def main():
         "i18n_check_non_source_keys.py",
         "i18n_check_unused_keys.py",
         "i18n_check_repeat_values.py",
+        # "i18n_check_map_object.py",
     ]
 
     for check in checks:

--- a/frontend/types/i18n-map.ts
+++ b/frontend/types/i18n-map.ts
@@ -1,0 +1,958 @@
+export const i18nMap = {
+  _global: {
+    about: "_global.about",
+    activist_icon_img_alt_text: "_global.activist_icon_img_alt_text",
+    auth: {
+      reset_password: "_global.auth.reset_password",
+      sign_in_aria_label: "_global.auth.sign_in_aria_label",
+      sign_up_aria_label: "_global.auth.sign_up_aria_label",
+      reset_password_forgot_password:
+        "_global.auth.reset_password_forgot_password",
+    },
+    contact: "_global.contact",
+    create_group: "_global.create_group",
+    discussion: "_global.discussion",
+    discussions: "_global.discussions",
+    enter_password: "_global.enter_password",
+    entity_logo: "_global.entity_logo",
+    events: "_global.events",
+    faq: "_global.faq",
+    home: "_global.home",
+    join_group: "_global.join_group",
+    join_group_aria_label: "_global.join_group_aria_label",
+    join_organization: "_global.join_organization",
+    join_organization_aria_label: "_global.join_organization_aria_label",
+    navigate_to: "_global.navigate_to",
+    new_event: "_global.new_event",
+    new_group: "_global.new_group",
+    new_resource: "_global.new_resource",
+    notifications: "_global.notifications",
+    offer_to_help: "_global.offer_to_help",
+    offer_to_help_aria_label: "_global.offer_to_help_aria_label",
+    on_github: "_global.on_github",
+    organization: "_global.organization",
+    organization_name: "_global.organization_name",
+    organizations: "_global.organizations",
+    public_matrix_chat_rooms: "_global.public_matrix_chat_rooms",
+    repeat_password: "_global.repeat_password",
+    resources: "_global.resources",
+    resources_lower: "_global.resources_lower",
+    return_home: "_global.return_home",
+    return_home_aria_label: "_global.return_home_aria_label",
+    search: "_global.search",
+    settings: "_global.settings",
+    share: "_global.share",
+    share_event: "_global.share_event",
+    share_event_aria_label: "_global.share_event_aria_label",
+    share_organization: "_global.share_organization",
+    share_organization_aria_label: "_global.share_organization_aria_label",
+    sign_in: "_global.sign_in",
+    sign_in_aria_label: "_global.sign_in_aria_label",
+    sign_up: "_global.sign_up",
+    sign_up_aria_label: "_global.sign_up_aria_label",
+    support: "_global.support",
+    support_event: "_global.support_event",
+    support_event_aria_label: "_global.support_event_aria_label",
+    support_organization: "_global.support_organization",
+    support_organization_aria_label: "_global.support_organization_aria_label",
+    tasks: "_global.tasks",
+    team: "_global.team",
+  },
+  components: {
+    _global: {
+      command_tooltip_label: "components._global.command_tooltip_label",
+      connect: "components._global.connect",
+      control_tooltip_label: "components._global.control_tooltip_label",
+      documentation: "components._global.documentation",
+      get_involved: "components._global.get_involved",
+      github: "components._global.github",
+      instagram: "components._global.instagram",
+      join: "components._global.join",
+      join_group_link: "components._global.join_group_link",
+      join_group_subtext: "components._global.join_group_subtext",
+      join_organization_subtext: "components._global.join_organization_subtext",
+      matrix: "components._global.matrix",
+      navigate_to_group_aria_label:
+        "components._global.navigate_to_group_aria_label",
+      navigate_to_start: "components._global.navigate_to_start",
+      offer_to_help_link: "components._global.offer_to_help_link",
+      participate: "components._global.participate",
+      participate_subtext: "components._global.participate_subtext",
+      roadmap: "components._global.roadmap",
+      slash_tooltip_label: "components._global.slash_tooltip_label",
+      star: "components._global.star",
+      upvote_application_aria_label:
+        "components._global.upvote_application_aria_label",
+      working_groups_subtext: "components._global.working_groups_subtext",
+      navigate_to_organization_aria_label:
+        "components._global.navigate_to_organization_aria_label",
+    },
+    btn_road_map: {
+      aria_label: "components.btn_road_map.aria_label",
+    },
+    btn_share_icon: {
+      opening_instagram: "components.btn_share_icon.opening_instagram",
+      opening_matrix: "components.btn_share_icon.opening_matrix",
+      opening_signal: "components.btn_share_icon.opening_signal",
+      url_copied: "components.btn_share_icon.url_copied",
+    },
+    card: {
+      about: {
+        _global: {
+          full_text: "components.card.about._global.full_text",
+          full_text_aria_label:
+            "components.card.about._global.full_text_aria_label",
+          members_lower: "components.card.about._global.members_lower",
+          reduce_text: "components.card.about._global.reduce_text",
+          reduce_text_aria_label:
+            "components.card.about._global.reduce_text_aria_label",
+        },
+      },
+      discussion: {
+        _global: {
+          upvote_discussion_aria_label:
+            "components.card.discussion._global.upvote_discussion_aria_label",
+        },
+      },
+    },
+    card_change_account_info_email: {
+      cta_aria_label:
+        "components.card_change_account_info_email.cta_aria_label",
+      enter_new_email:
+        "components.card_change_account_info_email.enter_new_email",
+      enter_old_email:
+        "components.card_change_account_info_email.enter_old_email",
+      header_cta: "components.card_change_account_info_email.header_cta",
+      new_email: "components.card_change_account_info_email.new_email",
+      old_email: "components.card_change_account_info_email.old_email",
+    },
+    card_change_account_info_password: {
+      cta_aria_label:
+        "components.card_change_account_info_password.cta_aria_label",
+      current_password:
+        "components.card_change_account_info_password.current_password",
+      enter_current_password:
+        "components.card_change_account_info_password.enter_current_password",
+      enter_new_password:
+        "components.card_change_account_info_password.enter_new_password",
+      enter_repeat_password:
+        "components.card_change_account_info_password.enter_repeat_password",
+      header_cta: "components.card_change_account_info_password.header_cta",
+      new_password: "components.card_change_account_info_password.new_password",
+    },
+    card_change_account_info_username: {
+      cta_aria_label:
+        "components.card_change_account_info_username.cta_aria_label",
+      enter_new_username:
+        "components.card_change_account_info_username.enter_new_username",
+      header_cta: "components.card_change_account_info_username.header_cta",
+      new_username: "components.card_change_account_info_username.new_username",
+    },
+    card_connect: {
+      app_account_popup_cta_btn_label:
+        "components.card_connect.app_account_popup_cta_btn_label",
+      app_account_popup_field_label_prompt:
+        "components.card_connect.app_account_popup_field_label_prompt",
+      app_account_popup_field_name_prompt:
+        "components.card_connect.app_account_popup_field_name_prompt",
+      app_account_popup_title:
+        "components.card_connect.app_account_popup_title",
+      new_account: "components.card_connect.new_account",
+      new_account_aria_label: "components.card_connect.new_account_aria_label",
+    },
+    card_danger_zone: {
+      header: "components.card_danger_zone.header",
+      password_label: "components.card_danger_zone.password_label",
+      username_label: "components.card_danger_zone.username_label",
+      username_placeholder: "components.card_danger_zone.username_placeholder",
+    },
+    card_date_picker: {
+      all_day: "components.card_date_picker.all_day",
+      date: "components.card_date_picker.date",
+      multiple_days: "components.card_date_picker.multiple_days",
+    },
+    card_details: {
+      attending: "components.card_details.attending",
+      header: "components.card_details.header",
+    },
+    card_discussion: {
+      filter_discussion_category_aria_label:
+        "components.card_discussion.filter_discussion_category_aria_label",
+    },
+    card_discussion_entry: {
+      on: "components.card_discussion_entry.on",
+    },
+    card_discussion_input: {
+      comment: "components.card_discussion_input.comment",
+      comment_aria_label: "components.card_discussion_input.comment_aria_label",
+      leave_comment: "components.card_discussion_input.leave_comment",
+      leave_comment_high_risk:
+        "components.card_discussion_input.leave_comment_high_risk",
+      markdown_support: "components.card_discussion_input.markdown_support",
+      preview: "components.card_discussion_input.preview",
+      preview_aria_label: "components.card_discussion_input.preview_aria_label",
+      write: "components.card_discussion_input.write",
+      write_aria_label: "components.card_discussion_input.write_aria_label",
+    },
+    card_donate: {
+      donate: "components.card_donate.donate",
+      go_to_donation_page_aria_label:
+        "components.card_donate.go_to_donation_page_aria_label",
+      template_text: "components.card_donate.template_text",
+    },
+    card_faq_entry: {
+      answer: "components.card_faq_entry.answer",
+      question: "components.card_faq_entry.question",
+    },
+    card_get_involved_event: {
+      legal_disclaimer_subtext:
+        "components.card_get_involved_event.legal_disclaimer_subtext",
+    },
+    card_get_involved_organization: {
+      join_organization_no_info:
+        "components.card_get_involved_organization.join_organization_no_info",
+      view_all_groups:
+        "components.card_get_involved_organization.view_all_groups",
+      view_all_groups_aria_label:
+        "components.card_get_involved_organization.view_all_groups_aria_label",
+    },
+    card_legal_disclaimer: {
+      header: "components.card_legal_disclaimer.header",
+    },
+    card_metrics_overview: {
+      action: "components.card_metrics_overview.action",
+      header: "components.card_metrics_overview.header",
+      learn: "components.card_metrics_overview.learn",
+      new_organizations: "components.card_metrics_overview.new_organizations",
+    },
+    card_org_application_vote: {
+      downvote_application_aria_label:
+        "components.card_org_application_vote.downvote_application_aria_label",
+    },
+    card_search_result: {
+      event_img_alt_text: "components.card_search_result.event_img_alt_text",
+      group_img_alt_text: "components.card_search_result.group_img_alt_text",
+      label: "components.card_search_result.label",
+      members: "components.card_search_result.members",
+      navigate_to_event_aria_label:
+        "components.card_search_result.navigate_to_event_aria_label",
+      navigate_to_resource_aria_label:
+        "components.card_search_result.navigate_to_resource_aria_label",
+      navigate_to_user_aria_label:
+        "components.card_search_result.navigate_to_user_aria_label",
+      organization_img_alt_text:
+        "components.card_search_result.organization_img_alt_text",
+      supporters_lower: "components.card_search_result.supporters_lower",
+      view_video: "components.card_search_result.view_video",
+    },
+    card_topic_selection: {
+      header: "components.card_topic_selection.header",
+      hide_all_topics: "components.card_topic_selection.hide_all_topics",
+      selector_placeholder:
+        "components.card_topic_selection.selector_placeholder",
+      subtext_group: "components.card_topic_selection.subtext_group",
+      subtext_organization:
+        "components.card_topic_selection.subtext_organization",
+      subtext_resource: "components.card_topic_selection.subtext_resource",
+      view_all_topics: "components.card_topic_selection.view_all_topics",
+    },
+    combobox_topics: {
+      all_topics: "components.combobox_topics.all_topics",
+      no_matching_topics: "components.combobox_topics.no_matching_topics",
+    },
+    dropdown_create: {
+      create: "components.dropdown_create.create",
+      create_aria_label: "components.dropdown_create.create_aria_label",
+      new_organization: "components.dropdown_create.new_organization",
+    },
+    dropdown_info: {
+      help: "components.dropdown_info.help",
+      info: "components.dropdown_info.info",
+      info_aria_label: "components.dropdown_info.info_aria_label",
+      legal: "components.dropdown_info.legal",
+    },
+    dropdown_language: {
+      open_dropdown_aria_label:
+        "components.dropdown_language.open_dropdown_aria_label",
+    },
+    dropdown_theme: {
+      dark: "components.dropdown_theme.dark",
+      dark_aria_label: "components.dropdown_theme.dark_aria_label",
+      label: "components.dropdown_theme.label",
+      light: "components.dropdown_theme.light",
+      light_aria_label: "components.dropdown_theme.light_aria_label",
+      open_dropdown_aria_label:
+        "components.dropdown_theme.open_dropdown_aria_label",
+      system: "components.dropdown_theme.system",
+      system_aria_label: "components.dropdown_theme.system_aria_label",
+    },
+    dropdown_user_options: {
+      join_activist: "components.dropdown_user_options.join_activist",
+      sign_out: "components.dropdown_user_options.sign_out",
+      username: "components.dropdown_user_options.username",
+      username_aria_label:
+        "components.dropdown_user_options.username_aria_label",
+      your_events: "components.dropdown_user_options.your_events",
+      your_orgs: "components.dropdown_user_options.your_orgs",
+      your_profile: "components.dropdown_user_options.your_profile",
+    },
+    empty_state: {
+      affiliates_header: "components.empty_state.affiliates_header",
+      create_event: "components.empty_state.create_event",
+      create_event_aria_label: "components.empty_state.create_event_aria_label",
+      create_group_aria_label: "components.empty_state.create_group_aria_label",
+      create_organization: "components.empty_state.create_organization",
+      create_organization_aria_label:
+        "components.empty_state.create_organization_aria_label",
+      create_resource_aria_label:
+        "components.empty_state.create_resource_aria_label",
+      cta_header_no_permission:
+        "components.empty_state.cta_header_no_permission",
+      discussions_header: "components.empty_state.discussions_header",
+      events_header: "components.empty_state.events_header",
+      faq_header: "components.empty_state.faq_header",
+      groups_header: "components.empty_state.groups_header",
+      img_alt_text: "components.empty_state.img_alt_text",
+      message_no_permission: "components.empty_state.message_no_permission",
+      message_with_permission: "components.empty_state.message_with_permission",
+      organizations_header: "components.empty_state.organizations_header",
+      resources_header: "components.empty_state.resources_header",
+      tasks_header: "components.empty_state.tasks_header",
+      team_header: "components.empty_state.team_header",
+    },
+    feed_item: {
+      img_alt_text: "components.feed_item.img_alt_text",
+    },
+    footer: {
+      flex: {
+        _global: {
+          activist_tagline: "components.footer.flex._global.activist_tagline",
+          copyright: "components.footer.flex._global.copyright",
+          powered_by_netlify:
+            "components.footer.flex._global.powered_by_netlify",
+        },
+      },
+    },
+    footer_website: {
+      imprint: "components.footer_website.imprint",
+      privacy_policy: "components.footer_website.privacy_policy",
+      source_code: "components.footer_website.source_code",
+      supporters: "components.footer_website.supporters",
+      trademark_policy: "components.footer_website.trademark_policy",
+      version_number: "components.footer_website.version_number",
+    },
+    form_radio_group: {
+      custom_numeric_value_placeholder:
+        "components.form_radio_group.custom_numeric_value_placeholder",
+    },
+    form_view_selector: {
+      title_aria_label: "components.form_view_selector.title_aria_label",
+      view_as_calendar_aria_label:
+        "components.form_view_selector.view_as_calendar_aria_label",
+      view_as_grid_aria_label:
+        "components.form_view_selector.view_as_grid_aria_label",
+      view_as_list_aria_label:
+        "components.form_view_selector.view_as_list_aria_label",
+      view_as_map_aria_label:
+        "components.form_view_selector.view_as_map_aria_label",
+    },
+    friendly_captcha: {
+      captcha_disabled: "components.friendly_captcha.captcha_disabled",
+      captcha_disabled_aria_label:
+        "components.friendly_captcha.captcha_disabled_aria_label",
+    },
+    grid_app_shields: {
+      app_store: "components.grid_app_shields.app_store",
+      download_on_the: "components.grid_app_shields.download_on_the",
+      f_droid: "components.grid_app_shields.f_droid",
+      get_it_on: "components.grid_app_shields.get_it_on",
+      google_play: "components.grid_app_shields.google_play",
+    },
+    grid_git_hub_shields: {
+      fork: "components.grid_git_hub_shields.fork",
+      visit_us: "components.grid_git_hub_shields.visit_us",
+    },
+    grid_supporters: {
+      impact_hub_belgrade_logo_aria_label:
+        "components.grid_supporters.impact_hub_belgrade_logo_aria_label",
+      wikimedia_de_logo_aria_label:
+        "components.grid_supporters.wikimedia_de_logo_aria_label",
+      wikimedia_rs_logo_aria_label:
+        "components.grid_supporters.wikimedia_rs_logo_aria_label",
+    },
+    header_app_page: {
+      status_pending: "components.header_app_page.status_pending",
+      under_development: "components.header_app_page.under_development",
+    },
+    header_website: {
+      support_aria_label: "components.header_website.support_aria_label",
+    },
+    icon_organization_status: {
+      approved_tooltip_hover_text:
+        "components.icon_organization_status.approved_tooltip_hover_text",
+      pending_tooltip_hover_text:
+        "components.icon_organization_status.pending_tooltip_hover_text",
+    },
+    indicator_password_strength: {
+      invalid: "components.indicator_password_strength.invalid",
+      medium: "components.indicator_password_strength.medium",
+      strong: "components.indicator_password_strength.strong",
+      title: "components.indicator_password_strength.title",
+      very_strong: "components.indicator_password_strength.very_strong",
+      very_weak: "components.indicator_password_strength.very_weak",
+      weak: "components.indicator_password_strength.weak",
+    },
+    indicator_process_progress: {
+      close_process: "components.indicator_process_progress.close_process",
+      close_process_aria_label:
+        "components.indicator_process_progress.close_process_aria_label",
+    },
+    landing_splash: {
+      header: "components.landing_splash.header",
+      message_1: "components.landing_splash.message_1",
+      message_2: "components.landing_splash.message_2",
+      request_access: "components.landing_splash.request_access",
+      request_access_aria_label:
+        "components.landing_splash.request_access_aria_label",
+      view_events: "components.landing_splash.view_events",
+      view_events_aria_label:
+        "components.landing_splash.view_events_aria_label",
+      view_organizations: "components.landing_splash.view_organizations",
+      view_organizations_aria_label:
+        "components.landing_splash.view_organizations_aria_label",
+    },
+    landing_tech_banner: {
+      open_header: "components.landing_tech_banner.open_header",
+      open_source_tagline: "components.landing_tech_banner.open_source_tagline",
+      open_source_text: "components.landing_tech_banner.open_source_text",
+    },
+    logo_activist: {
+      aria_label: "components.logo_activist.aria_label",
+    },
+    media_image_carousel: {
+      img_alt_text: "components.media_image_carousel.img_alt_text",
+    },
+    media_map: {
+      change_profile: "components.media_map.change_profile",
+      clear_directions: "components.media_map.clear_directions",
+      fullscreen: "components.media_map.fullscreen",
+      geolocate: "components.media_map.geolocate",
+      maplibre_gl_alert: "components.media_map.maplibre_gl_alert",
+      reset_north: "components.media_map.reset_north",
+      zoom_in: "components.media_map.zoom_in",
+      zoom_out: "components.media_map.zoom_out",
+    },
+    modal: {
+      edit: {
+        _global: {
+          join_organization_link:
+            "components.modal.edit._global.join_organization_link",
+          remember_https: "components.modal.edit._global.remember_https",
+          update_texts: "components.modal.edit._global.update_texts",
+          update_texts_aria_label:
+            "components.modal.edit._global.update_texts_aria_label",
+        },
+      },
+    },
+    modal_base: {
+      close_modal_aria_label: "components.modal_base.close_modal_aria_label",
+    },
+    modal_command_palette: {
+      jump_to: "components.modal_command_palette.jump_to",
+    },
+    modal_image_btn: {
+      open_modal_aria_label: "components.modal_image_btn.open_modal_aria_label",
+    },
+    modal_organization_status: {
+      status_accepted: "components.modal_organization_status.status_accepted",
+    },
+    modal_qr_code: {
+      aria_label: "components.modal_qr_code.aria_label",
+      download_qr_code: "components.modal_qr_code.download_qr_code",
+      download_qr_code_aria_label:
+        "components.modal_qr_code.download_qr_code_aria_label",
+      header: "components.modal_qr_code.header",
+      qr_code_options_aria_label:
+        "components.modal_qr_code.qr_code_options_aria_label",
+      section_1_paragraph_1_2:
+        "components.modal_qr_code.section_1_paragraph_1_2",
+      section_1_paragraph_1_event:
+        "components.modal_qr_code.section_1_paragraph_1_event",
+      section_1_paragraph_1_group:
+        "components.modal_qr_code.section_1_paragraph_1_group",
+      section_1_paragraph_1_organization:
+        "components.modal_qr_code.section_1_paragraph_1_organization",
+      section_1_paragraph_1_resource:
+        "components.modal_qr_code.section_1_paragraph_1_resource",
+      section_1_paragraph_1_user:
+        "components.modal_qr_code.section_1_paragraph_1_user",
+      section_2_list_1_item_1:
+        "components.modal_qr_code.section_2_list_1_item_1",
+      section_2_list_1_item_2:
+        "components.modal_qr_code.section_2_list_1_item_2",
+      section_2_list_1_item_3:
+        "components.modal_qr_code.section_2_list_1_item_3",
+      subheader_2: "components.modal_qr_code.subheader_2",
+      tooltip: "components.modal_qr_code.tooltip",
+    },
+    modal_qr_code_btn: {
+      img_alt_text: "components.modal_qr_code_btn.img_alt_text",
+      open_modal_aria_label:
+        "components.modal_qr_code_btn.open_modal_aria_label",
+      qr_code: "components.modal_qr_code_btn.qr_code",
+    },
+    modal_share_page: {
+      copy_link: "components.modal_share_page.copy_link",
+      facebook: "components.modal_share_page.facebook",
+      header: "components.modal_share_page.header",
+      mastodon: "components.modal_share_page.mastodon",
+      messenger: "components.modal_share_page.messenger",
+      offline: "components.modal_share_page.offline",
+      online: "components.modal_share_page.online",
+      signal: "components.modal_share_page.signal",
+      telegram: "components.modal_share_page.telegram",
+    },
+    modal_upload_images: {
+      drag_image: "components.modal_upload_images.drag_image",
+      drag_images: "components.modal_upload_images.drag_images",
+      drop_image: "components.modal_upload_images.drop_image",
+      drop_images: "components.modal_upload_images.drop_images",
+      number_of_files: "components.modal_upload_images.number_of_files",
+      picture_limit_1: "components.modal_upload_images.picture_limit_1",
+      picture_limit_multiple:
+        "components.modal_upload_images.picture_limit_multiple",
+      upload: "components.modal_upload_images.upload",
+      upload_an_image: "components.modal_upload_images.upload_an_image",
+      upload_image: "components.modal_upload_images.upload_image",
+      upload_images: "components.modal_upload_images.upload_images",
+    },
+    page_breadcrumbs: {
+      aria_label: "components.page_breadcrumbs.aria_label",
+    },
+    page_community_footer: {
+      invite_text_1: "components.page_community_footer.invite_text_1",
+      invite_text_2_1: "components.page_community_footer.invite_text_2_1",
+      invite_text_2_3: "components.page_community_footer.invite_text_2_3",
+      invite_text_3_1: "components.page_community_footer.invite_text_3_1",
+      invite_text_3_3: "components.page_community_footer.invite_text_3_3",
+      invite_text_4_2: "components.page_community_footer.invite_text_4_2",
+      invite_text_4_3: "components.page_community_footer.invite_text_4_3",
+      need_help: "components.page_community_footer.need_help",
+      need_help_text_1_1: "components.page_community_footer.need_help_text_1_1",
+      need_help_text_1_3: "components.page_community_footer.need_help_text_1_3",
+      need_help_text_2_1: "components.page_community_footer.need_help_text_2_1",
+      need_help_text_2_3: "components.page_community_footer.need_help_text_2_3",
+      visit_our: "components.page_community_footer.visit_our",
+    },
+    shield_private: {
+      private: "components.shield_private.private",
+    },
+    sidebar_left: {
+      location_search_placeholder:
+        "components.sidebar_left.location_search_placeholder",
+      orgs_search_placeholder:
+        "components.sidebar_left.orgs_search_placeholder",
+    },
+    sidebar_left_header: {
+      sidebar_collapse_aria_label:
+        "components.sidebar_left_header.sidebar_collapse_aria_label",
+    },
+    sidebar_right_hamburger: {
+      collapse_aria_label:
+        "components.sidebar_right_hamburger.collapse_aria_label",
+    },
+    tooltip_discussion_warning: {
+      email_addresses: "components.tooltip_discussion_warning.email_addresses",
+      home_addresses: "components.tooltip_discussion_warning.home_addresses",
+      names: "components.tooltip_discussion_warning.names",
+      phone_numbers: "components.tooltip_discussion_warning.phone_numbers",
+      text: "components.tooltip_discussion_warning.text",
+    },
+    tooltip_menu_search_result_event: {
+      attend: "components.tooltip_menu_search_result_event.attend",
+      attend_aria_label:
+        "components.tooltip_menu_search_result_event.attend_aria_label",
+    },
+    tooltip_menu_search_result_user: {
+      share_user: "components.tooltip_menu_search_result_user.share_user",
+      share_user_aria_label:
+        "components.tooltip_menu_search_result_user.share_user_aria_label",
+      support_user: "components.tooltip_menu_search_result_user.support_user",
+      support_user_aria_label:
+        "components.tooltip_menu_search_result_user.support_user_aria_label",
+    },
+    tooltip_password_requirements: {
+      capital_letters:
+        "components.tooltip_password_requirements.capital_letters",
+      contains_numbers:
+        "components.tooltip_password_requirements.contains_numbers",
+      contains_special_chars:
+        "components.tooltip_password_requirements.contains_special_chars",
+      lower_case_letters:
+        "components.tooltip_password_requirements.lower_case_letters",
+      number_of_chars:
+        "components.tooltip_password_requirements.number_of_chars",
+      password_rules_message:
+        "components.tooltip_password_requirements.password_rules_message",
+    },
+    tooltip_sign_in: {
+      text: "components.tooltip_sign_in.text",
+    },
+  },
+  composables: {
+    use_menu_entries_state: {
+      affiliates: "composables.use_menu_entries_state.affiliates",
+      groups: "composables.use_menu_entries_state.groups",
+    },
+  },
+  error: {
+    message: "error.message",
+    title: "error.title",
+  },
+  layouts: {
+    auth: {
+      auth: "layouts.auth.auth",
+      set_password_set_new_password:
+        "layouts.auth.set_password_set_new_password",
+      sign_in_welcome_back: "layouts.auth.sign_in_welcome_back",
+      sign_up_first_time_welcome: "layouts.auth.sign_up_first_time_welcome",
+      welcome: "layouts.auth.welcome",
+    },
+  },
+  pages: {
+    _global: {
+      create: {
+        description: "pages._global.create.description",
+        information: "pages._global.create.information",
+        link: "pages._global.create.link",
+        location: "pages._global.create.location",
+        tagline: "pages._global.create.tagline",
+      },
+      discussions_lower: "pages._global.discussions_lower",
+      new_discussion: "pages._global.new_discussion",
+      new_discussion_aria_label: "pages._global.new_discussion_aria_label",
+      resources: {
+        new_resource_aria_label:
+          "pages._global.resources.new_resource_aria_label",
+      },
+      settings: {
+        save_settings: "pages._global.settings.save_settings",
+        save_settings_aria_label:
+          "pages._global.settings.save_settings_aria_label",
+        settings_lower: "pages._global.settings.settings_lower",
+      },
+      tasks: {
+        new_task: "pages._global.tasks.new_task",
+        new_task_aria_label: "pages._global.tasks.new_task_aria_label",
+        tasks_lower: "pages._global.tasks.tasks_lower",
+        tasks_page_tagline: "pages._global.tasks.tasks_page_tagline",
+      },
+      team: {
+        invite_someone: "pages._global.team.invite_someone",
+        team_lower: "pages._global.team.team_lower",
+      },
+      terms_of_service_pt_1: "pages._global.terms_of_service_pt_1",
+      terms_of_service_pt_2: "pages._global.terms_of_service_pt_2",
+    },
+    auth: {
+      _global: {
+        enter_user_name: "pages.auth._global.enter_user_name",
+      },
+      index: {
+        where_to_start: "pages.auth.index.where_to_start",
+      },
+      reset_password: {
+        enter_username_mail: "pages.auth.reset_password.enter_username_mail",
+        index: {
+          back_to_sign_in: "pages.auth.reset_password.index.back_to_sign_in",
+          reset_password_info:
+            "pages.auth.reset_password.index.reset_password_info",
+        },
+      },
+      set_password: {
+        set_password: "pages.auth.set_password.set_password",
+      },
+      sign_in: {
+        forgot_password_captcha_tooltip:
+          "pages.auth.sign_in.forgot_password_captcha_tooltip",
+        index: {
+          no_account: "pages.auth.sign_in.index.no_account",
+        },
+      },
+      sign_up: {
+        index: {
+          enter_user_name: "pages.auth.sign_up.index.enter_user_name",
+          have_account: "pages.auth.sign_up.index.have_account",
+        },
+      },
+    },
+    contact: {
+      contact_img_alt_text: "pages.contact.contact_img_alt_text",
+      email_label: "pages.contact.email_label",
+      email_placeholder: "pages.contact.email_placeholder",
+      error_empty: "pages.contact.error_empty",
+      header: "pages.contact.header",
+      message_label: "pages.contact.message_label",
+      message_placeholder: "pages.contact.message_placeholder",
+      name: "pages.contact.name",
+      name_placeholder: "pages.contact.name_placeholder",
+      section_1_paragraph_1_1: "pages.contact.section_1_paragraph_1_1",
+      section_1_paragraph_1_3: "pages.contact.section_1_paragraph_1_3",
+      section_1_paragraph_1_5: "pages.contact.section_1_paragraph_1_5",
+      section_1_paragraph_2_1: "pages.contact.section_1_paragraph_2_1",
+      section_1_paragraph_2_2: "pages.contact.section_1_paragraph_2_2",
+      section_1_paragraph_2_3: "pages.contact.section_1_paragraph_2_3",
+      send: "pages.contact.send",
+      send_form_aria_label: "pages.contact.send_form_aria_label",
+      subheader_1: "pages.contact.subheader_1",
+      subject_label: "pages.contact.subject_label",
+      subject_placeholder: "pages.contact.subject_placeholder",
+      thanks_1: "pages.contact.thanks_1",
+      thanks_2: "pages.contact.thanks_2",
+      valid: "pages.contact.valid",
+    },
+    events: {
+      create: {
+        button_left: "pages.events.create.button_left",
+        button_right: "pages.events.create.button_right",
+        description_placeholder: "pages.events.create.description_placeholder",
+        event_type: "pages.events.create.event_type",
+        events_name: "pages.events.create.events_name",
+        events_name_placeholder: "pages.events.create.events_name_placeholder",
+        format: "pages.events.create.format",
+        format_placeholder: "pages.events.create.format_placeholder",
+        go_to_previous_page: "pages.events.create.go_to_previous_page",
+        header_1: "pages.events.create.header_1",
+        header_2: "pages.events.create.header_2",
+        link_placeholder: "pages.events.create.link_placeholder",
+        location_placeholder: "pages.events.create.location_placeholder",
+        organizer: "pages.events.create.organizer",
+        organizer_instructions: "pages.events.create.organizer_instructions",
+        organizer_placeholder: "pages.events.create.organizer_placeholder",
+        roles: "pages.events.create.roles",
+        setting: "pages.events.create.setting",
+        submit: "pages.events.create.submit",
+        submit_aria_label: "pages.events.create.submit_aria_label",
+        subtext_0: "pages.events.create.subtext_0",
+        subtext_1: "pages.events.create.subtext_1",
+        subtext_2: "pages.events.create.subtext_2",
+        tagline_placeholder: "pages.events.create.tagline_placeholder",
+      },
+      discussion: {
+        discussion_lower: "pages.events.discussion.discussion_lower",
+        tagline: "pages.events.discussion.tagline",
+      },
+      index: {
+        header_title: "pages.events.index.header_title",
+        subheader: "pages.events.index.subheader",
+      },
+      resources: {
+        tagline: "pages.events.resources.tagline",
+      },
+      search: {
+        header_title: "pages.events.search.header_title",
+        subheader: "pages.events.search.subheader",
+      },
+      settings: {
+        danger_zone_event_cta_btn_aria_label:
+          "pages.events.settings.danger_zone_event_cta_btn_aria_label",
+        danger_zone_event_cta_btn_text:
+          "pages.events.settings.danger_zone_event_cta_btn_text",
+        danger_zone_event_description:
+          "pages.events.settings.danger_zone_event_description",
+      },
+      team: {
+        invite_someone_event_aria_label:
+          "pages.events.team.invite_someone_event_aria_label",
+        tagline: "pages.events.team.tagline",
+      },
+    },
+    groups: {
+      create: {
+        create_group_aria_label: "pages.groups.create.create_group_aria_label",
+        description_placeholder: "pages.groups.create.description_placeholder",
+        group_name: "pages.groups.create.group_name",
+        group_name_placeholder: "pages.groups.create.group_name_placeholder",
+        header: "pages.groups.create.header",
+        location_placeholder: "pages.groups.create.location_placeholder",
+        subtext: "pages.groups.create.subtext",
+        tagline_placeholder: "pages.groups.create.tagline_placeholder",
+      },
+      index: {
+        header_title: "pages.groups.index.header_title",
+        subheader: "pages.groups.index.subheader",
+      },
+    },
+    home: {
+      index: {
+        header: "pages.home.index.header",
+        subheader: "pages.home.index.subheader",
+      },
+    },
+    index: {
+      about_us: "pages.index.about_us",
+      activist_section_btn_aria_label:
+        "pages.index.activist_section_btn_aria_label",
+      activist_section_tagline: "pages.index.activist_section_tagline",
+      activist_section_text: "pages.index.activist_section_text",
+      become_supporter: "pages.index.become_supporter",
+      get_active: "pages.index.get_active",
+      get_active_aria_label: "pages.index.get_active_aria_label",
+      get_active_img_alt_text: "pages.index.get_active_img_alt_text",
+      get_active_tagline: "pages.index.get_active_tagline",
+      get_active_text: "pages.index.get_active_text",
+      get_organized: "pages.index.get_organized",
+      get_organized_aria_label: "pages.index.get_organized_aria_label",
+      get_organized_img_alt_text: "pages.index.get_organized_img_alt_text",
+      get_organized_tagline: "pages.index.get_organized_tagline",
+      get_organized_text: "pages.index.get_organized_text",
+      grow_organization: "pages.index.grow_organization",
+      grow_organization_aria_label: "pages.index.grow_organization_aria_label",
+      grow_organization_header: "pages.index.grow_organization_header",
+      grow_organization_img_alt_text:
+        "pages.index.grow_organization_img_alt_text",
+      grow_organization_tagline: "pages.index.grow_organization_tagline",
+      grow_organization_text: "pages.index.grow_organization_text",
+      learn_more: "pages.index.learn_more",
+      our_supporters: "pages.index.our_supporters",
+      our_supporters_btn_become_aria_label:
+        "pages.index.our_supporters_btn_become_aria_label",
+      our_supporters_btn_view_aria_label:
+        "pages.index.our_supporters_btn_view_aria_label",
+      our_supporters_sub_text: "pages.index.our_supporters_sub_text",
+      our_supporters_tagline: "pages.index.our_supporters_tagline",
+      our_supporters_text: "pages.index.our_supporters_text",
+      title: "pages.index.title",
+      view_all_supporters: "pages.index.view_all_supporters",
+    },
+    organizations: {
+      _global: {
+        events_lower: "pages.organizations._global.events_lower",
+        events_tagline: "pages.organizations._global.events_tagline",
+        faq_tagline: "pages.organizations._global.faq_tagline",
+        resources_tagline: "pages.organizations._global.resources_tagline",
+      },
+      affiliates: {
+        affiliates_lower: "pages.organizations.affiliates.affiliates_lower",
+        tagline: "pages.organizations.affiliates.tagline",
+      },
+      create: {
+        complete_application: "pages.organizations.create.complete_application",
+        description_placeholder:
+          "pages.organizations.create.description_placeholder",
+        header: "pages.organizations.create.header",
+        location_placeholder: "pages.organizations.create.location_placeholder",
+        organization_name_placeholder:
+          "pages.organizations.create.organization_name_placeholder",
+        subtext: "pages.organizations.create.subtext",
+        tagline_placeholder: "pages.organizations.create.tagline_placeholder",
+      },
+      discussions: {
+        index: {
+          tagline: "pages.organizations.discussions.index.tagline",
+        },
+      },
+      events: {
+        new_event_aria_label: "pages.organizations.events.new_event_aria_label",
+      },
+      faq: {
+        new_faq: "pages.organizations.faq.new_faq",
+        new_faq_aria_label: "pages.organizations.faq.new_faq_aria_label",
+      },
+      groups: {
+        _global: {
+          support_group_aria_label:
+            "pages.organizations.groups._global.support_group_aria_label",
+        },
+        about: {
+          share_group: "pages.organizations.groups.about.share_group",
+          share_group_aria_label:
+            "pages.organizations.groups.about.share_group_aria_label",
+        },
+        index: {
+          groups_lower: "pages.organizations.groups.index.groups_lower",
+          new_group_aria_label:
+            "pages.organizations.groups.index.new_group_aria_label",
+          tagline: "pages.organizations.groups.index.tagline",
+        },
+      },
+      index: {
+        header_title: "pages.organizations.index.header_title",
+        subheader: "pages.organizations.index.subheader",
+      },
+      search: {
+        header_title: "pages.organizations.search.header_title",
+        subheader: "pages.organizations.search.subheader",
+      },
+      settings: {
+        danger_zone_delete_organization_cta:
+          "pages.organizations.settings.danger_zone_delete_organization_cta",
+        danger_zone_delete_organization_cta_aria_label:
+          "pages.organizations.settings.danger_zone_delete_organization_cta_aria_label",
+        danger_zone_delete_organization_text:
+          "pages.organizations.settings.danger_zone_delete_organization_text",
+      },
+      team: {
+        invite_someone_org_aria_label:
+          "pages.organizations.team.invite_someone_org_aria_label",
+        tagline: "pages.organizations.team.tagline",
+      },
+    },
+    resources: {
+      create: {
+        complete_application_aria_label:
+          "pages.resources.create.complete_application_aria_label",
+        create_resource: "pages.resources.create.create_resource",
+        description: "pages.resources.create.description",
+        description_placeholder:
+          "pages.resources.create.description_placeholder",
+        link_placeholder: "pages.resources.create.link_placeholder",
+        location_placeholder: "pages.resources.create.location_placeholder",
+        organization_placeholder:
+          "pages.resources.create.organization_placeholder",
+        resource_name_placeholder:
+          "pages.resources.create.resource_name_placeholder",
+        subtext: "pages.resources.create.subtext",
+        title: "pages.resources.create.title",
+      },
+      index: {
+        header_title: "pages.resources.index.header_title",
+        subheader: "pages.resources.index.subheader",
+      },
+    },
+    search: {
+      index: {
+        header: "pages.search.index.header",
+        subheader: "pages.search.index.subheader",
+      },
+    },
+  },
+  types: {
+    command_palette: {
+      upcoming_events: "types.command_palette.upcoming_events",
+    },
+    topics: {
+      accessibility: "types.topics.accessibility",
+      animal_rights: "types.topics.animal_rights",
+      children_rights: "types.topics.children_rights",
+      democracy: "types.topics.democracy",
+      education: "types.topics.education",
+      elders: "types.topics.elders",
+      emergency_relief: "types.topics.emergency_relief",
+      environment: "types.topics.environment",
+      expression: "types.topics.expression",
+      health: "types.topics.health",
+      housing: "types.topics.housing",
+      labor: "types.topics.labor",
+      lgbtqia: "types.topics.lgbtqia",
+      migration: "types.topics.migration",
+      mobility: "types.topics.mobility",
+      nutrition: "types.topics.nutrition",
+      peace_resolution: "types.topics.peace_resolution",
+      racial_justice: "types.topics.racial_justice",
+      technology_privacy: "types.topics.technology_privacy",
+      transparency: "types.topics.transparency",
+      women: "types.topics.women",
+    },
+  },
+};


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR is the final part of the planned functionality of `i18n-check`, with these commits being added to the [i18n-check](https://github.com/activist-org/i18n-check) repo. Specifically we discussed the potential to load all i18n keys into a generated map object that would then type check all use cases of the keys to make sure that none are misspelled. This is of particular importance for aria labels where the key being misspelled will not be evident to the development team.

Once this is merged a new issue will be opened to switch all keys over to the `i18nMap` object. As of now it's only used in the search bar component for the word `Search`.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #546
