### PR TITLE
throttling setup for tests, throttling tests for anon and user

### DIFF
--- a/backend/core/tests/unit/conftest.py
+++ b/backend/core/tests/unit/conftest.py
@@ -11,21 +11,26 @@ def api_client() -> APIClient:
 @pytest.fixture(autouse=True)
 def turn_off_throttling(settings, request: pytest.FixtureRequest):
     """
-        Automatically disables API throttling for all tests unless the test is marked with 'enable_throttling'.
+    Automatically disables API throttling for all tests unless the test is marked with 'enable_throttling'.
 
-    This fixture modifies the Django REST Framework settings to set throttle rates for both anonymous and authenticated users to None,
-    effectively turning off request throttling during test execution. If the test is explicitly marked with 'enable_throttling',
-    this fixture does not alter the throttling settings.
+    This fixture modifies the Django REST Framework settings to set throttle rates for both anonymous and authenticated users to None.
+    This effectively turns off request throttling during test execution.
+    If the test is explicitly marked with 'enable_throttling', this fixture does not alter the throttling settings.
 
-    Args:
-        settings: The Django settings fixture, used to modify REST framework configuration.
-        request (pytest.FixtureRequest): Provides information about the requesting test function, including markers.
+    Parameters
+    ----------
+    settings : django.conf.settings
+        The Django settings fixture, used to modify REST framework configuration.
 
-    Usage:
-        To enable throttling for a specific test, mark it with @pytest.mark.enable_throttling.
+    request : pytest.FixtureRequest)
+        Provides information about the requesting test function, including markers.
+
+    Notes
+    -----
+    To enable throttling for a specific test, mark it with @pytest.mark.enable_throttling.
     """
     if "enable_throttling" in request.keywords:
-        # If the test has the disable_throttling marker, skip this fixture
+        # If the test has the disable_throttling marker, skip this fixture.
         return
 
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {

--- a/backend/core/tests/unit/conftest.py
+++ b/backend/core/tests/unit/conftest.py
@@ -6,3 +6,29 @@ from rest_framework.test import APIClient
 @pytest.fixture
 def api_client() -> APIClient:
     return APIClient()
+
+
+@pytest.fixture(autouse=True)
+def turn_off_throttling(settings, request: pytest.FixtureRequest):
+    """
+        Automatically disables API throttling for all tests unless the test is marked with 'enable_throttling'.
+
+    This fixture modifies the Django REST Framework settings to set throttle rates for both anonymous and authenticated users to None,
+    effectively turning off request throttling during test execution. If the test is explicitly marked with 'enable_throttling',
+    this fixture does not alter the throttling settings.
+
+    Args:
+        settings: The Django settings fixture, used to modify REST framework configuration.
+        request (pytest.FixtureRequest): Provides information about the requesting test function, including markers.
+
+    Usage:
+        To enable throttling for a specific test, mark it with @pytest.mark.enable_throttling.
+    """
+    if "enable_throttling" in request.keywords:
+        # If the test has the disable_throttling marker, skip this fixture
+        return
+
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"] = {
+        "anon": None,
+        "user": None,
+    }

--- a/backend/core/tests/unit/test_throttling.py
+++ b/backend/core/tests/unit/test_throttling.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
 import pytest
 from django.conf import settings
 from django.core.cache import cache

--- a/backend/core/tests/unit/test_throttling.py
+++ b/backend/core/tests/unit/test_throttling.py
@@ -1,0 +1,81 @@
+import pytest
+from django.conf import settings
+from django.core.cache import cache
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from authentication.factories import UserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.enable_throttling
+def test_anon_throttle():
+    """
+    Test the anonymous user throttle mechanism.
+    """
+    # Override the autouse fixture by resetting throttle rates for this test
+    # and clear the cache to ensure a clean state
+    cache.clear()
+    client = APIClient()
+
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["anon"] = "3/min"
+    endpoint = "/v1/communities/organizations/"
+
+    for i in range(3):
+        print(f"Request {i + 1}")
+        response = client.get(endpoint)
+        assert response.status_code == status.HTTP_200_OK
+
+    response = client.get(endpoint)
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    # Reset the throttle rates
+    # This is necessary to ensure that the test does not affect other tests
+    cache.clear()
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["anon"] = None
+
+
+@pytest.mark.enable_throttling
+def test_auth_throttle():
+    """
+    Test the user authentication throttle mechanism.
+    """
+    # Override the autouse fixture by resetting throttle rates for this test
+    # and clear the cache to ensure a clean state
+    cache.clear()
+    client = APIClient()
+
+    test_username = "test_username"
+    test_plaintext_password = "test_password123!"
+    user = UserFactory(
+        username=test_username, plaintext_password=test_plaintext_password
+    )
+    user.is_confirmed = True
+    user.verified = True
+    user.is_staff = True
+    user.save()
+
+    login_response = client.post(
+        path="/v1/auth/sign_in/",
+        data={"username": test_username, "password": test_plaintext_password},
+    )
+    token = login_response.json()["token"]
+
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user"] = "5/min"
+    endpoint = "/v1/communities/organizations/"
+
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    for i in range(5):
+        print(f"Request {i + 1}")
+        response = client.get(endpoint)
+        assert response.status_code == status.HTTP_200_OK
+
+    response = client.get(endpoint)
+    print(f"Request {6}")
+    assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    # Reset the throttle rates
+    # This is necessary to ensure that the test does not affect other tests
+    cache.clear()
+    settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user"] = None

--- a/backend/core/tests/unit/test_throttling.py
+++ b/backend/core/tests/unit/test_throttling.py
@@ -15,8 +15,8 @@ def test_anon_throttle():
     """
     Test the anonymous user throttle mechanism.
     """
-    # Override the autouse fixture by resetting throttle rates for this test
-    # and clear the cache to ensure a clean state
+    # Override the autouse fixture by resetting throttle rates for this test.
+    # Clear the cache to ensure a clean state.
     cache.clear()
     client = APIClient()
 
@@ -31,8 +31,8 @@ def test_anon_throttle():
     response = client.get(endpoint)
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
-    # Reset the throttle rates
-    # This is necessary to ensure that the test does not affect other tests
+    # Reset the throttle rates.
+    # This is necessary to ensure that the test does not affect other tests.
     cache.clear()
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["anon"] = None
 
@@ -42,8 +42,8 @@ def test_auth_throttle():
     """
     Test the user authentication throttle mechanism.
     """
-    # Override the autouse fixture by resetting throttle rates for this test
-    # and clear the cache to ensure a clean state
+    # Override the autouse fixture by resetting throttle rates for this test.
+    # Clear the cache to ensure a clean state.
     cache.clear()
     client = APIClient()
 
@@ -73,10 +73,10 @@ def test_auth_throttle():
         assert response.status_code == status.HTTP_200_OK
 
     response = client.get(endpoint)
-    print(f"Request {6}")
+    print("Request 6")
     assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
-    # Reset the throttle rates
-    # This is necessary to ensure that the test does not affect other tests
+    # Reset the throttle rates.
+    # This is necessary to ensure that the test does not affect other tests.
     cache.clear()
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user"] = None


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This PR introduces a pytest fixture that disables throttling by default for all tests, improving test performance and developer experience. Throttling can still be enabled for specific tests by marking them with @pytest.mark.enable_throttling.

Additionally, I added dedicated throttling tests for both anonymous and authenticated users, with the appropriate marker applied to ensure throttling is tested as expected.

### Notes 
I initially explored PR #1229 to build on that work, but the branch hadn't been updated in a while and I ran into issues running it locally. To make things easier to test, I opened this new PR with a fresh implementation.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #879 
