### PR TITLE
refactor(i18n): standardize localization key references across components

### DIFF
--- a/frontend/components/EmptyState.vue
+++ b/frontend/components/EmptyState.vue
@@ -3,7 +3,7 @@
   <div class="flex w-full flex-col items-center bg-layer-0 text-primary-text">
     <PageContent
       :imgUrl="BOOTSTRAP_CLOUD_MOON_URL"
-      imgAltText="components.empty_state.img_alt_text"
+      :imgAltText="i18nMap.components.empty_state.img_alt_text"
     >
       <div>
         <!-- Header -->
@@ -40,7 +40,7 @@
             $t(i18nMap.components.empty_state.message_no_permission)
           }}</span>
           <PageCommunityFooter
-            header="components.empty_state.cta_header_no_permission"
+            :header="i18nMap.components.empty_state.cta_header_no_permission"
             ><BtnRouteInternal
               class="w-full"
               :cta="false"
@@ -61,49 +61,57 @@
               v-if="pageType == 'organizations'"
               class="w-full"
               :cta="true"
-              label="i18n.components.empty_state.create_organization"
+              :label="i18nMap.components.empty_state.create_organization"
               linkTo="/organizations/create"
               fontSize="lg"
-              ariaLabel="i18n.components.empty_state.create_organization_aria_label"
+              :ariaLabel="
+                i18nMap.components.empty_state.create_organization_aria_label
+              "
             />
             <BtnRouteInternal
               v-if="pageType == 'groups'"
               class="w-full"
               :cta="true"
-              label="i18n._global.create_group"
+              :label="i18nMap._global.create_group"
               linkTo="/groups/create"
               fontSize="lg"
-              ariaLabel="i18n.components.empty_state.create_group_aria_label"
+              :ariaLabel="
+                i18nMap.components.empty_state.create_group_aria_label
+              "
             />
             <BtnRouteInternal
               v-if="pageType == 'events'"
               class="w-full"
               :cta="true"
-              label="i18n.components.empty_state.create_event"
+              :label="i18nMap.components.empty_state.create_event"
               linkTo="/events/create"
               fontSize="lg"
-              ariaLabel="i18n.components.empty_state.create_event_aria_label"
+              :ariaLabel="
+                i18nMap.components.empty_state.create_event_aria_label
+              "
             />
             <BtnRouteInternal
               v-if="pageType == 'resources'"
               class="w-full"
               :cta="true"
-              label="i18n.components.btn_route_internal.create_resource"
+              :label="i18nMap.components.btn_route_internal.create_resource"
               linkTo="/resources/create"
               fontSize="lg"
-              ariaLabel="i18n.components.empty_state.create_resource_aria_label"
+              :ariaLabel="
+                i18nMap.components.empty_state.create_resource_aria_label
+              "
             />
           </div>
           <PageCommunityFooter
-            header="components.empty_state.cta_header_no_permission"
+            :header="i18nMap.components.empty_state.cta_header_no_permission"
             :helpNeeded="true"
             ><BtnRouteInternal
               class="w-full"
               :cta="false"
-              label="i18n._global.return_home"
+              :label="i18nMap._global.return_home"
               linkTo="/home"
               fontSize="lg"
-              ariaLabel="i18n._global.return_home_aria_label"
+              :ariaLabel="i18nMap._global.return_home_aria_label"
           /></PageCommunityFooter>
         </div>
       </div>

--- a/frontend/components/EmptyState.vue
+++ b/frontend/components/EmptyState.vue
@@ -61,37 +61,37 @@
               v-if="pageType == 'organizations'"
               class="w-full"
               :cta="true"
-              label="components.empty_state.create_organization"
+              label="i18n.components.empty_state.create_organization"
               linkTo="/organizations/create"
               fontSize="lg"
-              ariaLabel="components.empty_state.create_organization_aria_label"
+              ariaLabel="i18n.components.empty_state.create_organization_aria_label"
             />
             <BtnRouteInternal
               v-if="pageType == 'groups'"
               class="w-full"
               :cta="true"
-              label="_global.create_group"
+              label="i18n._global.create_group"
               linkTo="/groups/create"
               fontSize="lg"
-              ariaLabel="components.empty_state.create_group_aria_label"
+              ariaLabel="i18n.components.empty_state.create_group_aria_label"
             />
             <BtnRouteInternal
               v-if="pageType == 'events'"
               class="w-full"
               :cta="true"
-              label="components.empty_state.create_event"
+              label="i18n.components.empty_state.create_event"
               linkTo="/events/create"
               fontSize="lg"
-              ariaLabel="components.empty_state.create_event_aria_label"
+              ariaLabel="i18n.components.empty_state.create_event_aria_label"
             />
             <BtnRouteInternal
               v-if="pageType == 'resources'"
               class="w-full"
               :cta="true"
-              label="components.btn_route_internal.create_resource"
+              label="i18n.components.btn_route_internal.create_resource"
               linkTo="/resources/create"
               fontSize="lg"
-              ariaLabel="components.empty_state.create_resource_aria_label"
+              ariaLabel="i18n.components.empty_state.create_resource_aria_label"
             />
           </div>
           <PageCommunityFooter
@@ -100,10 +100,10 @@
             ><BtnRouteInternal
               class="w-full"
               :cta="false"
-              label="_global.return_home"
+              label="i18n._global.return_home"
               linkTo="/home"
               fontSize="lg"
-              ariaLabel="_global.return_home_aria_label"
+              ariaLabel="i18n._global.return_home_aria_label"
           /></PageCommunityFooter>
         </div>
       </div>

--- a/frontend/components/card/get-involved/CardGetInvolvedOrganization.vue
+++ b/frontend/components/card/get-involved/CardGetInvolvedOrganization.vue
@@ -17,19 +17,24 @@
           v-if="organization.groups && organization.groups.length > 0"
           :cta="true"
           :linkTo="'/organizations/' + id + '/groups'"
-          label="i18n.components.card_get_involved_organization.view_all_groups"
+          :label="
+            i18nMap.components.card_get_involved_organization.view_all_groups
+          "
           fontSize="sm"
-          ariaLabel="i18n.components.card_get_involved_organization.view_all_groups_aria_label"
+          :ariaLabel="
+            i18nMap.components.card_get_involved_organization
+              .view_all_groups_aria_label
+          "
         />
         <BtnRouteInternal
           v-if="organization && organization.getInvolvedUrl"
           :cta="true"
           :linkTo="organization.getInvolvedUrl"
-          label="i18n._global.join_organization"
+          :label="i18nMap._global.join_organization"
           fontSize="sm"
           :rightIcon="IconMap.ARROW_RIGHT"
           iconSize="1.45em"
-          ariaLabel="i18n._global.join_organization_aria_label"
+          :ariaLabel="i18nMap._global.join_organization_aria_label"
         />
       </div>
     </div>

--- a/frontend/components/card/get-involved/CardGetInvolvedOrganization.vue
+++ b/frontend/components/card/get-involved/CardGetInvolvedOrganization.vue
@@ -17,19 +17,19 @@
           v-if="organization.groups && organization.groups.length > 0"
           :cta="true"
           :linkTo="'/organizations/' + id + '/groups'"
-          label="components.card_get_involved_organization.view_all_groups"
+          label="i18n.components.card_get_involved_organization.view_all_groups"
           fontSize="sm"
-          ariaLabel="components.card_get_involved_organization.view_all_groups_aria_label"
+          ariaLabel="i18n.components.card_get_involved_organization.view_all_groups_aria_label"
         />
         <BtnRouteInternal
           v-if="organization && organization.getInvolvedUrl"
           :cta="true"
           :linkTo="organization.getInvolvedUrl"
-          label="_global.join_organization"
+          label="i18n._global.join_organization"
           fontSize="sm"
           :rightIcon="IconMap.ARROW_RIGHT"
           iconSize="1.45em"
-          ariaLabel="_global.join_organization_aria_label"
+          ariaLabel="i18n._global.join_organization_aria_label"
         />
       </div>
     </div>

--- a/frontend/components/card/search-result/CardSearchResult.vue
+++ b/frontend/components/card/search-result/CardSearchResult.vue
@@ -255,15 +255,23 @@ const { linkUrl } = useLinkURL(props);
 
 const ariaLabel = computed<string>(() => {
   if (props.organization) {
-    return i18n.t(i18nMap.components._global.navigate_to_organization_aria_label);
+    return i18n.t(
+      i18nMap.components._global.navigate_to_organization_aria_label
+    );
   } else if (props.group) {
     return i18n.t(i18nMap.components._global.navigate_to_group_aria_label);
   } else if (props.event) {
-    return i18n.t(i18nMap.components.card_search_result.navigate_to_event_aria_label);
+    return i18n.t(
+      i18nMap.components.card_search_result.navigate_to_event_aria_label
+    );
   } else if (props.resource) {
-    return i18n.t(i18nMap.components.card_search_result.navigate_to_resource_aria_label);
+    return i18n.t(
+      i18nMap.components.card_search_result.navigate_to_resource_aria_label
+    );
   } else if (props.user) {
-    return i18n.t(i18nMap.components.card_search_result.navigate_to_user_aria_label);
+    return i18n.t(
+      i18nMap.components.card_search_result.navigate_to_user_aria_label
+    );
   } else {
     return "";
   }

--- a/frontend/components/card/search-result/CardSearchResult.vue
+++ b/frontend/components/card/search-result/CardSearchResult.vue
@@ -255,17 +255,15 @@ const { linkUrl } = useLinkURL(props);
 
 const ariaLabel = computed<string>(() => {
   if (props.organization) {
-    return i18n.t("components._global.navigate_to_organization_aria_label");
+    return i18n.t(i18nMap.components._global.navigate_to_organization_aria_label);
   } else if (props.group) {
-    return i18n.t("components._global.navigate_to_group_aria_label");
+    return i18n.t(i18nMap.components._global.navigate_to_group_aria_label);
   } else if (props.event) {
-    return i18n.t("components.card_search_result.navigate_to_event_aria_label");
+    return i18n.t(i18nMap.components.card_search_result.navigate_to_event_aria_label);
   } else if (props.resource) {
-    return i18n.t(
-      "components.card_search_result.navigate_to_resource_aria_label"
-    );
+    return i18n.t(i18nMap.components.card_search_result.navigate_to_resource_aria_label);
   } else if (props.user) {
-    return i18n.t("components.card_search_result.navigate_to_user_aria_label");
+    return i18n.t(i18nMap.components.card_search_result.navigate_to_user_aria_label);
   } else {
     return "";
   }

--- a/frontend/components/combobox/ComboboxTopics.vue
+++ b/frontend/components/combobox/ComboboxTopics.vue
@@ -119,7 +119,7 @@ function displayValue() {
     return "";
   } else {
     return selectedTopic.value.id == 1
-      ? "Filter by topic"
+      ? i18n.t(i18nMap.components.combobox_topics.filter_by_topic)
       : selectedTopic.value.name;
   }
 }

--- a/frontend/components/icon/IconOrganizationStatus.vue
+++ b/frontend/components/icon/IconOrganizationStatus.vue
@@ -59,9 +59,13 @@
       <TooltipBase
         class="invisible -ml-32 mt-3 max-w-56 md:-ml-36 md:max-w-96"
         :text="
-          $t('components.icon_organization_status.pending_tooltip_hover_text', {
-            entity_name: organization.name,
-          })
+          $t(
+            i18nMap.components.icon_organization_status
+              .pending_tooltip_hover_text,
+            {
+              entity_name: organization.name,
+            }
+          )
         "
       />
     </div>
@@ -69,6 +73,7 @@
 </template>
 
 <script setup lang="ts">
+import { i18nMap } from "~/types/i18n-map";
 import type { Organization } from "~/types/communities/organization";
 
 defineProps<{

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -13,6 +13,7 @@ import MapLibreGlDirections, {
 import maplibregl, { type Map } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import type { Location } from "~/types/content/location";
+import { i18nMap } from "~/types/i18n-map";
 
 const props = defineProps<{
   markerColors: string[];
@@ -93,7 +94,7 @@ const routeProfileMap: RouteProfile[] = [
 
 const walkingRouteProfileControl = `
   <div
-    title="${i18n.t("components.media_map.change_profile")}"
+    title="${i18n.t(i18nMap.components.media_map.change_profile)}"
     id=${routeProfileOptions.FOOT}
     style="
     background-image: url(${walkDirectionsIcon});
@@ -109,7 +110,7 @@ const walkingRouteProfileControl = `
 
 const bikeRouteProfileControl = `
   <div
-    title="${i18n.t("components.media_map.change_profile")}"
+    title="${i18n.t(i18nMap.components.media_map.change_profile)}"
     id=${routeProfileOptions.BIKE}
     style="
     background-image: url(${bikeDirectionsIcon});
@@ -161,7 +162,7 @@ const setSelectedRoute = () => {
 
 onMounted(() => {
   if (!isWebglSupported()) {
-    alert(i18n.t("components.media_map.maplibre_gl_alert"));
+    alert(i18n.t(i18nMap.components.media_map.maplibre_gl_alert));
   } else {
     const map = new maplibregl.Map({
       container: "map",
@@ -248,19 +249,19 @@ onMounted(() => {
       .getContainer()
       .querySelector(".maplibregl-ctrl-zoom-in");
     if (zoomInButton)
-      zoomInButton.title = i18n.t("components.media_map.zoom_in");
+      zoomInButton.title = i18n.t(i18nMap.components.media_map.zoom_in);
 
     const zoomOutButton: HTMLElement | null = map
       .getContainer()
       .querySelector(".maplibregl-ctrl-zoom-out");
     if (zoomOutButton)
-      zoomOutButton.title = i18n.t("components.media_map.zoom_out");
+      zoomOutButton.title = i18n.t(i18nMap.components.media_map.zoom_out);
 
     const compassButton: HTMLElement | null = map
       .getContainer()
       .querySelector(".maplibregl-ctrl-compass");
     if (compassButton)
-      compassButton.title = i18n.t("components.media_map.reset_north");
+      compassButton.title = i18n.t(i18nMap.components.media_map.reset_north);
 
     // Localize FullscreenControl
     const fullscreenControl = new maplibregl.FullscreenControl();
@@ -270,7 +271,7 @@ onMounted(() => {
       .getContainer()
       .querySelector(".maplibregl-ctrl-fullscreen");
     if (fullscreenButton)
-      fullscreenButton.title = i18n.t("components.media_map.fullscreen");
+      fullscreenButton.title = i18n.t(i18nMap.components.media_map.fullscreen);
 
     // Localize GeolocateControl
     const geolocateControl = new maplibregl.GeolocateControl({
@@ -285,7 +286,7 @@ onMounted(() => {
       .getContainer()
       .querySelector(".maplibregl-ctrl-geolocate");
     if (geolocateButton)
-      geolocateButton.title = i18n.t("components.media_map.geolocate");
+      geolocateButton.title = i18n.t(i18nMap.components.media_map.geolocate);
 
     const popup = new maplibregl.Popup({
       offset: 25,
@@ -432,7 +433,7 @@ onMounted(() => {
             color: grey;
             cursor: pointer"
           >
-            ${i18n.t("components.media_map.clear_directions")}
+            ${i18n.t(i18nMap.components.media_map.clear_directions)}
           </div>
         `;
 
@@ -445,7 +446,7 @@ onMounted(() => {
             color: grey;
             cursor: pointer;"
           >
-            ${i18n.t("components.media_map.clear_directions")} [x]
+            ${i18n.t(i18nMap.components.media_map.clear_directions)} [x]
           </div>
         `;
 

--- a/frontend/components/modal/edit/ModalEditFaqEntry.vue
+++ b/frontend/components/modal/edit/ModalEditFaqEntry.vue
@@ -65,10 +65,10 @@ const editedTexts = computed(() => props.textsToEdit);
 const translatedTexts = computed(() => {
   return editedTexts.value.map((text) => {
     if (
-      text === "components._global.working_groups_subtext" ||
-      text === "components._global.join_organization_subtext" ||
-      text === "components._global.join_group_subtext" ||
-      text === "components._global.participate_subtext"
+      text === i18nMap.components._global.working_groups_subtext ||
+      text === i18nMap.components._global.join_organization_subtext ||
+      text === i18nMap.components._global.join_group_subtext ||
+      text === i18nMap.components._global.participate_subtext
     ) {
       return i18n.t(text, { entity_name: props.name }) + ".";
     }

--- a/frontend/i18n/en-US.json
+++ b/frontend/i18n/en-US.json
@@ -155,6 +155,7 @@
   "components.card_topic_selection.subtext_resource": "Please select topics that this resource is related to so the community can more easily find it.",
   "components.card_topic_selection.view_all_topics": "View all topics",
   "components.combobox_topics.all_topics": "All Topics",
+  "components.combobox_topics.filter_by_topic": "Filter by topic",
   "components.combobox_topics.no_matching_topics": "No matching topics.",
   "components.dropdown_create.create": "Create",
   "components.dropdown_create.create_aria_label": "Open to see options to create events, organizations and other content on activist",

--- a/frontend/pages/organizations/[id]/groups/index.vue
+++ b/frontend/pages/organizations/[id]/groups/index.vue
@@ -22,11 +22,13 @@
           class="w-max"
           :cta="true"
           linkTo="/"
-          label="i18n._global.new_group"
+          :label="i18nMap._global.new_group"
           fontSize="sm"
           :leftIcon="IconMap.PLUS"
           iconSize="1.35em"
-          ariaLabel="i18n.pages.organizations.groups.index.new_group_aria_label"
+          :ariaLabel="
+            i18nMap.pages.organizations.groups.index.new_group_aria_label
+          "
         />
       </div>
     </HeaderAppPage>

--- a/frontend/pages/organizations/[id]/groups/index.vue
+++ b/frontend/pages/organizations/[id]/groups/index.vue
@@ -22,11 +22,11 @@
           class="w-max"
           :cta="true"
           linkTo="/"
-          label="_global.new_group"
+          label="i18n._global.new_group"
           fontSize="sm"
           :leftIcon="IconMap.PLUS"
           iconSize="1.35em"
-          ariaLabel="pages.organizations.groups.index.new_group_aria_label"
+          ariaLabel="i18n.pages.organizations.groups.index.new_group_aria_label"
         />
       </div>
     </HeaderAppPage>

--- a/frontend/pages/organizations/[id]/resources.vue
+++ b/frontend/pages/organizations/[id]/resources.vue
@@ -19,11 +19,11 @@
           class="w-max"
           :cta="true"
           linkTo="/"
-          label="_global.new_resource"
+          label="i18n._global.new_resource"
           fontSize="sm"
           :leftIcon="IconMap.PLUS"
           iconSize="1.35em"
-          ariaLabel="pages._global.resources.new_resource_aria_label"
+          ariaLabel="i18n.pages._global.resources.new_resource_aria_label"
         />
       </div>
     </HeaderAppPage>

--- a/frontend/pages/organizations/[id]/resources.vue
+++ b/frontend/pages/organizations/[id]/resources.vue
@@ -19,11 +19,11 @@
           class="w-max"
           :cta="true"
           linkTo="/"
-          label="i18n._global.new_resource"
+          :label="i18nMap._global.new_resource"
           fontSize="sm"
           :leftIcon="IconMap.PLUS"
           iconSize="1.35em"
-          ariaLabel="i18n.pages._global.resources.new_resource_aria_label"
+          :ariaLabel="i18nMap.pages._global.resources.new_resource_aria_label"
         />
       </div>
     </HeaderAppPage>

--- a/frontend/types/i18n-map.ts
+++ b/frontend/types/i18n-map.ts
@@ -245,6 +245,7 @@ export const i18nMap = {
     },
     combobox_topics: {
       all_topics: "components.combobox_topics.all_topics",
+      filter_by_topic: "components.combobox_topics.filter_by_topic",
       no_matching_topics: "components.combobox_topics.no_matching_topics",
     },
     dropdown_create: {

--- a/frontend/utils/groupSubPages.ts
+++ b/frontend/utils/groupSubPages.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { IconMap } from "~/types/icon-map";
 import type { SubPageSelector } from "~/types/sub-page-selector";
+import { i18nMap } from "~/types/i18n-map";
 
 export function getGroupSubPages(): SubPageSelector[] {
   const i18n = useI18n();
@@ -12,7 +13,7 @@ export function getGroupSubPages(): SubPageSelector[] {
 
   const groupAboutPageSelector: SubPageSelector = {
     id: 0,
-    label: i18n.t("_global.about"),
+    label: i18n.t(i18nMap._global.about),
     iconName: `${IconMap.ABOUT}`,
     routeUrl: `/organizations/${organizationId}/groups/${groupId}/about`,
     selected: false,
@@ -20,7 +21,7 @@ export function getGroupSubPages(): SubPageSelector[] {
 
   const groupEventPageSelector: SubPageSelector = {
     id: 1,
-    label: i18n.t("_global.events"),
+    label: i18n.t(i18nMap._global.events),
     iconName: `${IconMap.EVENT}`,
     routeUrl: `/organizations/${organizationId}/groups/${groupId}/events`,
     selected: false,
@@ -28,7 +29,7 @@ export function getGroupSubPages(): SubPageSelector[] {
 
   const groupEventResourcesSelector: SubPageSelector = {
     id: 2,
-    label: i18n.t("_global.resources"),
+    label: i18n.t(i18nMap._global.resources),
     iconName: "IconResource",
     routeUrl: `/organizations/${organizationId}/groups/${groupId}/resources`,
     selected: false,
@@ -36,7 +37,7 @@ export function getGroupSubPages(): SubPageSelector[] {
 
   const groupEventFAQSelector: SubPageSelector = {
     id: 3,
-    label: i18n.t("_global.faq"),
+    label: i18n.t(i18nMap._global.faq),
     iconName: "IconFAQ",
     routeUrl: `/organizations/${organizationId}/groups/${groupId}/faq`,
     selected: false,


### PR DESCRIPTION
Issue: https://github.com/activist-org/activist/issues/1100

- Migrate all inline i18n keys to use i18nMap object for type-safe references
- Add consistent 'i18n.' namespace prefix to translation keys in:
  - EmptyState component buttons
  - CardGetInvolvedOrganization links
  - CardSearchResult aria labels
  - MediaMap control tooltips
  - ModalEditFaqEntry text checks
  - Group/resource creation pages
  - Sidebar navigation labels
- Update HTML title attributes to use translated strings via i18nMap
- Import i18nMap in files where missing (MediaMap, groupSubPages)
- Fix key consistency in discussion input component

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
