### PR TITLE
refactor: change getI18String to getEnglishText

### DIFF
--- a/frontend/test-e2e/accessibility/accessible-names.ts
+++ b/frontend/test-e2e/accessibility/accessible-names.ts
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 export const ROADMAP_LINK_NAME = new RegExp(
-  getI18nString("i18n.components.btn_road_map.aria_label"),
+  getEnglishText("i18n.components.btn_road_map.aria_label"),
   "i"
 );
 export const ACTIVIST_LANDING_LINK_NAME = new RegExp(
-  getI18nString("i18n.components.logo_activist.aria_label"),
+  getEnglishText("i18n.components.logo_activist.aria_label"),
   "i"
 );
 export const SIGN_IN_LINK_NAME = new RegExp(
-  getI18nString("i18n._global.sign_in_aria_label"),
+  getEnglishText("i18n._global.sign_in_aria_label"),
   "i"
 );
 export const SIGN_UP_LINK_NAME = new RegExp(
-  getI18nString("i18n._global.sign_up_aria_label"),
+  getEnglishText("i18n._global.sign_up_aria_label"),
   "i"
 );

--- a/frontend/test-e2e/component-objects/InfoMenu.ts
+++ b/frontend/test-e2e/component-objects/InfoMenu.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Locator, Page } from "playwright";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 export const newInfoMenu = (parent: Page | Locator) => ({
   toggleOpenButton: parent.getByRole("button", {
     name: new RegExp(
-      getI18nString("i18n.components.dropdown_info.info_aria_label"),
+      getEnglishText("i18n.components.dropdown_info.info_aria_label"),
       "i"
     ),
   }),

--- a/frontend/test-e2e/component-objects/LanguageMenu.ts
+++ b/frontend/test-e2e/component-objects/LanguageMenu.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Locator, Page } from "playwright";
 import { LOCALE_CODE } from "~/locales";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 const getMenuLocator = (parent: Page | Locator) =>
   parent.locator(".dropdown-language").getByRole("menu");
@@ -44,7 +44,7 @@ export const newLanguageMenu = (
         menu: getMenuLocator(parent),
         toggleOpenButton: parent.getByRole("button", {
           name: new RegExp(
-            getI18nString(
+            getEnglishText(
               "i18n.components.dropdown_language.open_dropdown_aria_label"
             ),
             "i"

--- a/frontend/test-e2e/component-objects/PasswordStrength.ts
+++ b/frontend/test-e2e/component-objects/PasswordStrength.ts
@@ -1,31 +1,31 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Locator, Page } from "playwright";
 import { expect } from "playwright/test";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 export const PASSWORD_RATING = {
   INVALID: new RegExp(
-    getI18nString("i18n.components.indicator_password_strength.invalid"),
+    getEnglishText("i18n.components.indicator_password_strength.invalid"),
     "i"
   ),
   VERY_WEAK: new RegExp(
-    getI18nString("i18n.components.indicator_password_strength.very_weak"),
+    getEnglishText("i18n.components.indicator_password_strength.very_weak"),
     "i"
   ),
   WEAK: new RegExp(
-    getI18nString("i18n.components.indicator_password_strength.weak"),
+    getEnglishText("i18n.components.indicator_password_strength.weak"),
     "i"
   ),
   MEDIUM: new RegExp(
-    getI18nString("i18n.components.indicator_password_strength.medium"),
+    getEnglishText("i18n.components.indicator_password_strength.medium"),
     "i"
   ),
   STRONG: new RegExp(
-    getI18nString("i18n.components.indicator_password_strength.strong"),
+    getEnglishText("i18n.components.indicator_password_strength.strong"),
     "i"
   ),
   VERY_STRONG: new RegExp(
-    getI18nString("i18n.components.indicator_password_strength.very_strong"),
+    getEnglishText("i18n.components.indicator_password_strength.very_strong"),
     "i"
   ),
 };

--- a/frontend/test-e2e/component-objects/SidebarLeft.ts
+++ b/frontend/test-e2e/component-objects/SidebarLeft.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Locator, Page } from "playwright";
 import { expect } from "playwright/test";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 export const newSidebarLeft = (page: Page) => new SidebarLeft(page);
 
@@ -20,7 +20,7 @@ export class SidebarLeft {
 
     this.lockToggle = this.root.getByRole("button", {
       name: new RegExp(
-        getI18nString(
+        getEnglishText(
           "i18n.components.sidebar_left_header.sidebar_collapse_aria_label"
         ),
         "i"

--- a/frontend/test-e2e/component-objects/SidebarRight.ts
+++ b/frontend/test-e2e/component-objects/SidebarRight.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Locator, Page } from "playwright";
 import { LOCALE_CODE } from "~/locales";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 export const newSidebarRight = (
   parent: Page | Locator,
@@ -53,7 +53,7 @@ export const newSidebarRight = (
         parent,
         closeButton: parent.getByRole("button", {
           name: new RegExp(
-            getI18nString(
+            getEnglishText(
               "i18n.components.sidebar_right_hamburger.collapse_aria_label"
             ),
             "i"
@@ -61,7 +61,7 @@ export const newSidebarRight = (
         }),
         openButton: parent.getByRole("button", {
           name: new RegExp(
-            getI18nString(
+            getEnglishText(
               "i18n.components.sidebar_right_hamburger.collapse_aria_label"
             ),
             "i"

--- a/frontend/test-e2e/component-objects/SignInMenu.ts
+++ b/frontend/test-e2e/component-objects/SignInMenu.ts
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Locator, Page } from "playwright";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 export const newSignInMenu = (parent: Page | Locator) => ({
   toggleOpenButton: parent.locator("#user-options").getByRole("button", {
     name: new RegExp(
-      getI18nString(
+      getEnglishText(
         "i18n.components.dropdown_user_options.username_aria_label"
       ),
       "i"
     ),
   }),
   signInOption: parent.locator("#user-options").getByRole("menuitem", {
-    name: new RegExp(getI18nString("i18n._global.sign_in"), "i"),
+    name: new RegExp(getEnglishText("i18n._global.sign_in"), "i"),
   }),
   signUpOption: parent.locator("#user-options").getByRole("menuitem", {
-    name: new RegExp(getI18nString("i18n._global.sign_up"), "i"),
+    name: new RegExp(getEnglishText("i18n._global.sign_up"), "i"),
   }),
 });

--- a/frontend/test-e2e/component-objects/ThemeMenu.ts
+++ b/frontend/test-e2e/component-objects/ThemeMenu.ts
@@ -1,34 +1,34 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Locator, Page } from "playwright";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 export const newThemeMenu = (parent: Page | Locator) => ({
   parent,
   menu: parent.locator(".dropdown-theme").getByRole("menu"),
   toggleOpenButton: parent.getByRole("button", {
     name: new RegExp(
-      getI18nString("i18n.components.dropdown_theme.open_dropdown_aria_label"),
+      getEnglishText("i18n.components.dropdown_theme.open_dropdown_aria_label"),
       "i"
     ),
   }),
 
   systemThemeOption: parent.getByRole("menuitem", {
     name: new RegExp(
-      getI18nString("i18n.components.dropdown_theme.system_aria_label"),
+      getEnglishText("i18n.components.dropdown_theme.system_aria_label"),
       "i"
     ),
   }),
 
   lightThemeOption: parent.getByRole("menuitem", {
     name: new RegExp(
-      getI18nString("i18n.components.dropdown_theme.light_aria_label"),
+      getEnglishText("i18n.components.dropdown_theme.light_aria_label"),
       "i"
     ),
   }),
 
   darkThemeOption: parent.getByRole("menuitem", {
     name: new RegExp(
-      getI18nString("i18n.components.dropdown_theme.dark_aria_label"),
+      getEnglishText("i18n.components.dropdown_theme.dark_aria_label"),
       "i"
     ),
   }),

--- a/frontend/test-e2e/page-objects/SignInPage.ts
+++ b/frontend/test-e2e/page-objects/SignInPage.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Page } from "@playwright/test";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 export const newSignInPage = (page: Page) => ({
   signUpLink: page.getByRole("link", {
-    name: new RegExp(getI18nString("i18n._global.sign_up_aria_label"), "i"),
+    name: new RegExp(getEnglishText("i18n._global.sign_up_aria_label"), "i"),
   }),
   usernameInput: page.locator("#sign-in-username input"),
   passwordInput: page.locator("#sign-in-password input"),
@@ -14,12 +14,12 @@ export const newSignInPage = (page: Page) => ({
   // Currently a button but should be a link
   forgotPasswordLink: page.getByRole("button", {
     name: new RegExp(
-      getI18nString("i18n._global.auth.reset_password_forgot_password"),
+      getEnglishText("i18n._global.auth.reset_password_forgot_password"),
       "i"
     ),
   }),
 
   signInButton: page.getByRole("button", {
-    name: new RegExp(getI18nString("i18n._global.sign_in_aria_label"), "i"),
+    name: new RegExp(getEnglishText("i18n._global.sign_in_aria_label"), "i"),
   }),
 });

--- a/frontend/test-e2e/specs/all/landing-page.spec.ts
+++ b/frontend/test-e2e/specs/all/landing-page.spec.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { expect, test } from "playwright/test";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/en");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(
-    new RegExp(getI18nString("i18n.components.landing_splash.header"), "i")
+    new RegExp(getEnglishText("i18n.components.landing_splash.header"), "i")
   );
 });
 
@@ -27,7 +27,7 @@ test.describe("Landing Page", { tag: ["@desktop", "@mobile"] }, () => {
   test("User can go to Organizations page", async ({ page }) => {
     const organizationsLink = page.getByRole("link", {
       name: new RegExp(
-        getI18nString(
+        getEnglishText(
           "i18n.components.landing_splash.view_organizations_aria_label"
         ),
         "i"
@@ -41,7 +41,7 @@ test.describe("Landing Page", { tag: ["@desktop", "@mobile"] }, () => {
   test("User can go to Events page", async ({ page }) => {
     const eventsLink = page.getByRole("link", {
       name: new RegExp(
-        getI18nString("i18n.components.landing_splash.view_events_aria_label"),
+        getEnglishText("i18n.components.landing_splash.view_events_aria_label"),
         "i"
       ),
     });
@@ -54,7 +54,7 @@ test.describe("Landing Page", { tag: ["@desktop", "@mobile"] }, () => {
     const links = [
       {
         name: new RegExp(
-          getI18nString("i18n.pages.index.get_active_aria_label"),
+          getEnglishText("i18n.pages.index.get_active_aria_label"),
           "i"
         ),
         url: "https://docs.activist.org/activist",
@@ -62,7 +62,7 @@ test.describe("Landing Page", { tag: ["@desktop", "@mobile"] }, () => {
 
       {
         name: new RegExp(
-          getI18nString("i18n.pages.index.get_organized_aria_label"),
+          getEnglishText("i18n.pages.index.get_organized_aria_label"),
           "i"
         ),
         url: "https://docs.activist.org/activist",
@@ -70,7 +70,7 @@ test.describe("Landing Page", { tag: ["@desktop", "@mobile"] }, () => {
 
       {
         name: new RegExp(
-          getI18nString("i18n.pages.index.grow_organization_aria_label"),
+          getEnglishText("i18n.pages.index.grow_organization_aria_label"),
           "i"
         ),
         url: "https://docs.activist.org/activist",
@@ -78,7 +78,7 @@ test.describe("Landing Page", { tag: ["@desktop", "@mobile"] }, () => {
 
       {
         name: new RegExp(
-          getI18nString("i18n.pages.index.activist_section_btn_aria_label"),
+          getEnglishText("i18n.pages.index.activist_section_btn_aria_label"),
           "i"
         ),
         url: "https://docs.activist.org/activist",
@@ -86,7 +86,7 @@ test.describe("Landing Page", { tag: ["@desktop", "@mobile"] }, () => {
 
       {
         name: new RegExp(
-          getI18nString(
+          getEnglishText(
             "i18n.pages.index.our_supporters_btn_become_aria_label"
           ),
           "i"
@@ -96,7 +96,7 @@ test.describe("Landing Page", { tag: ["@desktop", "@mobile"] }, () => {
 
       {
         name: new RegExp(
-          getI18nString("i18n.pages.index.our_supporters_btn_view_aria_label"),
+          getEnglishText("i18n.pages.index.our_supporters_btn_view_aria_label"),
           "i"
         ),
         url: "https://docs.activist.org/activist/organization/community/supporters",

--- a/frontend/test-e2e/specs/desktop/landing-page.spec.ts
+++ b/frontend/test-e2e/specs/desktop/landing-page.spec.ts
@@ -11,12 +11,12 @@ import { expectTheme } from "~/test-e2e/assertions";
 import { newLanguageMenu } from "~/test-e2e/component-objects/LanguageMenu";
 import { newThemeMenu } from "~/test-e2e/component-objects/ThemeMenu";
 import { newLandingPage } from "~/test-e2e/page-objects/LandingPage";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/en");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(
-    new RegExp(getI18nString("i18n.components.landing_splash.header"), "i")
+    new RegExp(getEnglishText("i18n.components.landing_splash.header"), "i")
   );
 });
 

--- a/frontend/test-e2e/specs/mobile/landing-page.spec.ts
+++ b/frontend/test-e2e/specs/mobile/landing-page.spec.ts
@@ -9,12 +9,12 @@ import { newSidebarRight } from "~/test-e2e/component-objects/SidebarRight";
 import { newSignInMenu } from "~/test-e2e/component-objects/SignInMenu";
 import { newThemeMenu } from "~/test-e2e/component-objects/ThemeMenu";
 import { newLandingPage } from "~/test-e2e/page-objects/LandingPage";
-import { getI18nString } from "~/utils/i18n";
+import { getEnglishText } from "~/utils/i18n";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/en");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(
-    new RegExp(getI18nString("i18n.components.landing_splash.header"), "i")
+    new RegExp(getEnglishText("i18n.components.landing_splash.header"), "i")
   );
 });
 

--- a/frontend/utils/i18n.ts
+++ b/frontend/utils/i18n.ts
@@ -17,9 +17,9 @@ const localeFiles: Record<LOCALE_CODE, LocaleFile> = {
 };
 
 export function getLocaleText(locale?: LOCALE_CODE): LocaleFile {
-  return localeFiles[locale || LOCALE_CODE.ENGLISH];
+  return localeFiles[locale ?? LOCALE_CODE.ENGLISH];
 }
 
-export const getI18nString = (key: string) => {
+export const getEnglishText = (key: string) => {
   return getLocaleText(LOCALE_CODE.ENGLISH)[key];
 };


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This is just renaming the `getI18String` function to `getEnglishText`.  `getEnglishText` more specifically shows what the function does, and follows the pattern of the name `getLocaleText`

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
