### PR TITLE
#1060 API calls in layouts and remove all page calls

### DIFF
--- a/frontend/layouts/event/EventList.vue
+++ b/frontend/layouts/event/EventList.vue
@@ -18,7 +18,7 @@
         class="bg-layer-0 pt-8 transition-padding duration-500 md:pt-0"
         :class="sidebarContentDynamicClass"
       >
-        <NuxtPage />
+        <NuxtPage :events="events" />
       </div>
       <FooterWebsite
         class="pb-24 transition-padding duration-500 md:pb-12"
@@ -33,6 +33,11 @@ import {
   getSidebarContentDynamicClass,
   getSidebarFooterDynamicClass,
 } from "~/utils/sidebarUtils";
+
+const eventStore = useEventStore();
+await eventStore.fetchAll();
+
+const { events } = eventStore;
 
 const { handleCloseModal: handleCloseModalUploadImages } =
   useModalHandlers("ModalUploadImages");

--- a/frontend/layouts/event/EventPage.vue
+++ b/frontend/layouts/event/EventPage.vue
@@ -18,7 +18,7 @@
         class="bg-layer-0 pt-8 transition-padding duration-500 md:pt-0"
         :class="sidebarContentDynamicClass"
       >
-        <NuxtPage />
+        <NuxtPage :event="event" />
       </div>
       <FooterWebsite
         class="pb-24 transition-padding duration-500 md:pb-12"
@@ -33,6 +33,14 @@ import {
   getSidebarContentDynamicClass,
   getSidebarFooterDynamicClass,
 } from "~/utils/sidebarUtils";
+
+const paramsEventId = useRoute().params.eventId;
+const eventId = typeof paramsEventId === "string" ? paramsEventId : undefined;
+
+const eventStore = useEventStore();
+await eventStore.fetchById(eventId);
+
+const { event } = eventStore;
 
 const { handleCloseModal: handleCloseModalUploadImages } =
   useModalHandlers("ModalUploadImages");

--- a/frontend/layouts/group/GroupPage.vue
+++ b/frontend/layouts/group/GroupPage.vue
@@ -18,7 +18,7 @@
         class="bg-layer-0 pt-8 transition-padding duration-500 md:pt-0"
         :class="sidebarContentDynamicClass"
       >
-        <NuxtPage />
+        <NuxtPage :group="group" />
       </div>
       <FooterWebsite
         class="pb-24 transition-padding duration-500 md:pb-12"
@@ -33,6 +33,14 @@ import {
   getSidebarContentDynamicClass,
   getSidebarFooterDynamicClass,
 } from "~/utils/sidebarUtils";
+
+const paramsGroupId = useRoute().params.groupid;
+const groupId = typeof paramsGroupId === "string" ? paramsGroupId : undefined;
+
+const groupStore = useGroupStore();
+await groupStore.fetchById(groupId);
+
+const { group } = groupStore;
 
 const { handleCloseModal: handleCloseModalUploadImages } =
   useModalHandlers("ModalUploadImages");

--- a/frontend/layouts/organization/OrganizationList.vue
+++ b/frontend/layouts/organization/OrganizationList.vue
@@ -19,7 +19,7 @@
         class="bg-layer-0 pt-8 transition-padding duration-500 md:pt-0"
         :class="sidebarContentDynamicClass"
       >
-        <NuxtPage />
+        <NuxtPage :organizations="organizations" />
       </div>
       <FooterWebsite
         class="pb-24 transition-padding duration-500 md:pb-12"
@@ -36,12 +36,15 @@ import {
   getSidebarFooterDynamicClass,
 } from "~/utils/sidebarUtils";
 
-const handleUploadComplete = async (fileUploadEntity: FileUploadEntity) => {
-  const orgStore = useOrganizationStore();
+const organizationStore = useOrganizationStore();
+await organizationStore.fetchAll();
 
+const { organizations } = organizationStore;
+
+const handleUploadComplete = async (fileUploadEntity: FileUploadEntity) => {
   if (fileUploadEntity === FileUploadEntity.ORGANIZATION_CAROUSEL) {
     const { fetchOrganizationImages } = useFileManager(
-      orgStore.organization.id
+      organizationStore.organization.id
     );
     await fetchOrganizationImages();
   }

--- a/frontend/layouts/organization/OrganizationPage.vue
+++ b/frontend/layouts/organization/OrganizationPage.vue
@@ -19,7 +19,7 @@
         class="bg-layer-0 pt-8 transition-padding duration-500 md:pt-0"
         :class="sidebarContentDynamicClass"
       >
-        <NuxtPage />
+        <NuxtPage :organization="organization" />
       </div>
       <FooterWebsite
         class="pb-24 transition-padding duration-500 md:pb-12"
@@ -36,12 +36,18 @@ import {
   getSidebarFooterDynamicClass,
 } from "~/utils/sidebarUtils";
 
-const handleUploadComplete = async (fileUploadEntity: FileUploadEntity) => {
-  const orgStore = useOrganizationStore();
+const paramsOrgId = useRoute().params.orgId;
+const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
 
+const organizationStore = useOrganizationStore();
+await organizationStore.fetchById(orgId);
+
+const { organization } = organizationStore;
+
+const handleUploadComplete = async (fileUploadEntity: FileUploadEntity) => {
   if (fileUploadEntity === FileUploadEntity.ORGANIZATION_CAROUSEL) {
     const { fetchOrganizationImages } = useFileManager(
-      orgStore.organization.id
+      organizationStore.organization.id
     );
     await fetchOrganizationImages();
   }

--- a/frontend/pages/events/[eventId]/about.vue
+++ b/frontend/pages/events/[eventId]/about.vue
@@ -80,18 +80,16 @@
 </template>
 
 <script setup lang="ts">
+import type { Event } from "~/types/events/event";
+
 import { BreakpointMap } from "~/types/breakpoint-map";
 import { IconMap } from "~/types/icon-map";
 
 const { openModal: openModalSharePage } = useModalHandlers("ModalSharePage");
 
-const paramsEventId = useRoute().params.eventId;
-const eventId = typeof paramsEventId === "string" ? paramsEventId : undefined;
-
-const eventStore = useEventStore();
-await eventStore.fetchById(eventId);
-
-const { event } = eventStore;
+defineProps<{
+  event: Event;
+}>();
 
 const textExpanded = ref(false);
 const expandReduceText = () => {

--- a/frontend/pages/events/[eventId]/discussion.vue
+++ b/frontend/pages/events/[eventId]/discussion.vue
@@ -40,17 +40,16 @@
 </template>
 
 <script setup lang="ts">
+import type { Event } from "~/types/events/event";
+
 import { IconMap } from "~/types/icon-map";
+
+defineProps<{
+  event: Event;
+}>();
 
 const aboveMediumBP = useBreakpoint("md");
 
-const paramsEventId = useRoute().params.eventId;
-const eventId = typeof paramsEventId === "string" ? paramsEventId : undefined;
-
-const eventStore = useEventStore();
-await eventStore.fetchById(eventId);
-
-const { event } = eventStore;
 // const event = {
 //   name: "Test Event",
 //   discussion: [

--- a/frontend/pages/events/[eventId]/index.vue
+++ b/frontend/pages/events/[eventId]/index.vue
@@ -68,19 +68,16 @@
 </template>
 
 <script setup lang="ts">
+import type { Event } from "~/types/events/event";
 import type { MenuSelector } from "~/types/menu/menu-selector";
 
 import useMenuEntriesState from "~/composables/useMenuEntriesState";
 import { BreakpointMap } from "~/types/breakpoint-map";
 import { IconMap } from "~/types/icon-map";
 
-const paramsEventId = useRoute().params.eventId;
-const eventId = typeof paramsEventId === "string" ? paramsEventId : undefined;
-
-const eventStore = useEventStore();
-await eventStore.fetchById(eventId);
-
-const { event } = eventStore;
+const props = defineProps<{
+  event: Event;
+}>();
 
 const localPath = useLocalePath();
 
@@ -101,10 +98,10 @@ const handleResize = () => {
     const currentRoute = useRoute();
 
     if (
-      currentRoute.path !== `/${locale.value}/events/${eventId}/about` ||
-      currentRoute.path === `/${locale.value}/events/${eventId}/`
+      currentRoute.path !== `/${locale.value}/events/${props.event.id}/about` ||
+      currentRoute.path === `/${locale.value}/events/${props.event.id}/`
     ) {
-      navigateTo(`/${locale.value}/events/${eventId}/about`);
+      navigateTo(`/${locale.value}/events/${props.event.id}/about`);
     }
   }
 };

--- a/frontend/pages/events/[eventId]/resources.vue
+++ b/frontend/pages/events/[eventId]/resources.vue
@@ -38,13 +38,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Event } from "~/types/events/event";
+
 import { IconMap } from "~/types/icon-map";
 
-const paramsEventId = useRoute().params.eventId;
-const eventId = typeof paramsEventId === "string" ? paramsEventId : undefined;
-
-const eventStore = useEventStore();
-await eventStore.fetchById(eventId);
-
-const { event } = eventStore;
+defineProps<{
+  event: Event;
+}>();
 </script>

--- a/frontend/pages/events/[eventId]/settings.vue
+++ b/frontend/pages/events/[eventId]/settings.vue
@@ -38,11 +38,9 @@
 </template>
 
 <script setup lang="ts">
-const paramsEventId = useRoute().params.eventId;
-const eventId = typeof paramsEventId === "string" ? paramsEventId : undefined;
+import type { Event } from "~/types/events/event";
 
-const eventStore = useEventStore();
-await eventStore.fetchById(eventId);
-
-const { event } = eventStore;
+defineProps<{
+  event: Event;
+}>();
 </script>

--- a/frontend/pages/events/[eventId]/tasks.vue
+++ b/frontend/pages/events/[eventId]/tasks.vue
@@ -30,13 +30,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Event } from "~/types/events/event";
+
 import { IconMap } from "~/types/icon-map";
 
-const paramsEventId = useRoute().params.eventId;
-const eventId = typeof paramsEventId === "string" ? paramsEventId : undefined;
-
-const eventStore = useEventStore();
-await eventStore.fetchById(eventId);
-
-const { event } = eventStore;
+defineProps<{
+  event: Event;
+}>();
 </script>

--- a/frontend/pages/events/[eventId]/team.vue
+++ b/frontend/pages/events/[eventId]/team.vue
@@ -37,13 +37,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Event } from "~/types/events/event";
+
 import { IconMap } from "~/types/icon-map";
 
-const paramsEventId = useRoute().params.eventId;
-const eventId = typeof paramsEventId === "string" ? paramsEventId : undefined;
-
-const eventStore = useEventStore();
-await eventStore.fetchById(eventId);
-
-const { event } = eventStore;
+defineProps<{
+  event: Event;
+}>();
 </script>

--- a/frontend/pages/events/index.vue
+++ b/frontend/pages/events/index.vue
@@ -22,8 +22,9 @@
 </template>
 
 <script setup lang="ts">
-const eventStore = useEventStore();
-await eventStore.fetchAll();
+import type { Event } from "~/types/events/event";
 
-const { events } = eventStore;
+defineProps<{
+  events: Event[];
+}>();
 </script>

--- a/frontend/pages/groups/index.vue
+++ b/frontend/pages/groups/index.vue
@@ -22,10 +22,9 @@
 </template>
 
 <script setup lang="ts">
-const { data: groups } = await useFetch(
-  `${BASE_BACKEND_URL}/communities/groups/`,
-  {
-    method: "GET",
-  }
-);
+import type { Group } from "~/types/communities/group";
+
+defineProps<{
+  groups: Group[];
+}>();
 </script>

--- a/frontend/pages/organizations/[orgId]/about.vue
+++ b/frontend/pages/organizations/[orgId]/about.vue
@@ -80,21 +80,19 @@
 </template>
 
 <script setup lang="ts">
+import type { Organization } from "~/types/communities/organization";
+
 import { BreakpointMap } from "~/types/breakpoint-map";
 import { FileUploadEntity } from "~/types/content/file-upload-entity";
 import { IconMap } from "~/types/icon-map";
 
+defineProps<{
+  organization: Organization;
+}>();
+
 const { openModal: openModalSharePage } = useModalHandlers("ModalSharePage");
 
 const aboveLargeBP = useBreakpoint("lg");
-
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
-
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
 
 const textExpanded = ref(false);
 const expandReduceText = () => {

--- a/frontend/pages/organizations/[orgId]/affiliates.vue
+++ b/frontend/pages/organizations/[orgId]/affiliates.vue
@@ -38,13 +38,11 @@
 </template>
 
 <script setup lang="ts">
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
+import type { Organization } from "~/types/communities/organization";
 
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+defineProps<{
+  organization: Organization;
+}>();
 
 // const orgSupporters = [];
 </script>

--- a/frontend/pages/organizations/[orgId]/application.vue
+++ b/frontend/pages/organizations/[orgId]/application.vue
@@ -19,3 +19,11 @@
     </div> -->
   </div>
 </template>
+
+<script setup lang="ts">
+// import type { Organization } from "~/types/communities/organization";
+
+// defineProps<{
+//   organization: Organization;
+// }>();
+</script>

--- a/frontend/pages/organizations/[orgId]/events.vue
+++ b/frontend/pages/organizations/[orgId]/events.vue
@@ -46,13 +46,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Organization } from "~/types/communities/organization";
+
 import { IconMap } from "~/types/icon-map";
 
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
-
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+defineProps<{
+  organization: Organization;
+}>();
 </script>

--- a/frontend/pages/organizations/[orgId]/faq.vue
+++ b/frontend/pages/organizations/[orgId]/faq.vue
@@ -32,17 +32,14 @@
 </template>
 
 <script setup lang="ts">
+import type { Organization } from "~/types/communities/organization";
 import type { FaqEntry } from "~/types/content/faq-entry.d";
 
 import { IconMap } from "~/types/icon-map";
 
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
-
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+defineProps<{
+  organization: Organization;
+}>();
 
 const orgFAQs: FaqEntry[] = [];
 </script>

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/about.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/about.vue
@@ -94,15 +94,11 @@ import { FileUploadEntity } from "~/types/content/file-upload-entity";
 import { IconMap } from "~/types/icon-map";
 import { getGroupSubPages } from "~/utils/groupSubPages";
 
+defineProps<{
+  group: Group;
+}>();
+
 const aboveLargeBP = useBreakpoint("lg");
-
-const paramsGroupId = useRoute().params.groupid;
-const groupId = typeof paramsGroupId === "string" ? paramsGroupId : undefined;
-
-const groupStore = useGroupStore();
-await groupStore.fetchById(groupId);
-
-const group: Group = groupStore.group;
 
 const groupSubPages = getGroupSubPages();
 

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/events.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/events.vue
@@ -48,13 +48,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Group } from "~/types/communities/group";
+
+defineProps<{
+  group: Group;
+}>();
+
 const groupSubPages = getGroupSubPages();
-
-const paramsGroupId = useRoute().params.groupId;
-const groupId = typeof paramsGroupId === "string" ? paramsGroupId : undefined;
-
-const groupStore = useGroupStore();
-await groupStore.fetchById(groupId);
-
-const { group } = groupStore;
 </script>

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/faq.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/faq.vue
@@ -38,15 +38,11 @@
 </template>
 
 <script setup lang="ts">
-import { getGroupSubPages } from "~/utils/groupSubPages";
+import type { Group } from "~/types/communities/group";
+
+defineProps<{
+  group: Group;
+}>();
 
 const groupSubPages = getGroupSubPages();
-
-const paramsGroupId = useRoute().params.groupId;
-const groupId = typeof paramsGroupId === "string" ? paramsGroupId : undefined;
-
-const groupStore = useGroupStore();
-await groupStore.fetchById(groupId);
-
-const { group } = groupStore;
 </script>

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/resources.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/resources.vue
@@ -43,15 +43,11 @@
 </template>
 
 <script setup lang="ts">
-import { getGroupSubPages } from "~/utils/groupSubPages";
+import type { Group } from "~/types/communities/group";
 
-const paramsGroupId = useRoute().params.groupId;
-const groupId = typeof paramsGroupId === "string" ? paramsGroupId : undefined;
-
-const groupStore = useGroupStore();
-await groupStore.fetchById(groupId);
-
-const { group } = groupStore;
+defineProps<{
+  group: Group;
+}>();
 
 const groupSubPages = getGroupSubPages();
 </script>

--- a/frontend/pages/organizations/[orgId]/groups/index.vue
+++ b/frontend/pages/organizations/[orgId]/groups/index.vue
@@ -30,7 +30,7 @@
         />
       </div>
     </HeaderAppPage>
-    <div v-if="organization.groups?.length > 0" class="space-y-3 py-4">
+    <div v-if="organization.groups!.length > 0" class="space-y-3 py-4">
       <CardSearchResultGroup
         v-for="(g, i) in organization.groups"
         :key="i"
@@ -44,13 +44,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Organization } from "~/types/communities/organization";
+
 import { IconMap } from "~/types/icon-map";
 
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
-
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+defineProps<{
+  organization: Organization;
+}>();
 </script>

--- a/frontend/pages/organizations/[orgId]/index.vue
+++ b/frontend/pages/organizations/[orgId]/index.vue
@@ -67,19 +67,16 @@
 </template>
 
 <script setup lang="ts">
+import type { Organization } from "~/types/communities/organization";
 import type { MenuSelector } from "~/types/menu/menu-selector";
 
 import useMenuEntriesState from "~/composables/useMenuEntriesState";
 import { BreakpointMap } from "~/types/breakpoint-map";
 import { IconMap } from "~/types/icon-map";
 
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
-
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+const props = defineProps<{
+  organization: Organization;
+}>();
 
 const localePath = useLocalePath();
 
@@ -100,10 +97,14 @@ const handleResize = () => {
     const currentRoute = useRoute();
 
     if (
-      currentRoute.path !== `/${locale.value}/organizations/${orgId}/about` ||
-      currentRoute.path === `/${locale.value}/organizations/${orgId}/`
+      currentRoute.path !==
+        `/${locale.value}/organizations/${props.organization.id}/about` ||
+      currentRoute.path ===
+        `/${locale.value}/organizations/${props.organization.id}/`
     ) {
-      navigateTo(`/${locale.value}/organizations/${orgId}/about`);
+      navigateTo(
+        `/${locale.value}/organizations/${props.organization.id}/about`
+      );
     }
   }
 };

--- a/frontend/pages/organizations/[orgId]/resources.vue
+++ b/frontend/pages/organizations/[orgId]/resources.vue
@@ -38,17 +38,14 @@
 </template>
 
 <script setup lang="ts">
+import type { Organization } from "~/types/communities/organization";
 import type { Resource } from "~/types/content/resource";
 
 import { IconMap } from "~/types/icon-map";
 
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
-
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+defineProps<{
+  organization: Organization;
+}>();
 
 const orgResources: Resource[] = [];
 </script>

--- a/frontend/pages/organizations/[orgId]/settings.vue
+++ b/frontend/pages/organizations/[orgId]/settings.vue
@@ -42,11 +42,9 @@
 </template>
 
 <script setup lang="ts">
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
+import type { Organization } from "~/types/communities/organization";
 
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+defineProps<{
+  organization: Organization;
+}>();
 </script>

--- a/frontend/pages/organizations/[orgId]/tasks.vue
+++ b/frontend/pages/organizations/[orgId]/tasks.vue
@@ -35,13 +35,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Organization } from "~/types/communities/organization";
+
 import { IconMap } from "~/types/icon-map";
 
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
-
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+defineProps<{
+  organization: Organization;
+}>();
 </script>

--- a/frontend/pages/organizations/[orgId]/team.vue
+++ b/frontend/pages/organizations/[orgId]/team.vue
@@ -42,13 +42,11 @@
 </template>
 
 <script setup lang="ts">
+import type { Organization } from "~/types/communities/organization";
+
 import { IconMap } from "~/types/icon-map";
 
-const paramsOrgId = useRoute().params.orgId;
-const orgId = typeof paramsOrgId === "string" ? paramsOrgId : undefined;
-
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchById(orgId);
-
-const { organization } = organizationStore;
+defineProps<{
+  organization: Organization;
+}>();
 </script>

--- a/frontend/pages/organizations/index.vue
+++ b/frontend/pages/organizations/index.vue
@@ -22,8 +22,9 @@
 </template>
 
 <script setup lang="ts">
-const organizationStore = useOrganizationStore();
-await organizationStore.fetchAll();
+import type { Organization } from "~/types/communities/organization";
 
-const { organizations } = organizationStore;
+defineProps<{
+  organizations: Organization[];
+}>();
 </script>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This is the first step in migrating the platform to just do API calls from the layouts. All layouts have had appropriate API calls added to them, the layouts have been dynamically assigned (in a prior commit) and all pages now load in the given object via props from `NuxtPage` within the layout.

Further steps needed:
- Convert all components to just access objects from pages
- Make layouts distinct given their functionality such that the left sidebar isn't conditionally rendering, but rather rendering for the page type

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1060
