### PR TITLE
#Issue1133 : Serializers tests for Authentication 

### DIFF
--- a/backend/authentication/tests/__init__.py
+++ b/backend/authentication/tests/__init__.py
@@ -1,0 +1,1 @@
+__author__ = "narmadha-raghu"

--- a/backend/authentication/tests/__init__.py
+++ b/backend/authentication/tests/__init__.py
@@ -1,1 +1,0 @@
-__author__ = "narmadha-raghu"

--- a/backend/authentication/tests/test_auth.py
+++ b/backend/authentication/tests/test_auth.py
@@ -4,20 +4,20 @@ Testing for the authentication app.
 """
 
 # mypy: ignore-errors
+import uuid
+from uuid import UUID
+
 import pytest
+from django.core import mail
+from django.test import Client
+from faker import Faker
+
 from authentication.factories import (
     SupportEntityTypeFactory,
     SupportFactory,
     UserFactory,
 )
 from authentication.models import UserModel
-
-from django.core import mail
-from faker import Faker
-
-from django.test import Client
-from uuid import UUID
-import uuid
 
 pytestmark = pytest.mark.django_db
 
@@ -280,7 +280,9 @@ def test_create_user_and_superuser():
     assert superuser.is_active
 
     # Test that creating a superuser with is_staff=False raises the expected error.
-    with pytest.raises(ValueError, match="Superuser must be assigned to is_staff=True."):
+    with pytest.raises(
+        ValueError, match="Superuser must be assigned to is_staff=True."
+    ):
         manager.create_superuser(
             email="admin2@example.com",
             username="admin2",
@@ -289,7 +291,9 @@ def test_create_user_and_superuser():
         )
 
     # Test that creating a superuser with is_superuser=False raises the expected error.
-    with pytest.raises(ValueError, match="Superuser must be assigned to is_superuser=True."):
+    with pytest.raises(
+        ValueError, match="Superuser must be assigned to is_superuser=True."
+    ):
         manager.create_superuser(
             email="admin3@example.com",
             username="admin3",
@@ -314,9 +318,6 @@ def test_delete_user(client: Client) -> None:
     )
 
     if response.status_code == 200:
-        delete_response = client.delete(
-            path="/v1/auth/delete/",
-            data={"pk": user.id}
-        )
+        delete_response = client.delete(path="/v1/auth/delete/", data={"pk": user.id})
 
         assert delete_response.status_code == 200

--- a/backend/authentication/tests/test_auth.py
+++ b/backend/authentication/tests/test_auth.py
@@ -12,14 +12,12 @@ from authentication.factories import (
 )
 from authentication.models import UserModel
 
-from django.test import Client
 from django.core import mail
 from faker import Faker
 
 from django.test import Client
 from uuid import UUID
 import uuid
-
 
 pytestmark = pytest.mark.django_db
 

--- a/backend/authentication/tests/test_serializers.py
+++ b/backend/authentication/tests/test_serializers.py
@@ -19,28 +19,28 @@ from authentication.serializers import (
 
 
 class TestDeleteUserResponseSerializer:
-    def test_valid_message(self):
+    def test_valid_message(self) -> None:
         data = {"message": "User deleted successfully."}
         serializer = DeleteUserResponseSerializer(data=data)
 
         assert serializer.is_valid()
         assert serializer.validated_data == data
 
-    def test_message_max_length_exceeded(self):
+    def test_message_max_length_exceeded(self) -> None:
         long_message = "A" * 201  # Exceeding 200 characters
         data = {"message": long_message}
         serializer = DeleteUserResponseSerializer(data=data)
         assert not serializer.is_valid()
 
-    def test_missing_message_field(self):
-        data = {}
+    def test_missing_message_field(self) -> None:
+        data: dict = {}
         serializer = DeleteUserResponseSerializer(data=data)
         assert not serializer.is_valid()
 
 
 @pytest.mark.django_db
 class TestSignupSerializer:
-    def test_valid_data(self):
+    def test_valid_data(self) -> None:
         data = {
             "username": "testuser",
             "password": "StrongPass!123",
@@ -50,7 +50,7 @@ class TestSignupSerializer:
         serializer = SignupSerializer(data=data)
         assert serializer.is_valid()
 
-    def test_password_mismatch(self):
+    def test_password_mismatch(self) -> None:
         data = {
             "username": "testuser",
             "password": "StrongPass!123",
@@ -63,7 +63,7 @@ class TestSignupSerializer:
             == "invalid_password_confirmation"
         )
 
-    def test_weak_password(self):
+    def test_weak_password(self) -> None:
         data = {
             "username": "testuser",
             "password": "weakpass",
@@ -90,7 +90,7 @@ class TestLoginSerializer:
         )
 
     @patch("authentication.serializers.authenticate")
-    def test_valid_login_with_email(self, mock_authenticate, user):
+    def test_valid_login_with_email(self, mock_authenticate, user) -> None:
         mock_authenticate.return_value = user
         data = {"email": "testuser@activist.com", "password": "ValidPass!123"}
         serializer = LoginSerializer(data=data)
@@ -98,21 +98,21 @@ class TestLoginSerializer:
         assert serializer.validated_data["user"] == user
 
     @patch("authentication.serializers.authenticate")
-    def test_valid_login_with_username(self, mock_authenticate, user):
+    def test_valid_login_with_username(self, mock_authenticate, user) -> None:
         mock_authenticate.return_value = user
         data = {"username": "testuser", "password": "ValidPass!123"}
         serializer = LoginSerializer(data=data)
         assert serializer.is_valid()
         assert serializer.validated_data["user"] == user
 
-    def test_invalid_credentials(self, user):
+    def test_invalid_credentials(self, user) -> None:
         data = {"email": "wrong@activist.com", "password": "WrongPass!123"}
         serializer = LoginSerializer(data=data)
         assert not serializer.is_valid()
         assert serializer.errors["non_field_errors"][0].code == "invalid_credentials"
 
     @patch("authentication.serializers.authenticate")
-    def test_unconfirmed_email(self, mock_authenticate, user):
+    def test_unconfirmed_email(self, mock_authenticate, user) -> None:
         mock_authenticate.return_value = user
         user.is_confirmed = False
         user.save()
@@ -138,7 +138,7 @@ class TestPasswordResetSerializer:
         user.save()
         return user, verification_code
 
-    def test_validate_with_code(self, user_with_verification):
+    def test_validate_with_code(self, user_with_verification) -> None:
         user, verification_code = user_with_verification
         serializer = PasswordResetSerializer(
             data={"code": str(verification_code), "password": "newpassword123"}
@@ -147,7 +147,7 @@ class TestPasswordResetSerializer:
         assert serializer.is_valid()
         assert serializer.validated_data == user
 
-    def test_validate_with_email(self, user_with_verification):
+    def test_validate_with_email(self, user_with_verification) -> None:
         user, _ = user_with_verification
         serializer = PasswordResetSerializer(
             data={"email": "testuser@activist.com", "password": "newpassword123"}
@@ -155,7 +155,7 @@ class TestPasswordResetSerializer:
         assert serializer.is_valid()
         assert serializer.validated_data == user
 
-    def test_validate_with_invalid_code(self, user_with_verification):
+    def test_validate_with_invalid_code(self, user_with_verification) -> None:
         _, _ = user_with_verification
         invalid_code = uuid.uuid4()
         serializer = PasswordResetSerializer(
@@ -164,7 +164,7 @@ class TestPasswordResetSerializer:
         assert not serializer.is_valid()
         assert serializer.errors["non_field_errors"][0].code == "invalid_email"
 
-    def test_validate_with_invalid_email(self, user_with_verification):
+    def test_validate_with_invalid_email(self, user_with_verification) -> None:
         """
         Test validation with invalid email (tests else branch).
         """

--- a/backend/authentication/tests/test_serializers.py
+++ b/backend/authentication/tests/test_serializers.py
@@ -4,6 +4,7 @@
 Tests for serializers in the authentication app.
 """
 
+# mypy: ignore-errors
 import uuid
 from unittest.mock import patch
 
@@ -15,7 +16,6 @@ from authentication.serializers import (
     LoginSerializer,
     PasswordResetSerializer,
     SignupSerializer,
-    authenticate,
 )
 
 
@@ -35,7 +35,7 @@ class TestDeleteUserResponseSerializer:
         assert not serializer.is_valid()
 
     def test_missing_message_field(self) -> None:
-        data: dict[None] = {}
+        data: dict = {}
         serializer = DeleteUserResponseSerializer(data=data)
 
         assert not serializer.is_valid()
@@ -96,9 +96,7 @@ class TestLoginSerializer:
         )
 
     @patch("authentication.serializers.authenticate")
-    def test_valid_login_with_email(
-        self, mock_authenticate: authenticate, user: UserFactory
-    ) -> None:
+    def test_valid_login_with_email(self, mock_authenticate, user) -> None:
         mock_authenticate.return_value = user
         data = {"email": "testuser@activist.com", "password": "ValidPass!123"}
         serializer = LoginSerializer(data=data)
@@ -107,9 +105,7 @@ class TestLoginSerializer:
         assert serializer.validated_data["user"] == user
 
     @patch("authentication.serializers.authenticate")
-    def test_valid_login_with_username(
-        self, mock_authenticate: authenticate, user: UserFactory
-    ) -> None:
+    def test_valid_login_with_username(self, mock_authenticate, user) -> None:
         mock_authenticate.return_value = user
         data = {"username": "testuser", "password": "ValidPass!123"}
         serializer = LoginSerializer(data=data)
@@ -117,7 +113,7 @@ class TestLoginSerializer:
         assert serializer.is_valid()
         assert serializer.validated_data["user"] == user
 
-    def test_invalid_credentials(self, user: UserFactory) -> None:
+    def test_invalid_credentials(self, user) -> None:
         data = {"email": "wrong@activist.com", "password": "WrongPass!123"}
         serializer = LoginSerializer(data=data)
 
@@ -125,9 +121,7 @@ class TestLoginSerializer:
         assert serializer.errors["non_field_errors"][0].code == "invalid_credentials"
 
     @patch("authentication.serializers.authenticate")
-    def test_unconfirmed_email(
-        self, mock_authenticate: authenticate, user: UserFactory
-    ) -> None:
+    def test_unconfirmed_email(self, mock_authenticate, user) -> None:
         mock_authenticate.return_value = user
         user.is_confirmed = False
         user.save()
@@ -145,7 +139,7 @@ class TestPasswordResetSerializer:
     """
 
     @pytest.fixture
-    def user_with_verification(self) -> list[UserFactory, uuid.uuid4]:
+    def user_with_verification(self):
         user = UserFactory.create(
             email="testuser@activist.com", password="oldpassword123"
         )
@@ -155,9 +149,7 @@ class TestPasswordResetSerializer:
 
         return user, verification_code
 
-    def test_validate_with_code(
-        self, user_with_verification: list[UserFactory, uuid.uuid4]
-    ) -> None:
+    def test_validate_with_code(self, user_with_verification) -> None:
         user, verification_code = user_with_verification
         serializer = PasswordResetSerializer(
             data={"code": str(verification_code), "password": "newpassword123"}
@@ -166,9 +158,7 @@ class TestPasswordResetSerializer:
         assert serializer.is_valid()
         assert serializer.validated_data == user
 
-    def test_validate_with_email(
-        self, user_with_verification: list[UserFactory, uuid.uuid4]
-    ) -> None:
+    def test_validate_with_email(self, user_with_verification) -> None:
         user, _ = user_with_verification
         serializer = PasswordResetSerializer(
             data={"email": "testuser@activist.com", "password": "newpassword123"}
@@ -177,9 +167,7 @@ class TestPasswordResetSerializer:
         assert serializer.is_valid()
         assert serializer.validated_data == user
 
-    def test_validate_with_invalid_code(
-        self, user_with_verification: list[UserFactory, uuid.uuid4]
-    ) -> None:
+    def test_validate_with_invalid_code(self, user_with_verification) -> None:
         _, _ = user_with_verification
         invalid_code = uuid.uuid4()
         serializer = PasswordResetSerializer(
@@ -189,9 +177,7 @@ class TestPasswordResetSerializer:
         assert not serializer.is_valid()
         assert serializer.errors["non_field_errors"][0].code == "invalid_email"
 
-    def test_validate_with_invalid_email(
-        self, user_with_verification: list[UserFactory, uuid.uuid4]
-    ) -> None:
+    def test_validate_with_invalid_email(self, user_with_verification) -> None:
         """
         Test validation with invalid email (tests else branch).
         """

--- a/backend/authentication/tests/test_serializers.py
+++ b/backend/authentication/tests/test_serializers.py
@@ -1,4 +1,6 @@
-__author__ = "narmadha-raghu"
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""Tests for serializers in the authentication app."""
 
 import pytest
 import uuid

--- a/backend/authentication/tests/test_serializers.py
+++ b/backend/authentication/tests/test_serializers.py
@@ -15,6 +15,7 @@ from authentication.serializers import (
     LoginSerializer,
     PasswordResetSerializer,
     SignupSerializer,
+    authenticate,
 )
 
 
@@ -34,7 +35,7 @@ class TestDeleteUserResponseSerializer:
         assert not serializer.is_valid()
 
     def test_missing_message_field(self) -> None:
-        data: dict[str:str] = {}
+        data: dict[None] = {}
         serializer = DeleteUserResponseSerializer(data=data)
 
         assert not serializer.is_valid()
@@ -95,7 +96,9 @@ class TestLoginSerializer:
         )
 
     @patch("authentication.serializers.authenticate")
-    def test_valid_login_with_email(self, mock_authenticate, user: UserFactory) -> None:
+    def test_valid_login_with_email(
+        self, mock_authenticate: authenticate, user: UserFactory
+    ) -> None:
         mock_authenticate.return_value = user
         data = {"email": "testuser@activist.com", "password": "ValidPass!123"}
         serializer = LoginSerializer(data=data)
@@ -105,7 +108,7 @@ class TestLoginSerializer:
 
     @patch("authentication.serializers.authenticate")
     def test_valid_login_with_username(
-        self, mock_authenticate, user: UserFactory
+        self, mock_authenticate: authenticate, user: UserFactory
     ) -> None:
         mock_authenticate.return_value = user
         data = {"username": "testuser", "password": "ValidPass!123"}
@@ -122,7 +125,9 @@ class TestLoginSerializer:
         assert serializer.errors["non_field_errors"][0].code == "invalid_credentials"
 
     @patch("authentication.serializers.authenticate")
-    def test_unconfirmed_email(self, mock_authenticate, user: UserFactory) -> None:
+    def test_unconfirmed_email(
+        self, mock_authenticate: authenticate, user: UserFactory
+    ) -> None:
         mock_authenticate.return_value = user
         user.is_confirmed = False
         user.save()
@@ -140,7 +145,7 @@ class TestPasswordResetSerializer:
     """
 
     @pytest.fixture
-    def user_with_verification(self) -> [UserFactory, uuid.uuid4]:
+    def user_with_verification(self) -> list[UserFactory, uuid.uuid4]:
         user = UserFactory.create(
             email="testuser@activist.com", password="oldpassword123"
         )
@@ -151,7 +156,7 @@ class TestPasswordResetSerializer:
         return user, verification_code
 
     def test_validate_with_code(
-        self, user_with_verification: [UserFactory, uuid.uuid4]
+        self, user_with_verification: list[UserFactory, uuid.uuid4]
     ) -> None:
         user, verification_code = user_with_verification
         serializer = PasswordResetSerializer(
@@ -162,7 +167,7 @@ class TestPasswordResetSerializer:
         assert serializer.validated_data == user
 
     def test_validate_with_email(
-        self, user_with_verification: [UserFactory, uuid.uuid4]
+        self, user_with_verification: list[UserFactory, uuid.uuid4]
     ) -> None:
         user, _ = user_with_verification
         serializer = PasswordResetSerializer(
@@ -173,7 +178,7 @@ class TestPasswordResetSerializer:
         assert serializer.validated_data == user
 
     def test_validate_with_invalid_code(
-        self, user_with_verification: [UserFactory, uuid.uuid4]
+        self, user_with_verification: list[UserFactory, uuid.uuid4]
     ) -> None:
         _, _ = user_with_verification
         invalid_code = uuid.uuid4()
@@ -185,7 +190,7 @@ class TestPasswordResetSerializer:
         assert serializer.errors["non_field_errors"][0].code == "invalid_email"
 
     def test_validate_with_invalid_email(
-        self, user_with_verification: [UserFactory, uuid.uuid4]
+        self, user_with_verification: list[UserFactory, uuid.uuid4]
     ) -> None:
         """
         Test validation with invalid email (tests else branch).

--- a/backend/authentication/tests/test_serializers.py
+++ b/backend/authentication/tests/test_serializers.py
@@ -1,0 +1,172 @@
+__author__ = "narmadha-raghu"
+
+import pytest
+import uuid
+from unittest.mock import patch
+
+from authentication.factories import UserFactory
+from authentication.serializers import PasswordResetSerializer, DeleteUserResponseSerializer, SignupSerializer, \
+    LoginSerializer
+
+
+class TestDeleteUserResponseSerializer:
+    def test_valid_message(self):
+        data = {"message": "User deleted successfully."}
+        serializer = DeleteUserResponseSerializer(data=data)
+
+        assert serializer.is_valid()
+        assert serializer.validated_data == data
+
+    def test_message_max_length_exceeded(self):
+        long_message = "A" * 201  # Exceeding 200 characters
+        data = {"message": long_message}
+        serializer = DeleteUserResponseSerializer(data=data)
+        assert not serializer.is_valid()
+
+    def test_missing_message_field(self):
+        data = {}
+        serializer = DeleteUserResponseSerializer(data=data)
+        assert not serializer.is_valid()
+
+
+@pytest.mark.django_db
+class TestSignupSerializer:
+    def test_valid_data(self):
+        data = {
+            "username": "testuser",
+            "password": "StrongPass!123",
+            "password_confirmed": "StrongPass!123",
+            "email": "testuser@example.com"
+        }
+        serializer = SignupSerializer(data=data)
+        assert serializer.is_valid()
+
+    def test_password_mismatch(self):
+        data = {
+            "username": "testuser",
+            "password": "StrongPass!123",
+            "password_confirmed": "WrongPass!123"
+        }
+        serializer = SignupSerializer(data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors['non_field_errors'][0].code == 'invalid_password_confirmation'
+
+    def test_weak_password(self):
+        data = {
+            "username": "testuser",
+            "password": "weakpass",
+            "password_confirmed": "weakpass"
+        }
+        serializer = SignupSerializer(data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors['non_field_errors'][0].code == 'invalid_password'
+
+
+@pytest.mark.django_db
+class TestLoginSerializer:
+    """
+    Test cases for LoginSerializer.
+    """
+
+    @pytest.fixture
+    def user(self):
+        return UserFactory.create(email="testuser@activist.com", username="testuser", password="ValidPass!123", is_confirmed=True)
+
+    @patch("authentication.serializers.authenticate")
+    def test_valid_login_with_email(self, mock_authenticate, user):
+        mock_authenticate.return_value = user
+        data = {
+            "email": "testuser@activist.com",
+            "password": "ValidPass!123"
+        }
+        serializer = LoginSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data["user"] == user
+
+    @patch("authentication.serializers.authenticate")
+    def test_valid_login_with_username(self, mock_authenticate, user):
+        mock_authenticate.return_value = user
+        data = {
+            "username": "testuser",
+            "password": "ValidPass!123"
+        }
+        serializer = LoginSerializer(data=data)
+        assert serializer.is_valid()
+        assert serializer.validated_data["user"] == user
+
+    def test_invalid_credentials(self, user):
+        data = {
+            "email": "wrong@activist.com",
+            "password": "WrongPass!123"
+        }
+        serializer = LoginSerializer(data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors["non_field_errors"][0].code == "invalid_credentials"
+
+    @patch("authentication.serializers.authenticate")
+    def test_unconfirmed_email(self, mock_authenticate, user):
+        mock_authenticate.return_value = user
+        user.is_confirmed = False
+        user.save()
+        data = {
+            "email": "testuser@activist.com",
+            "password": "ValidPass!123"
+        }
+        serializer = LoginSerializer(data=data)
+        assert not serializer.is_valid()
+        assert serializer.errors["non_field_errors"][0].code == "email_not_confirmed"
+
+
+@pytest.mark.django_db
+class TestPasswordResetSerializer:
+    """
+    Test cases for PasswordResetSerializer.
+    """
+
+    @pytest.fixture
+    def user_with_verification(self):
+        user = UserFactory.create(email='testuser@activist.com', password='oldpassword123')
+        verification_code = uuid.uuid4()
+        user.verification_code = verification_code
+        user.save()
+        return user, verification_code
+
+    def test_validate_with_code(self, user_with_verification):
+        user, verification_code = user_with_verification
+        serializer = PasswordResetSerializer(data={
+            'code': str(verification_code),
+            'password': 'newpassword123'
+        })
+
+        assert serializer.is_valid()
+        assert serializer.validated_data == user
+
+    def test_validate_with_email(self, user_with_verification):
+        user, _ = user_with_verification
+        serializer = PasswordResetSerializer(data={
+            'email': 'testuser@activist.com',
+            'password': 'newpassword123'
+        })
+        assert serializer.is_valid()
+        assert serializer.validated_data == user
+
+    def test_validate_with_invalid_code(self, user_with_verification):
+        _, _ = user_with_verification
+        invalid_code = uuid.uuid4()
+        serializer = PasswordResetSerializer(data={
+            'code': str(invalid_code),
+            'password': 'newpassword123'
+        })
+        assert not serializer.is_valid()
+        assert serializer.errors['non_field_errors'][0].code == 'invalid_email'
+
+    def test_validate_with_invalid_email(self, user_with_verification):
+        """Test validation with invalid email (tests else branch). """
+        _, _ = user_with_verification
+        serializer = PasswordResetSerializer(data={
+            'email': 'invalid_email@activist.com',
+            'password': 'newpassword123'
+        })
+        assert not serializer.is_valid()
+        assert 'non_field_errors' in serializer.errors
+        assert serializer.errors['non_field_errors'][0].code == 'invalid_email'


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

PFA 

<img width="1656" alt="Screenshot 2025-03-09 at 23 56 30" src="https://github.com/user-attachments/assets/3744466f-4445-4934-9c22-76c27e5d4d11" />

---

### Description

This pull request improves test coverage in `backend/authentication/serializers.py`, specifically addressing the missing lines **111-114** in the `PasswordResetSerializer`. I have added test cases to ensure these lines are covered.  

Changes :

Refactored the `tests/` folder, organizing them into separate files:

`test_auth.py`
`test_serializer.py`

Updated `DeleteUserResponseSerializer`, `SignupSerializer`, `LoginSerializer`, and `PasswordResetSerializer` for consistency and 100% test coverage, following the DRF serializer testing pattern.



Testing :
- Verified that all tests pass successfully.  

I followed [this resource](https://www.vintasoftware.com/blog/how-i-test-my-drf-serializers), as suggested by @andrewtavis, to refine the test implementation for DRF serializers.  

- #1133 
