### PR TITLE
Update mention suggestions to typescript

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -6,6 +6,7 @@ header:
     - '**/*.ts'
     - '**/*.test.ts'
     - '**/*.d.ts'
+    - '**/*.js'
     - '**/*.py'
   paths-ignore:
     - 'dist'

--- a/frontend/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/components/card/discussion/CardDiscussionInput.vue
@@ -159,6 +159,7 @@ const editor = useEditor({
         class:
           "hover:underline font-bold rounded-2xl box-decoration-clone px-1 py-0.5",
       },
+      // @ts-expect-error Ignore mismatched types.
       suggestion: Suggestion,
     }),
   ],

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -217,6 +217,7 @@ function resetRouteProfileControl() {
             requestOptions: {
               alternatives: "true",
             },
+            // @ts-expect-error Will break route profile change.
             mapLayers,
           });
 

--- a/frontend/components/media/MediaMap.vue
+++ b/frontend/components/media/MediaMap.vue
@@ -217,7 +217,7 @@ function resetRouteProfileControl() {
             requestOptions: {
               alternatives: "true",
             },
-            layers: mapLayers,
+            mapLayers,
           });
 
           directions.interactive = true;

--- a/frontend/components/menu/MenuSubPageSelector.vue
+++ b/frontend/components/menu/MenuSubPageSelector.vue
@@ -53,7 +53,7 @@ const defaultIndex = computed(() => {
 function changeTab(index: number) {
   const selectedRoute = props.selectors[index]?.routeUrl;
   if (selectedRoute) {
-    // @ts-expect-error 'nuxtApp.$localePath' is of type 'unknown'
+    // @ts-expect-error 'nuxtApp.$localePath' is of type 'unknown'.
     router.push(nuxtApp.$localePath(selectedRoute));
   }
 }

--- a/frontend/types/mention-suggestions.ts
+++ b/frontend/types/mention-suggestions.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { Editor } from "@tiptap/core";
+
+export interface MentionProps {
+  query: string;
+}
+
+export interface RendererProps {
+  editor: Editor;
+  clientRect?: () => DOMRect;
+}

--- a/frontend/utils/mentionSuggestion.ts
+++ b/frontend/utils/mentionSuggestion.ts
@@ -1,21 +1,23 @@
 import { VueRenderer } from "@tiptap/vue-3";
 import tippy from "tippy.js";
+import type { Instance as TippyInstance } from "tippy.js";
 
 import MentionList from "../components/tooltip/TooltipMentionList.vue";
+import type { MentionProps, RendererProps } from "~/types/mention-suggestions";
 
 export default {
-  items: ({ query }) => {
+  items: ({ query }: MentionProps): string[] => {
     return ["Jay Doe", "Jane Doe", "John Doe"]
       .filter((item) => item.toLowerCase().startsWith(query.toLowerCase()))
       .slice(0, 5);
   },
 
   render: () => {
-    let component;
-    let popup;
+    let component: VueRenderer;
+    let popup: TippyInstance[];
 
     return {
-      onStart: (props) => {
+      onStart: (props: RendererProps) => {
         component = new VueRenderer(MentionList, {
           props,
           editor: props.editor,
@@ -36,7 +38,7 @@ export default {
         });
       },
 
-      onUpdate(props) {
+      onUpdate(props: RendererProps) {
         component.updateProps(props);
 
         if (!props.clientRect) {
@@ -48,7 +50,7 @@ export default {
         });
       },
 
-      onKeyDown(props) {
+      onKeyDown(props: { event: KeyboardEvent }) {
         if (props.event.key === "Escape") {
           popup[0].hide();
 

--- a/frontend/utils/mentionSuggestion.ts
+++ b/frontend/utils/mentionSuggestion.ts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
 import { VueRenderer } from "@tiptap/vue-3";
 import tippy from "tippy.js";
 import type { Instance as TippyInstance } from "tippy.js";

--- a/frontend/utils/mentionSuggestion.ts
+++ b/frontend/utils/mentionSuggestion.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { VueRenderer } from "@tiptap/vue-3";
-import tippy from "tippy.js";
 import type { Instance as TippyInstance } from "tippy.js";
+import tippy from "tippy.js";
 
-import MentionList from "../components/tooltip/TooltipMentionList.vue";
 import type { MentionProps, RendererProps } from "~/types/mention-suggestions";
+import MentionList from "../components/tooltip/TooltipMentionList.vue";
 
 export default {
   items: ({ query }: MentionProps): string[] => {
@@ -31,7 +31,7 @@ export default {
         popup = tippy("body", {
           getReferenceClientRect: props.clientRect,
           appendTo: () => document.body,
-          content: component.element,
+          content: component.element ?? "Default content",
           showOnCreate: true,
           interactive: true,
           trigger: "manual",


### PR DESCRIPTION
### Contributor checklist

- [X] This pull request is on a [separate branch](https://github.com/annaleexjohnson/activist/tree/update-mentionSuggestions-to-typescript) and not the main branch
- [X] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description
Refactored mentionSuggestion.js to Typescript and added a types file

When running yarn typecheck, there was a type error when initializing the **popup** variable. I set the type to _Instance_ based on the [tippy.js docs](https://atomiks.github.io/tippyjs/v6/tippy-instance/), but it appears there's still an error.
<img width="829" alt="tippy_type_error" src="https://github.com/user-attachments/assets/06fe1d14-52d8-4821-98f0-a8dd35f6b42a" />

Please let me know if there's a better way to assign this type! Thank you!

### Related issue
- #1149 