### PR TITLE
Feat/add named colors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,7 +427,6 @@ In order to test locally, you need to build the production version of the fronte
 In a second shell:
 
 ```bash
-# In the root activist directory:
 cd frontend
 
 # Set the environment variables:
@@ -444,6 +443,8 @@ node .output/server/index.mjs  # start the frontend
 In a third shell:
 
 ```bash
+cd frontend
+
 yarn test:local
 
 # If tests don't pass, then as prompted run the following to see the HTML report:

--- a/frontend/assets/css/tailwind.css
+++ b/frontend/assets/css/tailwind.css
@@ -27,10 +27,10 @@
   --learn-blue: 33, 118, 174;
   --accepted-green: 62, 137, 20;
   --warn-yellow: 255, 191, 0;
-  --password-vweak: 204, 102, 102;
-  --password-weak: 230, 145, 56;
-  --password-medium: 241, 194, 50;
-  --password-strong: 106, 168, 79;
+  --password-strength-very-weak: 204, 102, 102;
+  --password-strength-weak: 230, 145, 56;
+  --password-strength-medium: 241, 194, 50;
+  --password-strength-strong: 106, 168, 79;
 }
 
 .dark {
@@ -54,10 +54,10 @@
   --learn-blue: 62, 146, 204;
   --accepted-green: 97, 139, 37;
   --warn-yellow: 255, 209, 102;
-  --password-vweak: 224, 102, 102;
-  --password-weak: 246, 178, 107;
-  --password-medium: 255, 217, 102;
-  --password-strong: 147, 196, 125;
+  --password-strength-very-weak: 224, 102, 102;
+  --password-strength-weak: 246, 178, 107;
+  --password-strength-medium: 255, 217, 102;
+  --password-strength-strong: 147, 196, 125;
 }
 
 @layer base {

--- a/frontend/assets/css/tailwind.css
+++ b/frontend/assets/css/tailwind.css
@@ -27,7 +27,7 @@
   --learn-blue: 33, 118, 174;
   --accepted-green: 62, 137, 20;
   --warn-yellow: 255, 191, 0;
-  --password-very-weak: 204, 102, 102;
+  --password-vweak: 204, 102, 102;
   --password-weak: 230, 145, 56;
   --password-medium: 241, 194, 50;
   --password-strong: 106, 168, 79;
@@ -54,7 +54,7 @@
   --learn-blue: 62, 146, 204;
   --accepted-green: 97, 139, 37;
   --warn-yellow: 255, 209, 102;
-  --password-very-weak: 224, 102, 102;
+  --password-vweak: 224, 102, 102;
   --password-weak: 246, 178, 107;
   --password-medium: 255, 217, 102;
   --password-strong: 147, 196, 125;

--- a/frontend/assets/css/tailwind.css
+++ b/frontend/assets/css/tailwind.css
@@ -27,6 +27,10 @@
   --learn-blue: 33, 118, 174;
   --accepted-green: 62, 137, 20;
   --warn-yellow: 255, 191, 0;
+  --password-very-weak: 204, 102, 102;
+  --password-weak: 230, 145, 56;
+  --password-medium: 241, 194, 50;
+  --password-strong: 106, 168, 79;
 }
 
 .dark {
@@ -50,6 +54,10 @@
   --learn-blue: 62, 146, 204;
   --accepted-green: 97, 139, 37;
   --warn-yellow: 255, 209, 102;
+  --password-very-weak: 224, 102, 102;
+  --password-weak: 246, 178, 107;
+  --password-medium: 255, 217, 102;
+  --password-strong: 147, 196, 125;
 }
 
 @layer base {

--- a/frontend/components/indicator/IndicatorPasswordStrength.vue
+++ b/frontend/components/indicator/IndicatorPasswordStrength.vue
@@ -46,19 +46,19 @@ const text = computed(() => passwordStrengthMap[score.value].text);
 
 const passwordStrengthMap: Record<number, { color: string; text: string }> = {
   0: {
-    color: "bg-[#cc0000] dark:bg-[#e06666]",
+    color: "bg-[rgba(var(--password-vweak))] dark:bg-[rgba(var(--password-vweak))]",
     text: "components.indicator_password_strength.very_weak",
   },
   1: {
-    color: "bg-[#e69138] dark:bg-[#f6b26b]",
+    color: "bg-[rgba(var(--password-weak))] dark:bg-[rgba(var(--password-weak))]",
     text: "components.indicator_password_strength.weak",
   },
   2: {
-    color: "bg-[#f1c232] dark:bg-[#ffd966]",
+    color: "bg-[rgba(var(--password-medium))] dark:bg-[rgba(var(--password-medium))]",
     text: "components.indicator_password_strength.medium",
   },
   3: {
-    color: "bg-[#6aa84f] dark:bg-[#93c47d]",
+    color: "bg-[rgba(var(--password-strong))] dark:bg-[rgba(var(--password-strong))]",
     text: "components.indicator_password_strength.strong",
   },
   4: {

--- a/frontend/components/indicator/IndicatorPasswordStrength.vue
+++ b/frontend/components/indicator/IndicatorPasswordStrength.vue
@@ -46,23 +46,19 @@ const text = computed(() => passwordStrengthMap[score.value].text);
 
 const passwordStrengthMap: Record<number, { color: string; text: string }> = {
   0: {
-    color:
-      "bg-[rgba(var(--password-vweak))] dark:bg-[rgba(var(--password-vweak))]",
+    color: "bg-password-strength-very-weak",
     text: "components.indicator_password_strength.very_weak",
   },
   1: {
-    color:
-      "bg-[rgba(var(--password-weak))] dark:bg-[rgba(var(--password-weak))]",
+    color: "bg-password-strength-weak",
     text: "components.indicator_password_strength.weak",
   },
   2: {
-    color:
-      "bg-[rgba(var(--password-medium))] dark:bg-[rgba(var(--password-medium))]",
+    color: "bg-password-strength-medium",
     text: "components.indicator_password_strength.medium",
   },
   3: {
-    color:
-      "bg-[rgba(var(--password-strong))] dark:bg-[rgba(var(--password-strong))]",
+    color: "bg-password-strength-strong",
     text: "components.indicator_password_strength.strong",
   },
   4: {

--- a/frontend/components/indicator/IndicatorPasswordStrength.vue
+++ b/frontend/components/indicator/IndicatorPasswordStrength.vue
@@ -46,19 +46,23 @@ const text = computed(() => passwordStrengthMap[score.value].text);
 
 const passwordStrengthMap: Record<number, { color: string; text: string }> = {
   0: {
-    color: "bg-[rgba(var(--password-vweak))] dark:bg-[rgba(var(--password-vweak))]",
+    color:
+      "bg-[rgba(var(--password-vweak))] dark:bg-[rgba(var(--password-vweak))]",
     text: "components.indicator_password_strength.very_weak",
   },
   1: {
-    color: "bg-[rgba(var(--password-weak))] dark:bg-[rgba(var(--password-weak))]",
+    color:
+      "bg-[rgba(var(--password-weak))] dark:bg-[rgba(var(--password-weak))]",
     text: "components.indicator_password_strength.weak",
   },
   2: {
-    color: "bg-[rgba(var(--password-medium))] dark:bg-[rgba(var(--password-medium))]",
+    color:
+      "bg-[rgba(var(--password-medium))] dark:bg-[rgba(var(--password-medium))]",
     text: "components.indicator_password_strength.medium",
   },
   3: {
-    color: "bg-[rgba(var(--password-strong))] dark:bg-[rgba(var(--password-strong))]",
+    color:
+      "bg-[rgba(var(--password-strong))] dark:bg-[rgba(var(--password-strong))]",
     text: "components.indicator_password_strength.strong",
   },
   4: {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -42,10 +42,11 @@ export default <Partial<Config>>{
         "learn-blue": "rgba(var(--learn-blue))",
         "accepted-green": "rgba(var(--accepted-green))",
         "warn-yellow": "rgba(var(--warn-yellow))",
-        "password-vweak": "rgba(var(--password-vweak))",
-        "password-weak": "rgba(var(--password-weak))",
-        "password-medium": "rgba(var(--password-medium))",
-        "password-strong": "rgba(var(--password-strong))",
+        "password-strength-very-weak":
+          "rgba(var(--password-strength-very-weak))",
+        "password-strength-weak": "rgba(var(--password-strength-weak))",
+        "password-strength-medium": "rgba(var(--password-strength-medium))",
+        "password-strength-strong": "rgba(var(--password-strength-strong))",
       },
       transitionProperty: {
         width: "width",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -42,6 +42,10 @@ export default <Partial<Config>>{
         "learn-blue": "rgba(var(--learn-blue))",
         "accepted-green": "rgba(var(--accepted-green))",
         "warn-yellow": "rgba(var(--warn-yellow))",
+        "password-very-weak": "rgba(var(--password-very-weak))",
+        "password-weak": "rgba(var(--password-weak))",
+        "password-medium": "rgba(var(--password-medium))",
+        "password-strong": "rgba(var(--password-strong))",
       },
       transitionProperty: {
         width: "width",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -42,7 +42,7 @@ export default <Partial<Config>>{
         "learn-blue": "rgba(var(--learn-blue))",
         "accepted-green": "rgba(var(--accepted-green))",
         "warn-yellow": "rgba(var(--warn-yellow))",
-        "password-very-weak": "rgba(var(--password-very-weak))",
+        "password-vweak": "rgba(var(--password-vweak))",
         "password-weak": "rgba(var(--password-weak))",
         "password-medium": "rgba(var(--password-medium))",
         "password-strong": "rgba(var(--password-strong))",

--- a/frontend/test-e2e/component-objects/PasswordStrength.ts
+++ b/frontend/test-e2e/component-objects/PasswordStrength.ts
@@ -21,10 +21,10 @@ export const PASSWORD_PROGRESS = {
 
 export const PASSWORD_STRENGTH_COLOR: Record<string, RegExp | ""> = {
   NONE: "",
-  RED: /bg-\[rgba(var(--password-very-weak))\] dark:bg-\[rgba(var(--password-very-weak))\]/,
-  ORANGE: /bg-[rgba(var(--password-weak))] dark:bg-[rgba(var(--password-weak))]/,
-  YELLOW: /bg-[rgba(var(--password-medium))] dark:bg-[rgba(var(--password-medium))]/,
-  GREEN: /bg-[rgba(var(--password-strong))] dark:bg-[rgba(var(--password-strong))]/,
+  RED: /bg-\[rgba\(var\(--password-vweak\)\)\] dark:bg-\[rgba\(var\(--password-vweak\)\)\]/,
+  ORANGE: /bg-\[rgba\(var\(--password-weak\)\)\] dark:bg-\[rgba\(var\(--password-weak\)\)\]/,
+  YELLOW: /bg-\[rgba\(var\(--password-medium\)\)\] dark:bg-\[rgba\(var\(--password-medium\)\)\]/,
+  GREEN: /bg-\[rgba\(var\(--password-strong\)\)\] dark:bg-\[rgba\(var\(--password-strong\)\)\]/,
   PRIMARY_TEXT: /bg-primary-text/,
 };
 

--- a/frontend/test-e2e/component-objects/PasswordStrength.ts
+++ b/frontend/test-e2e/component-objects/PasswordStrength.ts
@@ -22,9 +22,12 @@ export const PASSWORD_PROGRESS = {
 export const PASSWORD_STRENGTH_COLOR: Record<string, RegExp | ""> = {
   NONE: "",
   RED: /bg-\[rgba\(var\(--password-vweak\)\)\] dark:bg-\[rgba\(var\(--password-vweak\)\)\]/,
-  ORANGE: /bg-\[rgba\(var\(--password-weak\)\)\] dark:bg-\[rgba\(var\(--password-weak\)\)\]/,
-  YELLOW: /bg-\[rgba\(var\(--password-medium\)\)\] dark:bg-\[rgba\(var\(--password-medium\)\)\]/,
-  GREEN: /bg-\[rgba\(var\(--password-strong\)\)\] dark:bg-\[rgba\(var\(--password-strong\)\)\]/,
+  ORANGE:
+    /bg-\[rgba\(var\(--password-weak\)\)\] dark:bg-\[rgba\(var\(--password-weak\)\)\]/,
+  YELLOW:
+    /bg-\[rgba\(var\(--password-medium\)\)\] dark:bg-\[rgba\(var\(--password-medium\)\)\]/,
+  GREEN:
+    /bg-\[rgba\(var\(--password-strong\)\)\] dark:bg-\[rgba\(var\(--password-strong\)\)\]/,
   PRIMARY_TEXT: /bg-primary-text/,
 };
 

--- a/frontend/test-e2e/component-objects/PasswordStrength.ts
+++ b/frontend/test-e2e/component-objects/PasswordStrength.ts
@@ -21,13 +21,10 @@ export const PASSWORD_PROGRESS = {
 
 export const PASSWORD_STRENGTH_COLOR: Record<string, RegExp | ""> = {
   NONE: "",
-  RED: /bg-\[rgba\(var\(--password-vweak\)\)\] dark:bg-\[rgba\(var\(--password-vweak\)\)\]/,
-  ORANGE:
-    /bg-\[rgba\(var\(--password-weak\)\)\] dark:bg-\[rgba\(var\(--password-weak\)\)\]/,
-  YELLOW:
-    /bg-\[rgba\(var\(--password-medium\)\)\] dark:bg-\[rgba\(var\(--password-medium\)\)\]/,
-  GREEN:
-    /bg-\[rgba\(var\(--password-strong\)\)\] dark:bg-\[rgba\(var\(--password-strong\)\)\]/,
+  RED: /bg-password-strength-very-weak/,
+  ORANGE: /bg-password-strength-weak/,
+  YELLOW: /bg-password-strength-medium/,
+  GREEN: /bg-password-strength-strong/,
   PRIMARY_TEXT: /bg-primary-text/,
 };
 

--- a/frontend/test-e2e/component-objects/PasswordStrength.ts
+++ b/frontend/test-e2e/component-objects/PasswordStrength.ts
@@ -21,10 +21,10 @@ export const PASSWORD_PROGRESS = {
 
 export const PASSWORD_STRENGTH_COLOR: Record<string, RegExp | ""> = {
   NONE: "",
-  RED: /bg-\[#cc0000] dark:bg-\[#e06666]/,
-  ORANGE: /bg-\[#e69138] dark:bg-\[#f6b26b]/,
-  YELLOW: /bg-\[#f1c232] dark:bg-\[#ffd966]/,
-  GREEN: /bg-\[#6aa84f] dark:bg-\[#93c47d]/,
+  RED: /bg-[rgba(var(--password-very-weak))] dark:bg-[rgba(var(--password-very-weak))]/,
+  ORANGE: /bg-[rgba(var(--password-weak))] dark:bg-[rgba(var(--password-weak))]/,
+  YELLOW: /bg-[rgba(var(--password-medium))] dark:bg-[rgba(var(--password-medium))]/,
+  GREEN: /bg-[rgba(var(--password-strong))] dark:bg-[rgba(var(--password-strong))]/,
   PRIMARY_TEXT: /bg-primary-text/,
 };
 

--- a/frontend/test-e2e/component-objects/PasswordStrength.ts
+++ b/frontend/test-e2e/component-objects/PasswordStrength.ts
@@ -21,7 +21,7 @@ export const PASSWORD_PROGRESS = {
 
 export const PASSWORD_STRENGTH_COLOR: Record<string, RegExp | ""> = {
   NONE: "",
-  RED: /bg-[rgba(var(--password-very-weak))] dark:bg-[rgba(var(--password-very-weak))]/,
+  RED: /bg-\[rgba(var(--password-very-weak))\] dark:bg-\[rgba(var(--password-very-weak))\]/,
   ORANGE: /bg-[rgba(var(--password-weak))] dark:bg-[rgba(var(--password-weak))]/,
   YELLOW: /bg-[rgba(var(--password-medium))] dark:bg-[rgba(var(--password-medium))]/,
   GREEN: /bg-[rgba(var(--password-strong))] dark:bg-[rgba(var(--password-strong))]/,


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description
This pull request implements two changes : 
- Handling Password Strength indicator colors via CSS-named colors declared in frontend/assets/css/tailwind.css
- Modification of the end-to-end tests so that the test named "Page shows user password strength rating" (frontend/test-e2e/specs/all/sign-in-page.specs.ts) checks the webpage against the named colors instead of the hardcoded hex colors. 

This was put through the whole test process documented in the CONTRIBUTING.md file. The End2End tests were performed locally and it is important to note that **some tests failed (tests on aspects not modified in this PR).** Here are the tests that failed : 

- Sign-in page : Page shows error for invalid credentials > The screenshot given by the playwright report shows a user logged-in page so I would expect this to be a db / backend issue in my configuration which has nothing to do with the changes implemented in this PR.

- Landing Page : User can request access > **No modification to the landing page was done.**
```
Error: Timed out 5000ms waiting for expect(locator).toHaveAttribute(expected)

Locator: locator('#request-access')
Expected pattern: /^https:\/\/forms.activist.org\/s\/.*$/
Received: <element(s) not found>
Call log:
  - expect.toHaveAttribute with timeout 5000ms
  - waiting for locator('#request-access')


  > 18 |   test("User can request access", async ({ page }) => {
  > 19 |     const requestAccessLink = page.locator("#request-access");
  > 20 |     await expect(requestAccessLink).toHaveAttribute(
  >    |                     ^
  > 21 |       "href",
  > 22 |       /^https:\/\/forms.activist.org\/s\/.*$/
  > 23 |     );
at D:\OSS\activist\frontend\test-e2e\specs\all\landing-page.spec.ts:20:37
```
- Landing Page : User can change theme (Samsung Mobile) > **No modification to the landing page was done.**

It is also important to note that the 'yarn format' command for Prettier did not modify any file and gave some warnings. Using yarn format --write modified all files from CRLF to LF. Another commit for linting to transition from CRLF to LF can be added if requested.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1101
