### PR TITLE
added unit tests for the utils.py file

### DIFF
--- a/backend/utils/tests/test_utils.py
+++ b/backend/utils/tests/test_utils.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Unit tests for the utilities.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+
+from rest_framework.exceptions import ValidationError
+from utils.utils import (
+    validate_creation_and_deletion_dates,
+    validate_creation_and_deprecation_dates,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_validate_creation_and_deletion_dates_valid() -> None:
+    """
+    Test validate_creation_and_deletion_dates with valid dates.
+    """
+    creation_date = datetime.now()
+    deletion_date = creation_date + timedelta(days=1)
+
+    data = {
+        "creation_date": creation_date,
+        "deletion_date": deletion_date,
+    }
+
+    validate_creation_and_deletion_dates(data)
+
+
+def test_validate_creation_and_deletion_dates_invalid() -> None:
+    """
+    Test validate_creation_and_deletion_dates with invalid date order.
+    """
+    creation_date = datetime.now()
+    deletion_date = creation_date - timedelta(days=1)
+
+    data = {
+        "creation_date": creation_date,
+        "deletion_date": deletion_date,
+    }
+
+    with pytest.raises(ValidationError) as exc:
+        validate_creation_and_deletion_dates(data)
+
+    assert "deletion_date cannot be before creation_date" in str(exc.value)
+
+
+def test_validate_creation_and_deprecation_dates_valid() -> None:
+    """
+    Test validate_creation_and_deprecation_dates with valid dates.
+    """
+    creation_date = datetime.now()
+    deprecation_date = creation_date + timedelta(days=2)
+
+    data = {
+        "creation_date": creation_date,
+        "deprecation_date": deprecation_date,
+    }
+
+    validate_creation_and_deprecation_dates(data)
+
+
+def test_validate_creation_and_deprecation_dates_invalid() -> None:
+    """
+    Test validate_creation_and_deprecation_dates with invalid date order.
+    """
+    creation_date = datetime.now()
+    deprecation_date = creation_date - timedelta(days=3)
+
+    data = {
+        "creation_date": creation_date,
+        "deprecation_date": deprecation_date,
+    }
+
+    with pytest.raises(ValidationError) as exc:
+        validate_creation_and_deprecation_dates(data)
+
+    assert "deprecation_date cannot be before creation_date" in str(exc.value)

--- a/backend/utils/tests/test_utils.py
+++ b/backend/utils/tests/test_utils.py
@@ -3,10 +3,11 @@
 Unit tests for the utilities.
 """
 
-import pytest
 from datetime import datetime, timedelta
 
+import pytest
 from rest_framework.exceptions import ValidationError
+
 from utils.utils import (
     validate_creation_and_deletion_dates,
     validate_creation_and_deprecation_dates,


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This PR adds unit tests for the utils.py file while keeping the existing patterns intact. The utils.py file now has 100% test coverage.

```
content/serializers.py                        78     14    82%   86-91, 113-115, 148, 261-275
content/urls.py                               10      0   100%
content/views.py                             163    111    32%   35-43, 49-60, 63-73, 76-86, 89-100, 103-112, 125-133, 139-150, 153-156, 159-170, 173-184, 187-196, 208-215, 221-244, 247-256, 259-270, 273-284, 287-296
core/admin.py                                  4      0   100%
core/custom_settings.py                        2      0   100%
core/exception_handler.py                     10      0   100%
core/paginator.py                              6      0   100%
core/settings.py                              51      2    96%   21-22
core/urls.py                                   8      0   100%
events/admin.py                                8      0   100%
events/apps.py                                 4      0   100%
events/models.py                              75      0   100%
events/serializers.py                         57      8    86%   130, 138, 158-163, 197-199
events/urls.py                                 8      0   100%
events/views.py                              120     20    83%   54, 64-65, 85-87, 107, 116-117, 131, 138-139, 164, 171-172, 197, 203, 209, 233-234
utils/models.py                                1      0   100%
utils/utils.py                                 9      0   100%

```


### Related issue

- #1238
