### PR TITLE
fix: load i18n in tests without typescript error

### DIFF
--- a/.github/workflows/pr_ci_frontend.yaml
+++ b/.github/workflows/pr_ci_frontend.yaml
@@ -53,4 +53,4 @@ jobs:
       - name: Run Vitest - Component Testing
         if: always()
         working-directory: ./frontend
-        run: sudo yarn test
+        run: sudo yarn test --silent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -408,8 +408,10 @@ We use [Vitest](https://vitest.dev/) for component and unit testing.  You can ru
 
 ```bash
 # Within ./frontend:
-yarn test
+yarn test --silent
 ```
+> [!NOTE]
+> The `--silent` flag is to suppress a lot of warnings from existing issues between Nuxt and Vitest.  If you need to see the warnings omit the `--silent` flag.
 
 Please see the [frontend testing guide](FRONTEND_TESTING.md) for information on how to write component tests.
 

--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { useNuxtApp } from "#app";
 import { config } from "@vue/test-utils";
 import { createPinia, defineStore, setActivePinia } from "pinia";
+import { createI18n } from "vue-i18n";
+import en from "~/i18n/en-US.json" assert { type: "json" };
+
 import type { UseColorModeFn } from "~/test/vitest-globals";
 
 // Set up Pinia.
@@ -19,19 +21,15 @@ const useColorModeFn: UseColorModeFn = () => ({
 globalThis.useColorModeMock = vi.fn(useColorModeFn);
 
 // Set up I18n.
-beforeAll(() => {
-  // https://github.com/nuxt/test-utils/issues/566
-  const nuxtApp = useNuxtApp();
-
-  config.global.plugins.push({
-    async install(app, ...options) {
-      // @ts-expect-error Typescript cannot detect Nuxt plugins.
-      const i18n = nuxtApp.vueApp.__VUE_I18N__;
-
-      await i18n.install(app, ...options);
-    },
-  });
+// https://github.com/nuxt-modules/i18n/issues/2637#issuecomment-2233566361
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  fallbackLocale: "en",
+  messages: Object.assign({ en }),
 });
+
+config.global.plugins.push(i18n);
 
 afterEach(() => {
   // Clean up Pinia.


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This should fix the issue pointed out in https://github.com/activist-org/activist/pull/1166

Our frontend vitest tests broke recently because a configuration field "locales" was being overwritten causing a typescript error.  This is happening because we have to reload i18n in vitest for our frontend tests to work.

There is an ongoing issue with `@nuxt/test-utils` that makes this necessary because the testing environment has multiple vue app instances in it and doesn't reference them in a consistent manner: https://github.com/nuxt-modules/i18n/issues/2637

This PR changes how i18n is initialized in vitest to get around the typescript error.  This PR also adds the `--silent` flag to running the tests in CI to reduce the amount of Nuxt related warnings that probably need to be resolved in Nuxt itself.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
