### PR TITLE
WIP added pre-commit hook for spdx_checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       # - id: pretty-format-json
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+    rev: v0.11.12
     hooks:
       - id: ruff-check
         name: run ruff linting check
@@ -20,6 +20,15 @@ repos:
       - id: ruff-format
         name: run ruff formatting check
         files: ^backend/
+
+  - repo: https://github.com/to-sta/spdx-checker-pre-commit
+    rev: v0.1.1
+    hooks:
+      - id: spdx-license-checker
+        name: spdx-license-checker
+        args: [-l, AGPL-3.0-or-later]
+        language_version: python3.13
+        types_or: [python, ts, javascript, vue, css, html]
 
   - repo: https://github.com/numpy/numpydoc
     rev: v1.8.0


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

To speed up checking SPDX license headers with our current setup, I built a Python package that uses a compiled [Zig](https://ziglang.org/) extension. It works cross-platform and is available on PyPI as [spdx_checker](https://pypi.org/project/spdx_checker/)

I also created a separate pre-commit hook repository: [spdx-checker-pre-commit](https://github.com/to-sta/spdx-checker-pre-commit). This handles argument passing and keeps the pre-commit hook logic separate from the main package.

The development went through a few iterations. I started with a simple Zig function as a proof-of-concept, then moved on to turning it into a Python package.

Initially, I tried using [pydust-ziggy](https://github.com/spiraldb/ziggy-pydust), which is a great project — but unfortunately, it doesn’t support Windows at the moment. I still pushed forward using WSL and got a working version, and even attempted to add Windows support to ziggy-pydust. After some small wins and slow progress, I decided to take a different route.

My next and final approach was to take care of the integration with `zig` by myself instead of relying on `ziggy-pydust`. During my research I found a similar project on GitHub that uses a `zig` extension for parsing yaml called [zaml](https://github.com/adamserafini/zaml). I took some inspiration, espeaclially about form the custom builder. 

So, for the final version, I handled the Zig integration myself instead of relying on ziggy-pydust. During this process, I came across [zaml](https://github.com/adamserafini/zaml), which uses a Zig extension for YAML parsing. It gave me some inspiration, especially for the custom build system.

So, I made python wheels and went thru the hell of creating wheel via a GitHub workflow. Actually not that bad but not the most initutive either. [cibuildwheel]( https://github.com/pypa/cibuildwheel) made it alot more convient that setting it up manually.

Cross-platform compilation wasn’t straightforward at first — library paths and naming conventions differ a lot between systems, especially on Windows. At one point, I had a version that required Zig to be installed locally before building the binary, but I wasn’t happy with that setup. You didn't have to install it yourself but still It took sometime and around 70mb.

Eventually, I decided to build and publish Python wheels, and went through the (slightly painful but not terrible) process of setting that up in a GitHub workflow. [cibuildwheel](https://github.com/pypa/cibuildwheel) made it way easier than doing it manually.

It works on my machine 🙂 — but there should definitely be some testing before considering to merge this in. Right now, it's only compiled for Python 3.13. I ran into issues getting it to work with Python 3.12 on Windows (though it worked fine on the WSL), so I focused on 3.13 for now. I did use the Python limited ABI, which should help make it compatible with more Python versions down the line.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

To test it, I installed the pre-commit hook locally and added a Python file without a license. Here’s the result
-->

To test the setup, I install the pre-commit hook locally and added a python file without a license. Here are the resuls:

```bash
spdx-license-checker.....................................................Failed
- hook id: spdx-license-checker
- exit code: 1

File 'backend/without_license.py' does not match target license 'AGPL-3.0-or-later'.
Files with license 'AGPL-3.0-or-later': 0 / 1 Files
License check completed in (688000ns) 0ms 
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\<removed>\.cache\pre-commit\repondit329p\py_env-python3.13\Scripts\spdx_checker_pre_commit.EXE\__main__.py", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "C:\Users\<removed>\.cache\pre-commit\repondit329p\py_env-python3.13\Lib\site-packages\spdx_checker_pre_commit\main.py", line 41, in main
    spdx_checker.check_license(args.license, args.filenames)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: File does not match target license.

```

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1273

