### PR TITLE
missing test for backend/communities/organizations/models.py 🧪

### DIFF
--- a/backend/communities/organizations/tests/test_org_model_str_methods.py
+++ b/backend/communities/organizations/tests/test_org_model_str_methods.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import datetime
+
+import pytest
+
+from communities.factories import StatusTypeFactory
+from communities.organizations.factories import (
+    OrganizationApplicationStatusFactory,
+    OrganizationFactory,
+    OrganizationImageFactory,
+    OrganizationTextFactory,
+)
+from communities.organizations.models import OrganizationApplication
+
+pytestmark = pytest.mark.django_db
+
+
+def test_organization_application_str() -> None:
+    """Test string representation of OrganizationApplication model."""
+
+    org = OrganizationFactory.build()
+    status = StatusTypeFactory()
+    """
+    In this test I am using OrganizationApplication directly instead of OrganizationApplicationFactory
+    which was giving me many-to-many field assignment issues
+    """
+    org_application = OrganizationApplication(
+        org=org,
+        status=status,
+        creation_date=datetime.datetime.now(tz=datetime.timezone.utc),
+    )
+
+    assert str(org_application) == f"{org_application.creation_date}"
+
+    assert str(org_application) == f"{org_application.creation_date}"
+
+
+def test_organization_application_status_str() -> None:
+    """Test string representation of OrganizationApplicationStatus model."""
+    status = OrganizationApplicationStatusFactory.build(status_name="Approved")
+    assert str(status) == "Approved"
+
+
+def test_organization_image_str() -> None:
+    """Test string representation of OrganizationImage model."""
+    org_image = OrganizationImageFactory.build()
+    assert str(org_image) == f"{org_image.id}"
+
+
+def test_organization_text_str() -> None:
+    """Test string representation of OrganizationText model."""
+    org_text = OrganizationTextFactory.build(iso="en")
+    org = org_text.org
+    assert str(org_text) == f"{org} - en"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This PR covers the missing test for `backend/communities/organizations/models.py           71      4    94%   71, 79, 88, 131`

This test the string representation methods of several model classes in `organizations/models.py`

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- [#1134](https://github.com/activist-org/activist/issues/1134)
