### PR TITLE
fix: updated the check_dependency workflow to show dependency report

### DIFF
--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -9,8 +9,6 @@ jobs:
   update_dependencies:
     runs-on: ubuntu-latest
     steps:
-      # MARK: Environments
-
       - name: Checkout Repository
         uses: actions/checkout@v2
 
@@ -18,90 +16,109 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Install Yarn
-        working-directory: ./frontend
-        run: install
-
-      # MARK: Dependency Updates
-
+      
+      - name: Initialize Report
+        run: |
+          echo "# Dependency Update Report $(date '+%B %d, %Y')" > reports.md
+          echo "## Updated Dependencies" >> reports.md
+          
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.11'
-
-      - name: Update Backend Dependencies
-        working-directory: backend
-        run: |
-          python -m pip install --upgrade uv
-          uv venv
-          uv pip install -r requirements-dev.txt
-          pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1 | xargs -n1 pip install -U
-          pip freeze > requirements-dev.txt
-
-      - name: Install npm-check-updates
-        run: npm install -g npm-check-updates
-
+          
       - name: Update Frontend Dependencies
+        id: frontend-updates
         working-directory: frontend
+        continue-on-error: true
         run: |
+          cp package.json package.old.json
+          npm install -g npm-check-updates
           ncu -u
-
-      # MARK: Backend Tests
-
-      - name: Activate Virtual Environment
+          echo -e "\n### Frontend Dependencies" >> ../reports.md
+          echo "Changes:" >> ../reports.md
+          diff package.old.json package.json | grep "^>" | sed 's/^>/- /' >> ../reports.md || true
+        
+      - name: Setup Yarn
+        working-directory: frontend
+        continue-on-error: true
         run: |
-          . .venv/bin/activate
-          echo PATH=$PATH >> $GITHUB_ENV
-
-      - name: Run Ruff Format - Formatting and Linting Check
-        run: ruff check ./backend || echo "Ruff check failed" >> error_log.txt
-
-      - name: Run mypy - Static Type Checking
-        if: always()
-        run: mypy ./backend --config-file ./backend/pyproject.toml || echo "mypy check failed" >> error_log.txt
-
-      - name: Run pytest - Unit Tests
-        if: always()
-        run: pytest ./backend -vv || echo "Backend tests failed." >> error_log.txt
-
-      # MARK: Frontend Tests
-
-      - name: Install Prettier
-        run: yarn add prettier
-
-      - name: Run Prettier - Formatting Check
-        working-directory: ./frontend
+          corepack enable
+          corepack prepare yarn@4.6.0 --activate
+          
+      - name: Install Frontend Dependencies
+        id: install-frontend
+        working-directory: frontend
+        continue-on-error: true
         run: |
-          yarn prettier . --check --config ../.prettierrc --ignore-path ../.prettierignore || echo "Prettier check failed." >> error_log.txt
-
-      - name: Run Nuxt Type Check
-        if: always()
-        working-directory: ./frontend
-        run: nuxi typecheck || echo "Type check failed." >> error_log.txt
-
-      - name: Run ESLint - Linting
-        if: always()
-        working-directory: ./frontend
-        run: eslint . || echo "ESLint check failed." >> error_log.txt
-
-      # MARK: Errors and Issue
-
-      - name: Log Errors
-        if: failure()
+          rm -rf .yarn .pnp.* yarn.lock node_modules
+        
+          yarn set version 4.6.0
+          
+          yarn install --no-immutable
+          
+          yarn remove eslint @nuxtjs/eslint-config-typescript nuxt prettier || true
+          yarn add -D eslint@^8.0.0 prettier@^3.0.0
+          yarn add -D nuxt@^3.0.0
+          
+      - name: Run Frontend Tests
+        id: frontend-tests
+        working-directory: frontend
+        continue-on-error: true
         run: |
-          if [[ -f error_log.txt ]]; then
-            cat error_log.txt
-          else
-            echo "No errors found during dependency update."
-          fi
-
+          echo -e "\n### Prettier Results" >> ../reports.md
+          yarn prettier . --check --config ../.prettierrc --ignore-path ../.prettierignore 2>&1 | tee -a ../reports.md || true
+          echo -e "\n### Type Check Results" >> ../reports.md
+          yarn nuxi typecheck 2>&1 | tee -a ../reports.md || true
+          echo -e "\n### ESLint Results" >> ../reports.md
+          yarn eslint . 2>&1 | tee -a ../reports.md || true
+      
+      - name: Update Backend Dependencies
+        id: backend-updates
+        working-directory: backend
+        continue-on-error: true
+        run: |
+          cp requirements.txt requirements.old.txt
+          
+          pip install -U pip-tools
+          pip-compile --upgrade requirements.in
+          
+          echo -e "\n### Backend Dependencies" >> ../reports.md
+          echo "\`\`\`diff" >> ../reports.md
+          diff requirements.old.txt requirements.txt >> ../reports.md || true
+          echo "\`\`\`" >> ../reports.md
+          
+      - name: Install Backend Dependencies
+        id: install-backend
+        working-directory: backend
+        continue-on-error: true
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install mypy
+          
+      - name: Run Backend Tests
+        id: backend-tests
+        working-directory: backend
+        continue-on-error: true
+        run: |
+          echo -e "\n## Backend Test Results" >> ../reports.md
+          echo -e "\n### Mypy Results" >> ../reports.md
+          echo "\`\`\`" >> ../reports.md
+          mypy . --config-file mypy.ini 2>&1 | tee -a ../reports.md || true
+          echo "\`\`\`" >> ../reports.md
+          
+          echo -e "\n### Django Tests" >> ../reports.md
+          echo "\`\`\`" >> ../reports.md
+          DJANGO_SETTINGS_MODULE=app.settings.test python manage.py test 2>&1 | tee -a ../reports.md || true
+          echo "\`\`\`" >> ../reports.md
+          
       - name: Create GitHub Issue
-        if: failure()
+        if: always()
         uses: peter-evans/create-issue-from-file@v4
         with:
-          title: $(date +%Y-%m-%d) Dependency Update Errors
-          content-filepath: error_log.txt
+          title: "Dependency Update Errors - $(date '+%B %d, %Y') 🤖"
+          content-filepath: reports.md
           labels: |
             dependencies
             help wanted
+            good first issue

--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -1,44 +1,30 @@
 name: check_dependency_updates
-
 on:
   schedule:
     - cron: '0 0 15 */2 *'
   workflow_dispatch:
-
 jobs:
   update_dependencies:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-
+      
       - name: Set up Node Environment
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      
+
       - name: Initialize Report
         run: |
           echo "# Dependency Update Report $(date '+%B %d, %Y') 🤖 📝" > reports.md
-          echo "## Updated Dependencies" >> reports.md
+          echo "## Available Update ⚙️" >> reports.md
           
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.11'
-          
-      - name: Update Frontend Dependencies
-        id: frontend-updates
-        working-directory: frontend
-        continue-on-error: true
-        run: |
-          cp package.json package.old.json
-          npm install -g npm-check-updates
-          ncu -u
-          echo -e "\n### Frontend Dependencies" >> ../reports.md
-          echo "Changes:" >> ../reports.md
-          diff package.old.json package.json | grep "^>" | sed 's/^>/- /' >> ../reports.md || true
-        
+
       - name: Setup Yarn
         working-directory: frontend
         continue-on-error: true
@@ -52,42 +38,55 @@ jobs:
         continue-on-error: true
         run: |
           rm -rf .yarn .pnp.* yarn.lock node_modules
-        
           yarn set version 4.6.0
-          
           yarn install --no-immutable
-          
           yarn remove eslint @nuxtjs/eslint-config-typescript nuxt prettier || true
           yarn add -D eslint@^8.0.0 prettier@^3.0.0
           yarn add -D nuxt@^3.0.0
           
-      - name: Run Frontend Tests
-        id: frontend-tests
+      - name: Update Frontend Dependencies
+        id: frontend-updates
         working-directory: frontend
         continue-on-error: true
         run: |
-          echo -e "\n### Prettier Results" >> ../reports.md
-          yarn prettier . --check --config ../.prettierrc --ignore-path ../.prettierignore 2>&1 | tee -a ../reports.md || true
-          echo -e "\n### Type Check Results" >> ../reports.md
-          yarn nuxi typecheck 2>&1 | tee -a ../reports.md || true
-          echo -e "\n### ESLint Results" >> ../reports.md
-          yarn eslint . 2>&1 | tee -a ../reports.md || true
-      
-      - name: Update Backend Dependencies
-        id: backend-updates
-        working-directory: backend
-        continue-on-error: true
-        run: |
-          cp requirements.txt requirements.old.txt
+          cp package.json package.old.json
+          npm install -g npm-check-updates
+          cat > compare_versions.js << 'EOF'
+          #!/usr/bin/env node
+          const oldPkg = require('./package.old.json');
+          const newPkg = require('./package.json');
           
-          pip install -U pip-tools
-          pip-compile --upgrade requirements.in
+          const allDeps = new Set([
+            ...Object.keys(oldPkg.dependencies || {}),
+            ...Object.keys(oldPkg.devDependencies || {}),
+            ...Object.keys(newPkg.dependencies || {}),
+            ...Object.keys(newPkg.devDependencies || {})
+          ]);
           
-          echo -e "\n### Backend Dependencies" >> ../reports.md
-          echo "\`\`\`diff" >> ../reports.md
-          diff requirements.old.txt requirements.txt >> ../reports.md || true
-          echo "\`\`\`" >> ../reports.md
+          const getVersion = (pkg, name) => {
+            return (pkg.dependencies && pkg.dependencies[name]) || 
+                   (pkg.devDependencies && pkg.devDependencies[name]) || 
+                   'not present';
+          };
           
+          for (const dep of Array.from(allDeps).sort()) {
+            const oldVersion = getVersion(oldPkg, dep);
+            const newVersion = getVersion(newPkg, dep);
+            
+            if (oldVersion !== newVersion) {
+              console.log(`- ${dep}: ${oldVersion} → ${newVersion}`);
+            }
+          }
+          EOF
+          
+          chmod +x compare_versions.js
+          ncu -u
+          
+          echo -e "\n### Dependencies" >> ../reports.md
+          echo -e "| Package | Old Version | New Version | Type |" >> ../reports.md
+          echo -e "|---------|-------------|-------------|------|" >> ../reports.md     
+          node compare_versions.js | sed 's/- \(.*\): \(.*\) → \(.*\)/| \1 | \2 | \3 | Frontend |/' >> ../reports.md || echo "No frontend changes found" >> ../reports.md
+       
       - name: Install Backend Dependencies
         id: install-backend
         working-directory: backend
@@ -95,6 +94,41 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           python -m pip install mypy
+
+      - name: Update Backend Dependencies
+        id: backend-updates
+        working-directory: backend
+        continue-on-error: true
+        run: |
+          cp requirements.txt requirements.old.txt
+          pip install -U pip-tools
+          pip-compile --upgrade requirements.in
+          
+          cat > compare_versions.py << 'EOF'
+          import re
+          def parse_req_file(filename):
+              deps = {}
+              with open(filename, "r") as f:
+                  for line in f:
+                      line = line.strip()
+                      if line and not line.startswith("#") and "==" in line:
+                          parts = re.split("==|>=|<=", line, 1)
+                          if len(parts) == 2:
+                              name = parts[0].strip()
+                              version = parts[1].strip()
+                              deps[name] = version
+              return deps
+          old_deps = parse_req_file("requirements.old.txt")
+          new_deps = parse_req_file("requirements.txt")
+          all_deps = set(list(old_deps.keys()) + list(new_deps.keys()))
+          for dep in sorted(all_deps):
+              old_ver = old_deps.get(dep, "not present")
+              new_ver = new_deps.get(dep, "not present")
+              if old_ver != new_ver:
+                  print(f"| {dep} | {old_ver} | {new_ver} | Backend |")
+          EOF
+          
+          python compare_versions.py >> ../reports.md || echo "No backend changes found" >> ../reports.md
           
       - name: Run Backend Tests
         id: backend-tests
@@ -111,12 +145,22 @@ jobs:
           echo "\`\`\`" >> ../reports.md
           DJANGO_SETTINGS_MODULE=app.settings.test python manage.py test 2>&1 | tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
-          
+
+      - name: Run Frontend Tests
+        id: frontend-tests
+        working-directory: frontend
+        continue-on-error: true
+        run: |
+          echo -e "\n### Prettier Results" >> ../reports.md
+          yarn prettier . --check --config ../.prettierrc --ignore-path ../.prettierignore 2>&1 | tee -a ../reports.md || true
+          echo -e "\n### Type Check Results" >> ../reports.md
+          yarn nuxi typecheck 2>&1 | tee -a ../reports.md || true
+      
       - name: Create GitHub Issue
         if: always()
         uses: peter-evans/create-issue-from-file@v4
         with:
-          title: "Dependency Update Errors - $(date '+%B %d, %Y') 🤖"
+          title: "Dependency Update Report - $(date '+%B %d, %Y') 🤖"
           content-filepath: reports.md
           labels: |
             dependencies

--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -158,6 +158,7 @@ jobs:
         working-directory: frontend
         continue-on-error: true
         run: |
+          echo "compare_versions.js" >> ../.prettierignore
           echo -e "\n### Prettier Results" >> ../reports.md
           echo "\`\`\`" >> ../reports.md
           yarn prettier . --check --config ../.prettierrc --ignore-path ../.prettierignore 2>&1 | tee -a ../reports.md || true

--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          
       - name: Initialize Report
         run: |
           echo "# Dependency Update Report $(date '+%B %d, %Y') 🤖 📝" > reports.md
@@ -23,6 +24,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.11'
+          
       - name: Setup Yarn
         working-directory: frontend
         continue-on-error: true
@@ -86,10 +88,8 @@ jobs:
         id: setup-venv
         working-directory: backend
         continue-on-error: true
-        run: |
-          python -m venv .venv
-          echo "Created Python virtual environment in backend/.venv"
-
+        run: python -m venv .venv
+          
       - name: Install Backend Dependencies
         id: install-backend
         working-directory: backend
@@ -99,13 +99,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install mypy
-
+          
       - name: Update Backend Dependencies
         id: backend-updates
         working-directory: backend
         continue-on-error: true
         run: |
           source .venv/bin/activate
+          echo PATH=$PATH >> $GITHUB_ENV
           cp requirements.txt requirements.old.txt
           pip install -U pip-tools
           pip-compile --upgrade requirements.in
@@ -152,7 +153,7 @@ jobs:
           echo "\`\`\`" >> ../reports.md
           DJANGO_SETTINGS_MODULE=app.settings.test python manage.py test 2>&1 | tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
-
+          
       - name: Run Frontend Tests
         id: frontend-tests
         working-directory: frontend
@@ -166,7 +167,6 @@ jobs:
           
           echo -e "\n### Type Check Results" >> ../reports.md
           echo "\`\`\`" >> ../reports.md
-         
           yarn nuxi typecheck 2>&1 | sed 's/\[.*\]/\n&\n/g' | tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
       

--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -40,9 +40,6 @@ jobs:
           rm -rf .yarn .pnp.* yarn.lock node_modules
           yarn set version 4.6.0
           yarn install --no-immutable
-          yarn remove eslint @nuxtjs/eslint-config-typescript nuxt prettier || true
-          yarn add -D eslint@^8.0.0 prettier@^3.0.0
-          yarn add -D nuxt@^3.0.0
           
       - name: Update Frontend Dependencies
         id: frontend-updates
@@ -83,8 +80,8 @@ jobs:
           ncu -u
           
           echo -e "\n### Dependencies" >> ../reports.md
-          echo -e "| Package | Old Version | New Version | Type |" >> ../reports.md
-          echo -e "|---------|-------------|-------------|------|" >> ../reports.md     
+          echo -e "| Package Name | Old Version | New Available Version | Type |" >> ../reports.md
+          echo -e "|--------------|-------------|-----------------------|------|" >> ../reports.md     
           node compare_versions.js | sed 's/- \(.*\): \(.*\) → \(.*\)/| \1 | \2 | \3 | Frontend |/' >> ../reports.md || echo "No frontend changes found" >> ../reports.md
        
       - name: Install Backend Dependencies
@@ -135,7 +132,7 @@ jobs:
         working-directory: backend
         continue-on-error: true
         run: |
-          echo -e "\n## Backend Test Results" >> ../reports.md
+          echo -e "\n## Test Results" >> ../reports.md
           echo -e "\n### Mypy Results" >> ../reports.md
           echo "\`\`\`" >> ../reports.md
           mypy . --config-file mypy.ini 2>&1 | tee -a ../reports.md || true

--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -19,7 +19,7 @@ jobs:
       
       - name: Initialize Report
         run: |
-          echo "# Dependency Update Report $(date '+%B %d, %Y')" > reports.md
+          echo "# Dependency Update Report $(date '+%B %d, %Y') 🤖 📝" > reports.md
           echo "## Updated Dependencies" >> reports.md
           
       - name: Set up Python

--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
       - name: Initialize Report
         run: |
           echo "# Dependency Update Report $(date '+%B %d, %Y') 🤖 📝" > reports.md
@@ -24,7 +23,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.11'
-
       - name: Setup Yarn
         working-directory: frontend
         continue-on-error: true
@@ -84,11 +82,21 @@ jobs:
           echo -e "|--------------|-------------|-----------------------|------|" >> ../reports.md     
           node compare_versions.js | sed 's/- \(.*\): \(.*\) → \(.*\)/| \1 | \2 | \3 | Frontend |/' >> ../reports.md || echo "No frontend changes found" >> ../reports.md
        
+      - name: Create Python Virtual Environment
+        id: setup-venv
+        working-directory: backend
+        continue-on-error: true
+        run: |
+          python -m venv .venv
+          echo "Created Python virtual environment in backend/.venv"
+
       - name: Install Backend Dependencies
         id: install-backend
         working-directory: backend
         continue-on-error: true
         run: |
+          source .venv/bin/activate
+          python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
           python -m pip install mypy
 
@@ -97,6 +105,7 @@ jobs:
         working-directory: backend
         continue-on-error: true
         run: |
+          source .venv/bin/activate
           cp requirements.txt requirements.old.txt
           pip install -U pip-tools
           pip-compile --upgrade requirements.in
@@ -132,6 +141,7 @@ jobs:
         working-directory: backend
         continue-on-error: true
         run: |
+          source .venv/bin/activate
           echo -e "\n## Test Results" >> ../reports.md
           echo -e "\n### Mypy Results" >> ../reports.md
           echo "\`\`\`" >> ../reports.md

--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -149,9 +149,15 @@ jobs:
         continue-on-error: true
         run: |
           echo -e "\n### Prettier Results" >> ../reports.md
+          echo "\`\`\`" >> ../reports.md
           yarn prettier . --check --config ../.prettierrc --ignore-path ../.prettierignore 2>&1 | tee -a ../reports.md || true
+          echo "\`\`\`" >> ../reports.md
+          
           echo -e "\n### Type Check Results" >> ../reports.md
-          yarn nuxi typecheck 2>&1 | tee -a ../reports.md || true
+          echo "\`\`\`" >> ../reports.md
+         
+          yarn nuxi typecheck 2>&1 | sed 's/\[.*\]/\n&\n/g' | tee -a ../reports.md || true
+          echo "\`\`\`" >> ../reports.md
       
       - name: Create GitHub Issue
         if: always()


### PR DESCRIPTION
linked issue: https://github.com/activist-org/activist/issues/1090

The previous workflow didn't gave any information about the dependencies old version, available new version that we can update too, and didn't provide the information about the result of any frontend type checking or formatting. just a little information about mypy check failed `mypy check failed
Backend tests failed.` was only shown.

this now updated workflow will show the [following ](https://gist.github.com/Abhi-Bohora/f365a763edd14982ed145e2b091805fc)information when actions create the issue.

I try to keep the code less as possible but i have to include little script to compare old deps version and new deps version for both frontend and backend to put them together in a table along with their old version and new available version 😅

Thanks

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
