### PR TITLE
fix: Issue in report title is not showing

### DIFF
--- a/.github/workflows/check_dependency_updates.yaml
+++ b/.github/workflows/check_dependency_updates.yaml
@@ -191,11 +191,15 @@ jobs:
             tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
 
+      - name: Set date
+        id: date
+        run: echo "REPORT_DATE=$(date '+%B %d, %Y')" >> $GITHUB_ENV
+
       - name: Create GitHub Issue
         if: always()
         uses: peter-evans/create-issue-from-file@v4
         with:
-          title: "Dependency Update Report - $(date '+%B %d, %Y') 🤖"
+          title: "Dependency Update Report - ${{ env.REPORT_DATE }} 🤖"
           content-filepath: reports.md
           labels: |
             dependencies


### PR DESCRIPTION
When a bot creates an issue mentioning what are the latest dependencies version that our project will need to be updated, the date in the issue title title was showing `$(date '+%B %d, %Y'` instead of real date, so this PR aims to fix that.

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- [#1262](https://github.com/activist-org/activist/issues/1262)
