### PR TITLE
fix: remove upgrade-insecure-requests header in local dev

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -133,6 +133,18 @@ export default defineNuxtConfig({
           "blob:",
           import.meta.env.VITE_BACKEND_URL || "",
         ],
+        /**
+         * Header: "upgrade-insecure-requests" forces http requests to use https.
+         *
+         * Disabled in local dev environments to allow http requests in Safari.
+         * https://bugs.webkit.org/show_bug.cgi?id=250776
+         *
+         * Chromium and Firefox still allow http requests to localhost even with this header.
+         */
+        "upgrade-insecure-requests":
+          import.meta.env.VITE_FRONTEND_URL === "http://localhost:3000"
+            ? false
+            : true,
       },
     },
     rateLimiter: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "@nuxtjs/i18n": "9.3.0",
     "@nuxtjs/tailwindcss": "6.12.2",
     "@pinia/nuxt": "0.9.0",
-    "@playwright/test": "1.49.1",
+    "@playwright/test": "1.51.1",
     "@tailwindcss/typography": "0.5.16",
     "@testing-library/vue": "8.1.0",
     "@types/node": "22.12.0",
@@ -49,7 +49,6 @@
     "nuxt": "3.15.4",
     "nuxt-icon": "0.6.10",
     "nuxt-security": "2.2.0",
-    "playwright": "1.49",
     "prettier": "3.4.2",
     "prettier-plugin-tailwindcss": "0.6.11",
     "rollup": "4.32.1",
@@ -86,7 +85,7 @@
     "nuxt-mail": "5.1.1",
     "pinia": "2.3.1",
     "pinia-plugin-persistedstate": "4.2.0",
-    "playwright-core": "1.49",
+    "playwright-core": "1.51.1",
     "postcss": "8.5.1",
     "postcss-custom-properties": "14.0.4",
     "qrcode": "1.5.4",
@@ -109,7 +108,7 @@
   },
   "resolutions": {
     "chokidar": "3.6.0",
-    "playwright-core": "1.49"
+    "playwright-core": "1.51.1"
   },
   "packageManager": "yarn@4.7.0"
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2679,14 +2679,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:1.49.1":
-  version: 1.49.1
-  resolution: "@playwright/test@npm:1.49.1"
+"@playwright/test@npm:1.51.1":
+  version: 1.51.1
+  resolution: "@playwright/test@npm:1.51.1"
   dependencies:
-    playwright: "npm:1.49.1"
+    playwright: "npm:1.51.1"
   bin:
     playwright: cli.js
-  checksum: 10c0/2fca0bb7b334f7a23c7c5dfa5dbe37b47794c56f39b747c8d74a2f95c339e7902a296f2f1dd32c47bdd723cfa92cee05219f1a5876725dc89a1871b9137a286d
+  checksum: 10c0/bdb98f3df58f60b5c62e6d5c79c30910404d1855afea0803af0efd6dc63f90c473dbf92ff7dc212f1459f1d32c85dc44a60f70c2e0ea604f975b953d59523234
   languageName: node
   linkType: hard
 
@@ -5115,7 +5115,7 @@ __metadata:
     "@nuxtjs/tailwindcss": "npm:6.12.2"
     "@opentelemetry/api": "npm:1.9.0"
     "@pinia/nuxt": "npm:0.9.0"
-    "@playwright/test": "npm:1.49.1"
+    "@playwright/test": "npm:1.51.1"
     "@popperjs/core": "npm:2.11.8"
     "@somushq/vue3-friendly-captcha": "npm:1.0.2"
     "@tailwindcss/typography": "npm:0.5.16"
@@ -5158,8 +5158,7 @@ __metadata:
     nuxt-security: "npm:2.2.0"
     pinia: "npm:2.3.1"
     pinia-plugin-persistedstate: "npm:4.2.0"
-    playwright: "npm:1.49"
-    playwright-core: "npm:1.49"
+    playwright-core: "npm:1.51.1"
     postcss: "npm:8.5.1"
     postcss-custom-properties: "npm:14.0.4"
     prettier: "npm:3.4.2"
@@ -12682,27 +12681,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.49":
-  version: 1.49.1
-  resolution: "playwright-core@npm:1.49.1"
+"playwright-core@npm:1.51.1":
+  version: 1.51.1
+  resolution: "playwright-core@npm:1.51.1"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/990b619c75715cd98b2c10c1180a126e3a454b247063b8352bc67792fe01183ec07f31d30c8714c3768cefed12886d1d64ac06da701f2baafc2cad9b439e3919
+  checksum: 10c0/4f004d9dea5ecbd76b84c858fa4880ed955600b6cda972a3e8093ea47e150ce20bf2ea806e73e740497d34f4b61b080c208339a661fc75ad04d8f00bedcc21e0
   languageName: node
   linkType: hard
 
-"playwright@npm:1.49, playwright@npm:1.49.1":
-  version: 1.49.1
-  resolution: "playwright@npm:1.49.1"
+"playwright@npm:1.51.1":
+  version: 1.51.1
+  resolution: "playwright@npm:1.51.1"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.49.1"
+    playwright-core: "npm:1.51.1"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/2368762c898920d4a0a5788b153dead45f9c36c3f5cf4d2af5228d0b8ea65823e3bbe998877950a2b9bb23a211e4633996f854c6188769dc81a25543ac818ab5
+  checksum: 10c0/2aea553b8b1086ee419e72c9d4f4117686e6bdb5e09e0f47dfe563ce0f0bd79c4ee79dd9c8a0f023a2fb7803b81d4fdc552887410d16c036be07f21ab72b3f46
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Removes the `upgrade-insecure-requests` in local dev environments.  This allows playwright's webkit based browsers to make http requests when running playwright locally, as well as developers using safari locally.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1186 
