### PR TITLE
refactor: remove unused useModalHandlers imports from various components

### DIFF
--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -12,7 +12,6 @@
 <script setup lang="ts">
 import { useMagicKeys, whenever } from "@vueuse/core";
 
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { commandPaletteData } from "~/types/command-palette";
 
 const { openModal: openModalCommandPalette } = useModalHandlers(

--- a/frontend/components/card/CardConnect.vue
+++ b/frontend/components/card/CardConnect.vue
@@ -53,7 +53,6 @@ import type {
 import type { SocialLink } from "~/types/content/social-link";
 import type { Event, EventSocialLink } from "~/types/events/event";
 
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { IconMap } from "~/types/icon-map";
 
 const props = defineProps<{

--- a/frontend/components/card/CardDetails.vue
+++ b/frontend/components/card/CardDetails.vue
@@ -52,8 +52,6 @@
 </template>
 
 <script setup lang="ts">
-import { useModalHandlers } from "~/composables/useModalHandlers";
-
 const { openModal: openModalEditTextEvent } =
   useModalHandlers("ModalEditTextEvent");
 const { openModal: openModalOrganizationOverview } = useModalHandlers(

--- a/frontend/components/card/about/CardAboutEvent.vue
+++ b/frontend/components/card/about/CardAboutEvent.vue
@@ -60,8 +60,6 @@
 </template>
 
 <script setup lang="ts">
-import { useModalHandlers } from "~/composables/useModalHandlers";
-
 const { openModal: openModalEditTextEvent } =
   useModalHandlers("ModalEditTextEvent");
 

--- a/frontend/components/card/about/CardAboutGroup.vue
+++ b/frontend/components/card/about/CardAboutGroup.vue
@@ -80,7 +80,6 @@
 </template>
 
 <script setup lang="ts">
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { IconMap } from "~/types/icon-map";
 
 const { openModal: openModalEditTextGroup } =

--- a/frontend/components/card/about/CardAboutOrganization.vue
+++ b/frontend/components/card/about/CardAboutOrganization.vue
@@ -85,7 +85,6 @@
 </template>
 
 <script setup lang="ts">
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { IconMap } from "~/types/icon-map";
 
 const { openModal: openModalEditTextOrganization } = useModalHandlers(

--- a/frontend/components/card/get-involved/CardGetInvolvedEvent.vue
+++ b/frontend/components/card/get-involved/CardGetInvolvedEvent.vue
@@ -39,7 +39,6 @@
 </template>
 
 <script setup lang="ts">
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { IconMap } from "~/types/icon-map";
 
 const { openModal: openModalEditTextEvent } =

--- a/frontend/components/card/get-involved/CardGetInvolvedGroup.vue
+++ b/frontend/components/card/get-involved/CardGetInvolvedGroup.vue
@@ -36,7 +36,6 @@
 </template>
 
 <script setup lang="ts">
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { IconMap } from "~/types/icon-map";
 
 const { openModal: openModalEditTextGroup } =

--- a/frontend/components/card/get-involved/CardGetInvolvedOrganization.vue
+++ b/frontend/components/card/get-involved/CardGetInvolvedOrganization.vue
@@ -73,7 +73,6 @@
 </template>
 
 <script setup lang="ts">
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { IconMap } from "~/types/icon-map";
 
 const { openModal: openModalEditTextOrganization } = useModalHandlers(

--- a/frontend/components/media/image-carousel/MediaImageCarousel.vue
+++ b/frontend/components/media/image-carousel/MediaImageCarousel.vue
@@ -50,7 +50,6 @@
 <script setup lang="ts">
 import { register } from "swiper/element/bundle";
 
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { IconMap } from "~/types/icon-map";
 
 const props = defineProps({

--- a/frontend/components/media/image-carousel/MediaImageCarouselFull.vue
+++ b/frontend/components/media/image-carousel/MediaImageCarouselFull.vue
@@ -28,7 +28,6 @@
 <script setup lang="ts">
 import type { Swiper } from "swiper/types";
 
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { IconMap } from "~/types/icon-map";
 
 const {

--- a/frontend/components/modal/edit/ModalEditSocialLinks.vue
+++ b/frontend/components/modal/edit/ModalEditSocialLinks.vue
@@ -72,8 +72,6 @@ import type {
 } from "~/types/content/social-link";
 import type { Event, EventSocialLink } from "~/types/events/event";
 
-import { useModalHandlers } from "~/composables/useModalHandlers";
-
 const props = defineProps<{
   pageType: "organization" | "group" | "event" | "other";
 }>();

--- a/frontend/components/modal/edit/text/ModalEditTextEvent.vue
+++ b/frontend/components/modal/edit/text/ModalEditTextEvent.vue
@@ -51,8 +51,6 @@
 <script setup lang="ts">
 import type { EventUpdateTextFormData } from "~/types/events/event";
 
-import { useModalHandlers } from "~/composables/useModalHandlers";
-
 const modalName = "ModalEditTextEvent";
 const { handleCloseModal } = useModalHandlers(modalName);
 

--- a/frontend/components/modal/edit/text/ModalEditTextGroup.vue
+++ b/frontend/components/modal/edit/text/ModalEditTextGroup.vue
@@ -51,8 +51,6 @@
 <script setup lang="ts">
 import type { GroupUpdateTextFormData } from "~/types/communities/group";
 
-import { useModalHandlers } from "~/composables/useModalHandlers";
-
 const modalName = "ModalEditTextGroup";
 const { handleCloseModal } = useModalHandlers(modalName);
 

--- a/frontend/components/modal/edit/text/ModalEditTextOrganization.vue
+++ b/frontend/components/modal/edit/text/ModalEditTextOrganization.vue
@@ -51,8 +51,6 @@
 <script setup lang="ts">
 import type { OrganizationUpdateTextFormData } from "~/types/communities/organization";
 
-import { useModalHandlers } from "~/composables/useModalHandlers";
-
 const modalName = "ModalEditTextOrganization";
 const { handleCloseModal } = useModalHandlers(modalName);
 

--- a/frontend/pages/organizations/[orgId]/about.vue
+++ b/frontend/pages/organizations/[orgId]/about.vue
@@ -80,7 +80,6 @@
 </template>
 
 <script setup lang="ts">
-import { useModalHandlers } from "~/composables/useModalHandlers";
 import { BreakpointMap } from "~/types/breakpoint-map";
 import { IconMap } from "~/types/icon-map";
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description
This PR removes duplicate import statements across multiple components to improve code clarity and maintainability. The affected files had redundant type imports and composables, which have now been cleaned up.


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1189 
