### PR TITLE
Fix for #1270, Added fixture for authenticated requests

### DIFF
--- a/backend/core/tests/unit/conftest.py
+++ b/backend/core/tests/unit/conftest.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import pytest
 from rest_framework.test import APIClient
-from rest_framework.test import force_authenticate
 from django.contrib.auth import get_user_model
 
 @pytest.fixture

--- a/backend/core/tests/unit/conftest.py
+++ b/backend/core/tests/unit/conftest.py
@@ -7,6 +7,22 @@ from rest_framework.test import APIClient
 def api_client() -> APIClient:
     return APIClient()
 
+@pytest.fixture
+def authenticated_client(api_client) -> APIClient:
+    """
+    Provides an authenticated API client for testing.
+    
+    Creates a test user and forces authentication for all requests made with this client.
+    This eliminates the need to manually handle authentication in most test cases.
+    """
+    User = get_user_model()
+    user = User.objects.create_user(
+        username="testuser",
+        password="testpass123",
+        email="testuser@example.com"
+    )
+    api_client.force_authenticate(user=user)
+    return api_client
 
 @pytest.fixture(autouse=True)
 def turn_off_throttling(settings, request: pytest.FixtureRequest):

--- a/backend/core/tests/unit/conftest.py
+++ b/backend/core/tests/unit/conftest.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import pytest
 from rest_framework.test import APIClient
-
+from rest_framework.test import force_authenticate
 
 @pytest.fixture
 def api_client() -> APIClient:
@@ -15,7 +15,7 @@ def authenticated_client(api_client) -> APIClient:
     Creates a test user and forces authentication for all requests made with this client.
     This eliminates the need to manually handle authentication in most test cases.
     """
-    User = get_user_model()
+    factory = APIRequestFactory()
     user = User.objects.create_user(
         username="testuser",
         password="testpass123",

--- a/backend/core/tests/unit/conftest.py
+++ b/backend/core/tests/unit/conftest.py
@@ -2,6 +2,7 @@
 import pytest
 from rest_framework.test import APIClient
 from rest_framework.test import force_authenticate
+from django.contrib.auth import get_user_model
 
 @pytest.fixture
 def api_client() -> APIClient:
@@ -15,7 +16,7 @@ def authenticated_client(api_client) -> APIClient:
     Creates a test user and forces authentication for all requests made with this client.
     This eliminates the need to manually handle authentication in most test cases.
     """
-    factory = APIRequestFactory()
+    User = get_user_model() 
     user = User.objects.create_user(
         username="testuser",
         password="testpass123",
@@ -23,6 +24,7 @@ def authenticated_client(api_client) -> APIClient:
     )
     api_client.force_authenticate(user=user)
     return api_client
+
 
 @pytest.fixture(autouse=True)
 def turn_off_throttling(settings, request: pytest.FixtureRequest):


### PR DESCRIPTION

### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

Adding fixture for authenticated request using Django's REST Framework's force_authenticate function by changing conftest.py

### Related issue

- #1270
