### PR TITLE
Fix mypy Type Errors in Backend Files (#1190)

### DIFF
--- a/.github/workflows/pr_ci_backend.yaml
+++ b/.github/workflows/pr_ci_backend.yaml
@@ -8,6 +8,8 @@ on:
       - opened
       - reopened
       - synchronize
+    paths:
+      - "backend/**"
   push:
     branches:
       - main

--- a/.github/workflows/pr_ci_frontend.yaml
+++ b/.github/workflows/pr_ci_frontend.yaml
@@ -8,6 +8,8 @@ on:
       - opened
       - reopened
       - synchronize
+    paths:
+      - "frontend/**"
   push:
     branches:
       - main

--- a/backend/authentication/admin.py
+++ b/backend/authentication/admin.py
@@ -81,7 +81,7 @@ class UserAdmin(BaseUserAdmin[UserModel]):
     # The forms to add and change user instances.
     form = UserChangeForm
     add_form = UserCreationForm
-
+    
     # The fields to be used in displaying the User model.
     list_display = ["username", "email", "is_admin"]
     list_filter = ["is_admin"]

--- a/backend/authentication/admin.py
+++ b/backend/authentication/admin.py
@@ -81,7 +81,7 @@ class UserAdmin(BaseUserAdmin[UserModel]):
     # The forms to add and change user instances.
     form = UserChangeForm
     add_form = UserCreationForm
-    
+
     # The fields to be used in displaying the User model.
     list_display = ["username", "email", "is_admin"]
     list_filter = ["is_admin"]

--- a/backend/core/management/commands/wait_for_db.py
+++ b/backend/core/management/commands/wait_for_db.py
@@ -2,11 +2,12 @@
 import sys
 import time
 from argparse import ArgumentParser
-from typing import TypedDict, Unpack
+from typing import TypedDict
 
 from django.core.management.base import BaseCommand
 from django.db import connection
 from django.db.utils import OperationalError
+from typing_extensions import Unpack
 
 
 class Options(TypedDict):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -63,10 +63,8 @@ omit = [
 [tool.mypy]
 mypy_path = "backend"
 plugins = ["mypy_django_plugin.main", "mypy_drf_plugin.main"]
-ignore_missing_imports = true
 strict = true
 exclude = ["^.*/factories\\.py$"]
-enable_incomplete_feature = ["Unpack"]
 
 [[tool.mypy.overrides]]
 module = ["authentication.*", "content.*", "communities.*", "events.*"]


### PR DESCRIPTION


### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description


This pull request resolves the` **mypy**` type checking errors in multiple backend files. These errors were related to incorrect use of type annotations, particularly in the imports and the UserAdmin class. The fixes align the codebase with proper type checking and ensure that the backend is compliant with Python's typing standards.


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
- see the issue [here ](https://github.com/activist-org/activist/issues/1190)
