### PR TITLE
fix: frontend and backend test workflow

### DIFF
--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -152,7 +152,7 @@ jobs:
 
           echo -e "\n### Django Tests" >> ../reports.md
           echo "\`\`\`" >> ../reports.md
-          DJANGO_SETTINGS_MODULE=app.settings.test python manage.py test 2>&1 | tee -a ../reports.md || true
+          DJANGO_SETTINGS_MODULE=core.settings python manage.py test 2>&1 | tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
 
       - name: Run Frontend Tests
@@ -168,7 +168,10 @@ jobs:
 
           echo -e "\n### Type Check Results" >> ../reports.md
           echo "\`\`\`" >> ../reports.md
-          yarn typecheck 2>&1 | sed 's/\[.*\]/\n&\n/g' | tee -a ../reports.md || true
+          yarn typecheck 2>&1 | \
+            grep -E "error TS|exited with non-zero status" | \
+            sed 's/.*\/\([^/]*\.vue\)/\1/' | \
+            tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
 
       - name: Create GitHub Issue

--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -5,7 +5,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-repository:
+    runs-on: ubuntu-latest
+    outputs:
+      is_remote_main: ${{ steps.check.outputs.is_remote_main }}
+    steps:
+      - name: Check repository
+        id: check
+        run: |
+          if [ "$GITHUB_REPOSITORY" = "activist-org/activist" ]; then
+            echo "is_remote_main=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_remote_main=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::This workflow should only run in activist-org/activist repository."
+          fi
+
   update_dependencies:
+    needs: check-repository
+    if: needs.check-repository.outputs.is_remote_main == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
As said in the issue [comment ](https://github.com/activist-org/activist/issues/1090#issuecomment-2708444053) there was error while running the backend test in workflow `ModuleNotFoundError: No module named 'app'` and also as said in the [1147](https://github.com/activist-org/activist/issues/1147) the typecheck result in the frontend contains too much information and not the TypeErrors.

 I have updated the workflow to eliminate the backend error `ModuleNotFoundError: No module named 'app'` it was due to passing the wrong setting file in `DJANGO_SETTINGS_MODULE` and update the frontend test typecheck result to show only the typecheck errors if it exists.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- [#1090](https://github.com/activist-org/activist/issues/1090)  [#1147](https://github.com/activist-org/activist/issues/1147)
