### PR TITLE
 Issue 670. Image Upload Validation.

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,5 +1,6 @@
 FRONTEND_PORT="3000"
 VITE_FRONTEND_URL="http://localhost:3000"
+VITE_BACKEND_URL="http://localhost:8000"
 VITE_API_URL="http://localhost:8000/v1"
 
 ADMIN_PATH="admin/"

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ venv/
 .mypy_cache
 
 # Don't include migrations for now.
-*migrations/*
+**/migrations/*
 !*migrations/__init__.py
 
 # Testing

--- a/backend/authentication/models.py
+++ b/backend/authentication/models.py
@@ -83,7 +83,7 @@ class Support(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class UserModel(AbstractUser, PermissionsMixin):

--- a/backend/communities/groups/models.py
+++ b/backend/communities/groups/models.py
@@ -51,7 +51,7 @@ class GroupImage(models.Model):
     sequence_index = models.IntegerField()
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class GroupMember(models.Model):
@@ -68,7 +68,7 @@ class GroupMember(models.Model):
     is_comms = models.BooleanField(default=False)
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class GroupSocialLink(SocialLink):

--- a/backend/communities/organizations/models.py
+++ b/backend/communities/organizations/models.py
@@ -68,7 +68,7 @@ class OrganizationApplication(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
 
     def __str__(self) -> str:
-        return f"{self.creation_date}"
+        return str(self.creation_date)
 
 
 class OrganizationApplicationStatus(models.Model):
@@ -85,7 +85,7 @@ class OrganizationImage(models.Model):
     sequence_index = models.IntegerField()
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class OrganizationMember(models.Model):
@@ -96,7 +96,7 @@ class OrganizationMember(models.Model):
     is_comms = models.BooleanField(default=False)
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class OrganizationSocialLink(SocialLink):
@@ -114,7 +114,7 @@ class OrganizationTask(models.Model):
     )
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class OrganizationText(models.Model):

--- a/backend/content/models.py
+++ b/backend/content/models.py
@@ -3,6 +3,8 @@
 Models for the content app.
 """
 
+import os
+from typing import Any
 from uuid import uuid4
 
 from django.contrib.postgres.fields import ArrayField
@@ -40,15 +42,24 @@ class Faq(models.Model):
         return self.question
 
 
+# This is used to set the filename to the UUID of the model, in the Image model.
+def set_filename_to_uuid(instance: Any, filename: str) -> str:
+    """Generate a new filename using the model's UUID and keep the original extension."""
+    ext = os.path.splitext(filename)[1]  # Extract file extension
+    new_filename = f"{instance.id}{ext}"  # Use model UUID as filename
+    return os.path.join("images/", new_filename)  # Store in 'images/' folder
+
+
 class Image(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
     file_object = models.ImageField(
-        upload_to="images/", validators=[validate_image_file_extension]
+        upload_to=set_filename_to_uuid,
+        validators=[validate_image_file_extension],
     )
     creation_date = models.DateTimeField(auto_now_add=True)
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class Location(models.Model):

--- a/backend/content/models.py
+++ b/backend/content/models.py
@@ -26,7 +26,7 @@ class Discussion(models.Model):
     tags = models.ManyToManyField("content.Tag", blank=True)
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class Faq(models.Model):
@@ -45,9 +45,10 @@ class Faq(models.Model):
 # This is used to set the filename to the UUID of the model, in the Image model.
 def set_filename_to_uuid(instance: Any, filename: str) -> str:
     """Generate a new filename using the model's UUID and keep the original extension."""
-    ext = os.path.splitext(filename)[1]  # Extract file extension
-    new_filename = f"{instance.id}{ext}"  # Use model UUID as filename
-    return os.path.join("images/", new_filename)  # Store in 'images/' folder
+    ext = os.path.splitext(filename)[1]  # extract file extension
+    new_filename = f"{instance.id}{ext}"  # use model UUID as filename
+
+    return os.path.join("images/", new_filename)  # store in 'images/' folder
 
 
 class Image(models.Model):
@@ -72,7 +73,7 @@ class Location(models.Model):
     display_name = models.CharField(max_length=255)
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class Resource(models.Model):
@@ -128,7 +129,7 @@ class Tag(models.Model):
     creation_date = models.DateTimeField(auto_now_add=True)
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)
 
 
 class Task(models.Model):
@@ -174,4 +175,4 @@ class DiscussionEntry(models.Model):
     deletion_date = models.DateTimeField(blank=True, null=True)
 
     def __str__(self) -> str:
-        return f"{self.id}"
+        return str(self.id)

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -40,57 +40,20 @@ class FaqSerializer(serializers.ModelSerializer[Faq]):
 
 
 # MARK: Clear out image meta data. Used in Image Serializer, below.
-# def scrub_exif(image_file: InMemoryUploadedFile) -> InMemoryUploadedFile:
-#     """
-#     Remove EXIF data from JPEGs and text metadata from PNGs.
-#     """
-#     try:
-#         img = PILImage.open(image_file)
-#
-#         if img.format == "JPEG":
-#             img = img.convert("RGB")
-#             output_format = "JPEG"
-#         elif img.format == "PNG":
-#             img = img.copy()
-#             img.info = {}
-#             output_format = "PNG"
-#         else:
-#             return image_file
-#
-#         # Save the cleaned image
-#         output = io.BytesIO()
-#         img.save(
-#             output,
-#             format=output_format,
-#             quality=95 if output_format == "JPEG" else None,
-#         )
-#         output.seek(0)
-#
-#         return InMemoryUploadedFile(
-#             output,
-#             "ImageField",
-#             image_file.name,
-#             f"image/{output_format.lower()}",
-#             output.getbuffer().nbytes,
-#             None,
-#         )
-#
-#     except Exception as e:
-#         print(f"Error scrubbing EXIF: {e}")
-#         return image_file
 def scrub_exif(image_file: InMemoryUploadedFile) -> InMemoryUploadedFile:
     """
     Remove EXIF data from JPEGs and text metadata from PNGs.
     """
     try:
-        img = PILImage.open(image_file)
+        # img = PILImage.open(image_file)
+        img: PILImage.Image = PILImage.open(image_file)
         output_format = img.format
 
         if output_format == "JPEG":
-            img = img.convert("RGB")  # Remove EXIF and ensure compatibility
+            img = img.convert("RGB")
         elif output_format == "PNG":
             img = img.copy()
-            img.info = {}  # Clear metadata
+            img.info = {}
         else:
             return image_file  # Return as-is if it's not JPEG or PNG
 

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -45,7 +45,6 @@ def scrub_exif(image_file: InMemoryUploadedFile) -> InMemoryUploadedFile:
     Remove EXIF data from JPEGs and text metadata from PNGs.
     """
     try:
-        # img = PILImage.open(image_file)
         img: PILImage.Image = PILImage.open(image_file)
         output_format = img.format
 

--- a/backend/content/tests/test_image_upload.py
+++ b/backend/content/tests/test_image_upload.py
@@ -5,6 +5,7 @@ Testing for Image upload-related functionality.
 
 import io
 import os
+import uuid
 from datetime import datetime
 from typing import Generator
 
@@ -141,7 +142,15 @@ def test_image_create_view(client: APIClient, image_with_file: Image) -> None:
     uploaded_file = os.path.join(settings.MEDIA_ROOT, image.file_object.name)
     assert os.path.exists(uploaded_file)
 
-    # Get the actual filename of the "uploaded" file, so we can delete it from the file system.
+    filename_without_ext = os.path.splitext(os.path.basename(uploaded_file))[0]
+
+    try:
+        uuid_obj = uuid.UUID(filename_without_ext, version=4)
+        assert str(uuid_obj) == filename_without_ext
+    except ValueError:
+        assert False, f"Filename is not a valid UUID: {filename_without_ext}"
+
+    # Get the path and filename of the "uploaded" file, so we can delete it from the file system.
     # This is for test cleanup. In production, the file is not deleted.
     file_object = response.json()["fileObject"].split("/")[-1]
     file_to_delete = os.path.join(settings.MEDIA_ROOT, "images", file_object)

--- a/backend/content/tests/test_image_upload.py
+++ b/backend/content/tests/test_image_upload.py
@@ -3,12 +3,15 @@
 Testing for Image upload-related functionality.
 """
 
+import io
 import os
 from datetime import datetime
 from typing import Generator
 
 import pytest
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image as TestImage
 from rest_framework.test import APIClient
 
 from communities.organizations.factories import OrganizationFactory
@@ -28,6 +31,7 @@ def image_with_file() -> Generator[Image, None, None]:
     """
     # Clean up any leftover files.
     image = ImageFactory()  # create image using the factory
+
     yield image
 
     # Cleanup after the test.
@@ -121,8 +125,8 @@ def test_image_create_view(client: APIClient, image_with_file: Image) -> None:
 
     data = {"organization_id": str(org.id), "file_object": image.file_object}
 
-    # Test the upload behavior. Make the POST request to the image create endpoint.
-    # This will create a second copy of the image file in the media root.
+    # Make the POST request to the image create endpoint.
+    # This will create a second copy of the image file in the media root. This copy will have a UUID filename.
     # This is correct, default, upload behavior. POST is supposed to put a file on the server and add an Image entry to the database.
     response = client.post("/v1/content/images/", data, format="multipart")
 
@@ -133,7 +137,7 @@ def test_image_create_view(client: APIClient, image_with_file: Image) -> None:
         Image.objects.count() == 1
     ), "Expected one image in the database, but found more than one."
 
-    # Check if the file was "uploaded".
+    # Check if the file was "uploaded". "Uploaded" filename will be a UUID.
     uploaded_file = os.path.join(settings.MEDIA_ROOT, image.file_object.name)
     assert os.path.exists(uploaded_file)
 
@@ -149,6 +153,7 @@ def test_image_create_view(client: APIClient, image_with_file: Image) -> None:
 def test_image_create_missing_file(client: APIClient) -> None:
     """
     Test the create view for images with a missing file.
+    Test can return 'WARNING ... Bad Request: /v1/content/images/'. This is expected.
     """
 
     org = OrganizationFactory()
@@ -158,3 +163,74 @@ def test_image_create_missing_file(client: APIClient) -> None:
     assert response.status_code == 400
     assert "fileObject" in response.json()
     assert "No file was submitted." in response.json()["fileObject"]
+
+
+@pytest.mark.django_db
+def test_image_create_corrupted_file(client: APIClient) -> None:
+    """
+    Test the create view for images with a corrupted file.
+    The validation is likely happening in the model, not the serializer.
+    Test can return 'WARNING ... Bad Request: /v1/content/images/'. This is expected.
+    """
+
+    org = OrganizationFactory()
+    assert org is not None, "Organization was not created"
+
+    # Open a valid image file, take the first few bytes, then corrupt the rest.
+    img = TestImage.new("RGB", (100, 100), color="red")
+    img_file = io.BytesIO()
+    img.save(img_file, format="JPEG")
+    # Take the first 100 bytes
+    corrupted_img = img_file.getvalue()[:100]
+    # Add some corrupt data after
+    corrupted_img += b"corrupteddata"
+    # Wrap the corrupted image data in a SimpleUploadedFile.
+    file = SimpleUploadedFile(
+        "corrupted_image.jpg", corrupted_img, content_type="image/jpeg"
+    )
+
+    data = {"organization_id": str(org.id), "file_object": file}
+
+    response = client.post("/v1/content/images/", data, format="multipart")
+
+    assert response.status_code == 400
+    assert (
+        "Upload a valid image. The file you uploaded was either not an image or a corrupted image."
+        in response.json()["fileObject"]
+    )
+
+
+@pytest.mark.django_db
+def test_image_create_large_file(client: APIClient) -> None:
+    """
+    Test the create view for images with a large file.
+    Test can return 'WARNING ... Bad Request: /v1/content/images/'. This is expected.
+    """
+    org = OrganizationFactory()
+    assert org is not None, "Organization was not created"
+
+    # TestImage comes from the PIL import, above.
+    img = TestImage.new("RGB", (3000, 3000), color="red")
+
+    img_file = io.BytesIO()
+    # BMP is uncompressed = easy to create a large image file size.
+    img.save(img_file, format="BMP")
+    img_file.seek(0)
+
+    file = SimpleUploadedFile(
+        "large_image.bmp", img_file.getvalue(), content_type="image/bmp"
+    )
+
+    data = {"organization_id": str(org.id), "file_object": file}
+
+    response = client.post("/v1/content/images/", data, format="multipart")
+
+    assert response.status_code == 400
+
+    # DATA_UPLOAD_MAX_MEMORY_SIZE and IMAGE_UPLOAD_MAX_FILE_SIZE are set in core/settings.py.
+    # For whatever reason, the file size limit is not being enforced. To get around this,
+    # we're checking the file size in the serializer validation.
+    assert (
+        f"The file size ({file.size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes."
+        in response.json()["nonFieldErrors"]
+    )

--- a/backend/content/tests/test_image_upload.py
+++ b/backend/content/tests/test_image_upload.py
@@ -143,6 +143,7 @@ def test_image_create_view(client: APIClient, image_with_file: Image) -> None:
     try:
         uuid_obj = uuid.UUID(uuid_filename, version=4)
         assert str(uuid_obj) == uuid_filename
+
     except ValueError:
         assert False, f"Filename is not a valid UUID: {uuid_filename}"
 
@@ -183,9 +184,9 @@ def test_image_create_corrupted_file(client: APIClient) -> None:
     img = TestImage.new("RGB", (100, 100), color="red")
     img_file = io.BytesIO()
     img.save(img_file, format="JPEG")
-    # Take the first 100 bytes
+    # Take the first 100 bytes.
     corrupted_img = img_file.getvalue()[:100]
-    # Add some corrupt data after
+    # Add some corrupt data after.
     corrupted_img += b"corrupteddata"
     # Wrap the corrupted image data in a SimpleUploadedFile.
     file = SimpleUploadedFile(
@@ -231,8 +232,7 @@ def test_image_create_large_file(client: APIClient) -> None:
     assert response.status_code == 400
 
     # DATA_UPLOAD_MAX_MEMORY_SIZE and IMAGE_UPLOAD_MAX_FILE_SIZE are set in core/settings.py.
-    # For whatever reason, the file size limit is not being enforced. To get around this,
-    # we're checking the file size in the serializer validation.
+    # The file size limit is not being enforced. We're checking the file size in the serializer validation.
     assert (
         f"The file size ({file.size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes."
         in response.json()["nonFieldErrors"]

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -258,6 +258,10 @@ LOGGING = {
     },
 }
 
+# MARK: Image / Data Upload size limits
+IMAGE_UPLOAD_MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
+DATA_UPLOAD_MAX_MEMORY_SIZE = 5 * 1024 * 1024  # 5MB
+
 # MARK: API Settings
 
 from rest_framework import viewsets  # noqa: E402

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       retries: 5
     volumes:
       - ./backend/media:/app/media
+
   frontend:
     env_file:
       - .env.dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       retries: 5
     volumes:
       - ./backend/media:/app/media
-
   frontend:
     env_file:
       - .env.dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - DEBUG=${DEBUG}
       - SECRET_KEY=${SECRET_KEY}
       - VITE_FRONTEND_URL=${VITE_FRONTEND_URL}
+      - VITE_BACKEND_URL=${VITE_BACKEND_URL}
     depends_on:
       - db
     healthcheck:

--- a/frontend/modules.ts
+++ b/frontend/modules.ts
@@ -16,6 +16,7 @@ const modules: (string | [string, Record<string, object>] | NuxtModule)[] = [
       },
     },
   ],
+  "nuxt-security",
   "@nuxtjs/color-mode",
   "@nuxtjs/device",
   "@nuxt/devtools",

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -102,4 +102,20 @@ export default defineNuxtConfig({
   nitro: {
     preset: "netlify-static",
   },
+  security: {
+    headers: {
+      contentSecurityPolicy: {
+        "img-src": [
+          "'self'",
+          "data:",
+          "blob:",
+          import.meta.env.VITE_BACKEND_URL || "",
+        ],
+      },
+    },
+    removeLoggers: false, // When true, turns off console.log output? Also lookk at unplugin-remove Vite Plugin by Talljack
+    requestSizeLimiter: {
+      maxUploadFileRequestInBytes: 5000000,
+    },
+  },
 });

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -137,7 +137,8 @@ export default defineNuxtConfig({
       interval: "minute",
       whiteList: ["127.0.0.1"],
     },
-    removeLoggers: false, // When true, turns off console.log output? Also lookk at unplugin-remove Vite Plugin by Talljack
+    // When true, turns off console.log output? Also look at unplugin-remove Vite Plugin by Talljack.
+    removeLoggers: false,
     requestSizeLimiter: {
       maxUploadFileRequestInBytes: 5000000,
     },

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -113,6 +113,12 @@ export default defineNuxtConfig({
         ],
       },
     },
+    rateLimiter: {
+      // 150 requests per minute. Local machine is not rate limited.
+      tokensPerInterval: 150,
+      interval: "minute",
+      whiteList: ["127.0.0.1"],
+    },
     removeLoggers: false, // When true, turns off console.log output? Also lookk at unplugin-remove Vite Plugin by Talljack
     requestSizeLimiter: {
       maxUploadFileRequestInBytes: 5000000,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "happy-dom": "15.11.6",
     "nuxt": "3.15.4",
     "nuxt-icon": "0.6.10",
+    "nuxt-security": "2.2.0",
     "playwright": "1.49",
     "prettier": "3.4.2",
     "prettier-plugin-tailwindcss": "0.6.11",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -86,7 +86,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.23.0, @babel/core@npm:^7.26.0, @babel/core@npm:^7.26.7":
+"@babel/core@npm:^7.23.0, @babel/core@npm:^7.25.2, @babel/core@npm:^7.26.0, @babel/core@npm:^7.26.7":
   version: 7.26.10
   resolution: "@babel/core@npm:7.26.10"
   dependencies:
@@ -109,7 +109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.26.10":
+"@babel/generator@npm:^7.25.0, @babel/generator@npm:^7.26.10":
   version: 7.26.10
   resolution: "@babel/generator@npm:7.26.10"
   dependencies:
@@ -385,7 +385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.26.10, @babel/traverse@npm:^7.26.5, @babel/traverse@npm:^7.26.9":
+"@babel/traverse@npm:^7.25.3, @babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.26.10, @babel/traverse@npm:^7.26.5, @babel/traverse@npm:^7.26.9":
   version: 7.26.10
   resolution: "@babel/traverse@npm:7.26.10"
   dependencies:
@@ -2015,6 +2015,36 @@ __metadata:
     unimport: "npm:^4.1.2"
     untyped: "npm:^2.0.0"
   checksum: 10c0/f423f3b123f7e01996610df52a5709754fcc9f3bef6aaf60ad665402e320793a089bbfbeba7a4125335cda788f2637d82cc7940d0d5490cfb69b1e291c9c76f3
+  languageName: node
+  linkType: hard
+
+"@nuxt/kit@npm:^3.11.2":
+  version: 3.16.1
+  resolution: "@nuxt/kit@npm:3.16.1"
+  dependencies:
+    c12: "npm:^3.0.2"
+    consola: "npm:^3.4.2"
+    defu: "npm:^6.1.4"
+    destr: "npm:^2.0.3"
+    errx: "npm:^0.1.0"
+    exsolve: "npm:^1.0.4"
+    globby: "npm:^14.1.0"
+    ignore: "npm:^7.0.3"
+    jiti: "npm:^2.4.2"
+    klona: "npm:^2.0.6"
+    knitwork: "npm:^1.2.0"
+    mlly: "npm:^1.7.4"
+    ohash: "npm:^2.0.11"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^2.1.0"
+    scule: "npm:^1.3.0"
+    semver: "npm:^7.7.1"
+    std-env: "npm:^3.8.1"
+    ufo: "npm:^1.5.4"
+    unctx: "npm:^2.4.1"
+    unimport: "npm:^4.1.2"
+    untyped: "npm:^2.0.0"
+  checksum: 10c0/90fdd7cb4e89206aab54be3af31cf36cb4bfd18c06a79e8f95d0b4da2d6a0c03744b0c669f9e88cfa0653875536c65f48e028a5b7a55c2e2133862cdf67055f5
   languageName: node
   linkType: hard
 
@@ -5124,6 +5154,7 @@ __metadata:
     nuxt: "npm:3.15.4"
     nuxt-icon: "npm:0.6.10"
     nuxt-mail: "npm:5.1.1"
+    nuxt-security: "npm:2.2.0"
     pinia: "npm:2.3.1"
     pinia-plugin-persistedstate: "npm:4.2.0"
     playwright: "npm:1.49"
@@ -5520,6 +5551,15 @@ __metadata:
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
+  languageName: node
+  linkType: hard
+
+"basic-auth@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "basic-auth@npm:2.0.1"
+  dependencies:
+    safe-buffer: "npm:5.1.2"
+  checksum: 10c0/05f56db3a0fc31c89c86b605231e32ee143fb6ae38dc60616bc0970ae6a0f034172def99e69d3aed0e2c9e7cac84e2d63bc51a0b5ff6ab5fc8808cc8b29923c1
   languageName: node
   linkType: hard
 
@@ -6115,7 +6155,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.20.0":
+"commander@npm:^2.20.0, commander@npm:^2.20.3":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
@@ -6219,6 +6259,13 @@ __metadata:
   version: 3.4.1
   resolution: "consola@npm:3.4.1"
   checksum: 10c0/956003b5bb3d42ae0ab5c00b753e043e56c475861f31058af0c7c5741c80a95fab52d36eea5ea758212d8c52912cf9369536216fc35d1fe55396bfed67722a11
+  languageName: node
+  linkType: hard
+
+"consola@npm:^3.4.2":
+  version: 3.4.2
+  resolution: "consola@npm:3.4.2"
+  checksum: 10c0/7cebe57ecf646ba74b300bcce23bff43034ed6fbec9f7e39c27cee1dc00df8a21cd336b466ad32e304ea70fba04ec9e890c200270de9a526ce021ba8a7e4c11a
   languageName: node
   linkType: hard
 
@@ -6461,6 +6508,13 @@ __metadata:
   bin:
     cssesc: bin/cssesc
   checksum: 10c0/6bcfd898662671be15ae7827120472c5667afb3d7429f1f917737f3bf84c4176003228131b643ae74543f17a394446247df090c597bb9a728cce298606ed0aa7
+  languageName: node
+  linkType: hard
+
+"cssfilter@npm:0.0.10":
+  version: 0.0.10
+  resolution: "cssfilter@npm:0.0.10"
+  checksum: 10c0/478a227a616fb6e9bb338eb95f690df141b86231ec737cbea574484f31a09a51db894b4921afc4987459dae08d584355fd689ff2a7a7c7a74de4bb4c072ce553
   languageName: node
   linkType: hard
 
@@ -6781,7 +6835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"defu@npm:^6.1.2, defu@npm:^6.1.4":
+"defu@npm:^6.1.1, defu@npm:^6.1.2, defu@npm:^6.1.4":
   version: 6.1.4
   resolution: "defu@npm:6.1.4"
   checksum: 10c0/2d6cc366262dc0cb8096e429368e44052fdf43ed48e53ad84cc7c9407f890301aa5fcb80d0995abaaf842b3949f154d060be4160f7a46cb2bc2f7726c81526f5
@@ -11762,6 +11816,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nuxt-csurf@npm:^1.6.5":
+  version: 1.6.5
+  resolution: "nuxt-csurf@npm:1.6.5"
+  dependencies:
+    "@nuxt/kit": "npm:^3.13.2"
+    defu: "npm:^6.1.4"
+    uncsrf: "npm:^1.2.0"
+  checksum: 10c0/104b2c5ff89af3615c6f6bd2c4adc05531f20271104b331d2acbd73ee9caf6ea8b066d98d470ffd829ee21850619bf5815c87559e8e8f1723f5eeaf6ca738822
+  languageName: node
+  linkType: hard
+
 "nuxt-icon@npm:0.6.10":
   version: 0.6.10
   resolution: "nuxt-icon@npm:0.6.10"
@@ -11798,6 +11863,21 @@ __metadata:
     "@dword-design/functions": "npm:^4.0.0"
     "@nuxt/kit": "npm:^3.0.0"
   checksum: 10c0/519cdc516e6c2935e97fb237bdc591b58e83e4a727e010c0e447b7ccfc1fef4ca8af9579b2ab39932c35e0fe84edd92200b34838b7532ec85b9aca2b242805ce
+  languageName: node
+  linkType: hard
+
+"nuxt-security@npm:2.2.0":
+  version: 2.2.0
+  resolution: "nuxt-security@npm:2.2.0"
+  dependencies:
+    "@nuxt/kit": "npm:^3.11.2"
+    basic-auth: "npm:^2.0.1"
+    defu: "npm:^6.1.1"
+    nuxt-csurf: "npm:^1.6.5"
+    pathe: "npm:^1.0.0"
+    unplugin-remove: "npm:^1.0.3"
+    xss: "npm:^1.0.14"
+  checksum: 10c0/feb7e44a35ccf75e4661bfca992f35496a038bfd0b4e4080d513d8a30fc14c24aaca10ecc43aba139298c2be89057c8b199625ab8f1913da4949b813693b4780
   languageName: node
   linkType: hard
 
@@ -14405,17 +14485,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+  version: 5.1.2
+  resolution: "safe-buffer@npm:5.1.2"
+  checksum: 10c0/780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
-  languageName: node
-  linkType: hard
-
-"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
-  version: 5.1.2
-  resolution: "safe-buffer@npm:5.1.2"
-  checksum: 10c0/780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
   languageName: node
   linkType: hard
 
@@ -15718,6 +15798,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uncsrf@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "uncsrf@npm:1.2.0"
+  checksum: 10c0/608a5fe8a37bd2e06aae3c1a969cdfa4e67d9ced384b0d4405b2eabe5f21ce0e7607f937b866797bf397e742d94f2239c5164d01ac2a2f0d5f1249370bcd4122
+  languageName: node
+  linkType: hard
+
 "unctx@npm:^2.3.1, unctx@npm:^2.4.1":
   version: 2.4.1
   resolution: "unctx@npm:2.4.1"
@@ -15987,6 +16074,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unplugin-remove@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "unplugin-remove@npm:1.0.3"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.25.0"
+    "@babel/parser": "npm:^7.25.3"
+    "@babel/traverse": "npm:^7.25.3"
+    "@rollup/pluginutils": "npm:^5.1.0"
+    magic-string: "npm:^0.30.11"
+    unplugin: "npm:^1.12.0"
+  checksum: 10c0/7a382e3ca1b786adc2a8cf7469f7f35d1d3220b31bba610b1a65497978875e875ba1ccf9d7178dd463e67e2ff79311b031abe0f6f223fda7a094e712fb0d32d3
+  languageName: node
+  linkType: hard
+
 "unplugin-utils@npm:^0.2.4":
   version: 0.2.4
   resolution: "unplugin-utils@npm:0.2.4"
@@ -16071,7 +16173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unplugin@npm:^1.1.0, unplugin@npm:^1.10.0, unplugin@npm:^1.16.1":
+"unplugin@npm:^1.1.0, unplugin@npm:^1.10.0, unplugin@npm:^1.12.0, unplugin@npm:^1.16.1":
   version: 1.16.1
   resolution: "unplugin@npm:1.16.1"
   dependencies:
@@ -17195,6 +17297,18 @@ __metadata:
   version: 2.1.2
   resolution: "xmlhttprequest-ssl@npm:2.1.2"
   checksum: 10c0/70d60869323e823f473a238f78fd108437edbc3690ecd5859c39c83217080090a18899b272e515769c0d1f518cc64cbed6b6995b23fdd7ba13b297d530b6e631
+  languageName: node
+  linkType: hard
+
+"xss@npm:^1.0.14":
+  version: 1.0.15
+  resolution: "xss@npm:1.0.15"
+  dependencies:
+    commander: "npm:^2.20.3"
+    cssfilter: "npm:0.0.10"
+  bin:
+    xss: bin/xss
+  checksum: 10c0/9b31bee62a208f78e2b7bc8154e3ee87d980f4661dc4ab850ce6f4de7bc50eb152f0bdc13fa759ff8ab6d9bfdf8c0d79cf9f6f86249872b92181912309bccd08
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR addresses the issues presented in #670 .

<ins>Backend</ins>
- Validates image upload file type and content.
- Limits uploaded file size to 5MB.
- Sanitizes uploaded image file names to UUID filenames.
- Scrubs exif data / meta data from jpeg / png format files.
   - Uses Pillow. More detailed exif scrubbing is possible through the [piexif](https://pypi.org/project/piexif/) module.
- Adds pytest tests to content/tests/test_image_upload.py to increase test coverage for image upload.

<ins>Frontend</ins>
- Added nuxt-security module and set up first iteration of config.
   - This provides header- and middleware-based protection against OWASP Top Ten threats, as well as:
      - Image file source / location restriction as part of broader Content Security Policy.
      - Rate limiting.
      - Upload file size restriction now also handled on frontend.

<ins>To do</ins>
- Backend: 
   Decide if we want to implement [pyClamd](https://pypi.org/project/pyClamd/) or something similar for image file scanning. This could be run as a service in Docker.

- Frontend: 
   Configure access-control-allow-origin: * header in nuxt-security. Likely need to use VITE_FRONTEND_URL env var.
   Decide if we want to implement DOM purify.
   Needs tests (vitest and Playwright).
   
- 'Delete image' functionality (front and backend).

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #670 
