### PR TITLE
1172 - Disable CORS setting (Access-Control-Allow-Origin).

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -121,6 +121,8 @@ export default defineNuxtConfig({
   },
 
   security: {
+    // Cors not needed for frontend.
+    corsHandler: false,
     headers: {
       contentSecurityPolicy: {
         "img-src": [


### PR DESCRIPTION
Nuxt-security module provides cors protection for Nitro server. Cors is not needed here, so it is disabled.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR resolves the uncertainty about the Access-Control-Allow-Origin header that appeared after installing the nuxt-security module. It was not clear why this header was made available.

This setting is intended to configure the Nitro server (which Nuxt uses) for cross-origin connections. Since we don't anticipate cross-origin connections at the present time, cors headers are disabled.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1172 
