### PR TITLE
WIP refactor: use composition pattern for FormTextInput

### DIFF
--- a/frontend/components/form/text/FormPasswordInput.vue
+++ b/frontend/components/form/text/FormPasswordInput.vue
@@ -1,0 +1,32 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<template>
+  <FormTextInput2 :hasError="hasError" :type="isPassword ? 'password' : 'text'">
+    <template #icons>
+      <slot name="icons"></slot>
+      <button @click="changeInputType">
+        <Icon
+          :name="isPassword ? IconMap.VISIBLE : IconMap.HIDDEN"
+          size="1.4em"
+        />
+      </button>
+    </template>
+  </FormTextInput2>
+</template>
+
+<script setup lang="ts">
+import { IconMap } from "~/types/icon-map";
+
+export interface Props {
+  hasError?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  hasError: false,
+});
+
+const isPassword = ref<boolean>(true);
+
+const changeInputType = () => {
+  isPassword.value = !isPassword.value;
+};
+</script>

--- a/frontend/components/form/text/FormTextInput2.vue
+++ b/frontend/components/form/text/FormTextInput2.vue
@@ -1,0 +1,36 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<template>
+  <div
+    class="flex max-h-[40px] select-none items-center space-x-2 rounded border py-2 pl-[12px] pr-[10px] text-left text-distinct-text"
+    :class="{
+      'border-action-red dark:border-action-red': hasError,
+      'border-interactive': !hasError,
+    }"
+  >
+    <input
+      v-model="model"
+      class="h-5 w-full bg-transparent placeholder-distinct-text outline-none"
+      :class="{
+        'py-3': !$slots.icons,
+      }"
+      type="text"
+      v-bind="$attrs"
+    />
+    <slot name="icons"></slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
+const model = defineModel<string>();
+
+export interface Props {
+  hasError?: boolean;
+}
+
+withDefaults(defineProps<Props>(), {
+  hasError: false,
+});
+</script>

--- a/frontend/pages/auth/sign-up-2.vue
+++ b/frontend/pages/auth/sign-up-2.vue
@@ -3,54 +3,45 @@
   <div class="px-4 sm:px-6 md:px-8 xl:px-24 2xl:px-36">
     <form @submit.prevent="signUp" @enter="signUp" class="space-y-4">
       <div class="col">
-        <FormTextInput
-          @update:model-value="userNameValue = $event"
+        <FormTextInput2
+          v-model="userName"
           :placeholder="$t('i18n.pages.auth.sign_up.index.enter_user_name')"
-          :model-value="userNameValue"
         />
       </div>
       <div>
-        <FormTextInput
-          @update:model-value="passwordValue = $event"
-          @input="checkRules"
-          @blurred="
-            isBlurred = true;
-            isFocused = false;
-          "
-          @focused="
-            isFocused = true;
-            isBlurred = false;
-          "
+        <FormPasswordInput
+          @input="handlePasswordInput"
+          @blur="isPasswordFocused = false"
+          @focus="isPasswordFocused = true"
+          :value="password"
           :placeholder="$t('i18n._global.enter_password')"
-          :is-icon-visible="true"
-          input-type="password"
-          :model-value="passwordValue"
-          :icons="[IconMap.VISIBLE]"
-          :error="!isAllRulesValid && isBlurred"
+          :hasError="
+            !isPasswordFocused && password.length > 0 && !isAllRulesValid
+          "
         />
       </div>
-      <IndicatorPasswordStrength :password-value="passwordValue" />
+      <IndicatorPasswordStrength :password-value="password" />
       <TooltipPasswordRequirements
-        v-if="
-          !!passwordValue?.length &&
-          !isAllRulesValid &&
-          (!isBlurred || isFocused)
-        "
+        v-if="isPasswordFocused && password.length > 0 && !isAllRulesValid"
         :rules="rules"
       />
       <div>
-        <FormTextInput
-          @update:model-value="confirmPasswordValue = $event"
+        <FormPasswordInput
+          v-model="confirmPassword"
           :placeholder="$t('i18n._global.repeat_password')"
-          :is-icon-visible="true"
-          input-type="password"
-          :model-value="confirmPasswordValue"
-          :icons="
-            isPasswordMatch(passwordValue, confirmPasswordValue)
-              ? [IconMap.CHECK, IconMap.VISIBLE]
-              : [IconMap.X_LG, IconMap.VISIBLE]
-          "
-        />
+        >
+          <template #icons>
+            <span>
+              <Icon
+                v-if="doPasswordsMatch"
+                :name="IconMap.CHECK"
+                size="1.2em"
+                color="#3BA55C"
+              />
+              <Icon v-else :name="IconMap.X_LG" size="1.2em" color="#BA3D3B" />
+            </span>
+          </template>
+        </FormPasswordInput>
       </div>
       <div class="flex flex-col space-y-3">
         <FriendlyCaptcha />
@@ -93,19 +84,29 @@
 </template>
 
 <script setup lang="ts">
+// I have no idea why Nuxt can't find this component
+import FormPasswordInput from "~/components/form/text/FormPasswordInput.vue";
 import { IconMap } from "~/types/icon-map";
 
 const localePath = useLocalePath();
 
-const userNameValue = ref("");
-const passwordValue = ref("");
-const confirmPasswordValue = ref("");
+const userName = ref("");
+const password = ref("");
+const confirmPassword = ref("");
 const hasRed = ref(false);
-const isBlurred = ref(false);
-const isFocused = ref(false);
+const isPasswordFocused = ref(false);
 
 const { rules, isAllRulesValid, checkRules, isPasswordMatch } =
   usePasswordRules();
+
+const doPasswordsMatch = computed<boolean>(() =>
+  isPasswordMatch(password.value, confirmPassword.value)
+);
+
+const handlePasswordInput = (event: Event & { target: HTMLInputElement }) => {
+  checkRules(event);
+  password.value = event.target.value;
+};
 
 const signUp = () => {};
 </script>

--- a/frontend/test/pages/auth/sign-up-2.spec.ts
+++ b/frontend/test/pages/auth/sign-up-2.spec.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import SignUp from "@/pages/auth/sign-up-2.vue";
+import render from "@/test/render";
+import { fireEvent, screen, waitFor, within } from "@testing-library/vue";
+
+import {
+  PASSWORD_STRENGTH_COLOR as COLOR,
+  PASSWORD_RATING as RATING,
+} from "~/test-utils/constants";
+
+describe("sign-up", () => {
+  it("shows error border on blur when password invalid", async () => {
+    await render(SignUp);
+
+    const passwordInput = screen.getByPlaceholderText(/enter your password/i);
+
+    expect(passwordInput.parentElement!.className).toContain(
+      "border-interactive"
+    );
+
+    await fireEvent.update(passwordInput, "a");
+    await fireEvent.blur(passwordInput);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(/enter your password/i).parentElement!.className
+      ).toContain("border-action-red dark:border-action-red");
+    });
+  });
+
+  it("shows green check when passwords match", async () => {
+    await render(SignUp);
+
+    const passwordInput = screen.getByPlaceholderText(/enter your password/i);
+
+    await fireEvent.update(passwordInput, "abcd");
+    await fireEvent.blur(passwordInput);
+
+    const repeatPasswordInput = screen.getByPlaceholderText(/repeat password/i);
+
+    await fireEvent.update(repeatPasswordInput, "ab");
+
+    let icon = await screen.findByTestId("extra-icon");
+    expect(icon.style.color).toBe("#BA3D3B");
+
+    await fireEvent.update(repeatPasswordInput, "abcd");
+
+    await waitFor(() => {
+      icon = screen.getByTestId("extra-icon");
+      expect(icon.style.color).toBe("#3BA55C");
+    });
+  });
+
+  it.each([
+    ["a", RATING.VERY_WEAK],
+    ["Activis", RATING.WEAK],
+    ["Activist4Climat", RATING.MEDIUM],
+    ["Activist4ClimateChange", RATING.STRONG],
+    ["Activist4ClimateChange!", RATING.VERY_STRONG],
+  ])("shows password %s has rating of %s", async (password, ratingText) => {
+    await render(SignUp);
+
+    const passwordInput = screen.getByPlaceholderText(/enter your password/i);
+
+    await fireEvent.update(passwordInput, password);
+
+    await waitFor(() => {
+      const rating = screen.getByTestId("sign-in-password-strength-text");
+      expect(rating.textContent).toContain(ratingText);
+    });
+  });
+
+  it.each([
+    [
+      "a",
+      "20%",
+      (progressBar: HTMLElement) =>
+        expect(progressBar.className).toMatch(COLOR.RED),
+    ],
+    [
+      "Activis",
+      "40%",
+      (progressBar: HTMLElement) =>
+        expect(progressBar.className).toMatch(COLOR.ORANGE),
+    ],
+    [
+      "Activist4Climat",
+      "60%",
+      (progressBar: HTMLElement) =>
+        expect(progressBar.className).toMatch(COLOR.YELLOW),
+    ],
+    [
+      "Activist4ClimateChange",
+      "80%",
+      (progressBar: HTMLElement) =>
+        expect(progressBar.className).toMatch(COLOR.GREEN),
+    ],
+    [
+      "Activist4ClimateChange!",
+      "100%",
+      (progressBar: HTMLElement) =>
+        expect(progressBar.classList).not.toContain("bg"),
+    ],
+  ])(
+    "shows password %s has progress of %s",
+    async (password, progress, expectColor) => {
+      await render(SignUp);
+
+      const passwordInput = screen.getByPlaceholderText(/enter your password/i);
+
+      await fireEvent.update(passwordInput, password);
+
+      await waitFor(() => {
+        const progressBar = screen.getByTestId(
+          "password-strength-indicator-progress"
+        );
+        expect(progressBar.style.width).toBe(progress);
+        expectColor(progressBar);
+      });
+    }
+  );
+
+  it.each([
+    [
+      "a",
+      [
+        { rule: "capital-letters", passed: false },
+        { rule: "contains-numbers", passed: false },
+        { rule: "contains-special-chars", passed: false },
+        { rule: "lower-case-letters", passed: true },
+        { rule: "number-of-chars", passed: false },
+      ],
+    ],
+    [
+      "ABCEDFGHIJK",
+      [
+        { rule: "capital-letters", passed: true },
+        { rule: "contains-numbers", passed: false },
+        { rule: "contains-special-chars", passed: false },
+        { rule: "lower-case-letters", passed: false },
+        { rule: "number-of-chars", passed: false },
+      ],
+    ],
+    [
+      "#$%",
+      [
+        { rule: "capital-letters", passed: false },
+        { rule: "contains-numbers", passed: false },
+        { rule: "contains-special-chars", passed: true },
+        { rule: "lower-case-letters", passed: false },
+        { rule: "number-of-chars", passed: false },
+      ],
+    ],
+    [
+      "012345678912",
+      [
+        { rule: "capital-letters", passed: false },
+        { rule: "contains-numbers", passed: true },
+        { rule: "contains-special-chars", passed: false },
+        { rule: "lower-case-letters", passed: false },
+        { rule: "number-of-chars", passed: true },
+      ],
+    ],
+  ])("shows rule violations for password: %s", async (password, rules) => {
+    await render(SignUp);
+
+    const passwordInput = screen.getByPlaceholderText(/enter your password/i);
+
+    await fireEvent.update(passwordInput, password);
+    await screen.findByText(/for your security/i);
+
+    for (const { rule, passed } of rules) {
+      const line = screen.getByTestId(rule);
+
+      const icon = await within(line).findByRole("img", {
+        name: passed ? "passed" : "failed",
+      });
+
+      expect(icon.style.color).toBe(passed ? "#198754" : "#BA3D3B");
+    }
+  });
+});


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This refactors the FormTextInput from a component that handles both text and password inputs with a lot of imperative if statements to using a composition pattern instead.

I have also deliberately created a duplicate of the sign-in page so I could test the new pattern against the old pattern side by side.  I will remove the duplicates in my next PR.

I'm running into some weird Nuxt crashes on my local dev where Nuxt can't seem to find the new files.  No idea why atm.  I'm curious if the tests will pass in CI

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
