### PR TITLE
Doc: Exclude str method and meta class from numpy doc validation

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -89,3 +89,9 @@ checks = [
     "EX01",
     "SA01",
 ]
+
+exclude = [
+    "^.*\\.Meta$",  # Exclude all Meta classes
+    "^.*\\.__str__$",  # Exclude all __str__ methods
+    "^__init__$"  # Exclude module __init__ files
+]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -91,7 +91,7 @@ checks = [
 ]
 
 exclude = [
-    "^.*\\.Meta$",  # Exclude all Meta classes
-    "^.*\\.__str__$",  # Exclude all __str__ methods
-    "^__init__$"  # Exclude module __init__ files
+    "^.*\\.Meta$",    # Meta classes
+    "^.*\\.__str__$", # __str__ methods
+    "^__init__$",     # __init__ files
 ]


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This pull request contains config to exclude  `__str__` or `meta class` from numpy doc validation. After adding the config
`__str__` warning were suppressed. I have also added the config for meta and `__init__`

<img width="1261" alt="Screenshot 2025-04-21 at 9 09 20 PM" src="https://github.com/user-attachments/assets/916ca403-5bae-45ec-b193-5a186a499d9a" />


### Changes
Backend/pyproject.toml

### Testing
I have done the backend testing Attached are the result
<img width="1257" alt="Screenshot 2025-04-21 at 9 22 02 PM" src="https://github.com/user-attachments/assets/915e92c6-8335-41fa-aab9-49b3e8d76a25" />
<img width="1263" alt="Screenshot 2025-04-21 at 9 22 17 PM" src="https://github.com/user-attachments/assets/9fd31544-3d99-460e-8053-97617c61c9be" />
<img width="1261" alt="Screenshot 2025-04-21 at 9 24 12 PM" src="https://github.com/user-attachments/assets/7a4b63ec-044e-484c-b52d-d028d4dd14de" />





### Related issue

[Issue 1198](https://github.com/activist-org/activist/issues/1198)

