### PR TITLE
removed trailing slashes from api endpoints

### DIFF
--- a/backend/authentication/tests/flag/test_user_flag_create.py
+++ b/backend/authentication/tests/flag/test_user_flag_create.py
@@ -22,7 +22,7 @@ def test_user_flag_create():
     )
 
     error_response = client.post(
-        path="/v1/auth/user_flag/",
+        path="/v1/auth/user_flag",
         data={"user": flagged_user.id, "created_by": user.id},
     )
 
@@ -32,7 +32,7 @@ def test_user_flag_create():
     assert error_response_body["detail"] == "You are not allowed flag this user."
 
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -44,7 +44,7 @@ def test_user_flag_create():
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
     response = client.post(
-        path="/v1/auth/user_flag/",
+        path="/v1/auth/user_flag",
         data={"user": flagged_user.id, "created_by": user.id},
     )
 

--- a/backend/authentication/tests/flag/test_user_flag_delete.py
+++ b/backend/authentication/tests/flag/test_user_flag_delete.py
@@ -25,7 +25,7 @@ def test_user_flag_delete():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -35,6 +35,6 @@ def test_user_flag_delete():
     token = login_body["token"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.delete(path=f"/v1/auth/user_flag/{flagged_user.id}/")
+    response = client.delete(path=f"/v1/auth/user_flag/{flagged_user.id}")
 
     assert response.status_code == 204

--- a/backend/authentication/tests/flag/test_user_flag_list.py
+++ b/backend/authentication/tests/flag/test_user_flag_list.py
@@ -11,6 +11,6 @@ def test_user_flag_list():
     """
     client = APIClient()
 
-    response = client.get(path="/v1/auth/user_flag/")
+    response = client.get(path="/v1/auth/user_flag")
 
     assert response.status_code == 200

--- a/backend/authentication/tests/flag/test_user_flag_retrieve.py
+++ b/backend/authentication/tests/flag/test_user_flag_retrieve.py
@@ -15,6 +15,6 @@ def test_user_flag_retrieve():
 
     flagged_user = UserFlagFactory()
 
-    response = client.get(path=f"/v1/auth/user_flag/{flagged_user.id}/")
+    response = client.get(path=f"/v1/auth/user_flag/{flagged_user.id}")
 
     assert response.status_code == 200

--- a/backend/authentication/tests/test_auth.py
+++ b/backend/authentication/tests/test_auth.py
@@ -72,7 +72,7 @@ def test_sign_up(client: Client) -> None:
 
     # 1. Password strength fails.
     response = client.post(
-        path="/v1/auth/sign_up/",
+        path="/v1/auth/sign_up",
         data={
             "username": username,
             "password": weak_password,
@@ -86,7 +86,7 @@ def test_sign_up(client: Client) -> None:
 
     # 2. Password confirmation fails.
     response = client.post(
-        path="/v1/auth/sign_up/",
+        path="/v1/auth/sign_up",
         data={
             "username": username,
             "password": strong_password,
@@ -100,7 +100,7 @@ def test_sign_up(client: Client) -> None:
 
     # 3. User is created successfully.
     response = client.post(
-        path="/v1/auth/sign_up/",
+        path="/v1/auth/sign_up",
         data={
             "username": username,
             "password": strong_password,
@@ -121,7 +121,7 @@ def test_sign_up(client: Client) -> None:
 
     # 4. User already exists.
     response = client.post(
-        path="/v1/auth/sign_up/",
+        path="/v1/auth/sign_up",
         data={
             "username": username,
             "password": strong_password,
@@ -135,7 +135,7 @@ def test_sign_up(client: Client) -> None:
 
     # 5. User is created without an email.
     response = client.post(
-        path="/v1/auth/sign_up/",
+        path="/v1/auth/sign_up",
         data={
             "username": second_username,
             "password": strong_password,
@@ -172,7 +172,7 @@ def test_sign_in(client: Client) -> None:
 
     # 1. User that signed up with email, that has not confirmed their email.
     response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": user.username, "password": plaintext_password},
     )
     assert response.status_code == 400
@@ -181,27 +181,27 @@ def test_sign_in(client: Client) -> None:
     user.is_confirmed = True
     user.save()
     response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"email": user.email, "password": plaintext_password},
     )
     assert response.status_code == 200
     # Sign in via username.
     response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": user.username, "password": plaintext_password},
     )
     assert response.status_code == 200
 
     # 3. User exists but password is incorrect.
     response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"email": user.email, "password": "Strong_But_Incorrect?!123"},
     )
     assert response.status_code == 400
 
     # 4. User does not exists and tries to sign in.
     response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"email": "unknown_user@example.com", "password": "Password@123!?"},
     )
     assert response.status_code == 400
@@ -230,7 +230,7 @@ def test_pwreset(client: Client) -> None:
     # 1. User exists and password reset is successful.
     user = UserFactory(plaintext_password=old_password)
     response = client.get(
-        path="/v1/auth/pwreset/",
+        path="/v1/auth/pwreset",
         data={"email": user.email},
     )
     assert response.status_code == 200
@@ -238,7 +238,7 @@ def test_pwreset(client: Client) -> None:
 
     # 2. Password reset with invalid email.
     response = client.get(
-        path="/v1/auth/pwreset/", data={"email": "invalid_email@example.com"}
+        path="/v1/auth/pwreset", data={"email": "invalid_email@example.com"}
     )
     assert response.status_code == 404
 
@@ -246,7 +246,7 @@ def test_pwreset(client: Client) -> None:
     user.verification_code = uuid.uuid4()
     user.save()
     response = client.post(
-        path=f"/v1/auth/pwreset/?code={user.verification_code}",
+        path=f"/v1/auth/pwreset?code={user.verification_code}",
         data={"password": new_password},
     )
     assert response.status_code == 200
@@ -255,7 +255,7 @@ def test_pwreset(client: Client) -> None:
 
     # 4. Password reset with invalid verification code.
     response = client.post(
-        path="/v1/auth/pwreset/invalid_code/",
+        path="/v1/auth/pwreset/invalid_code",
         data={"password": new_password},
     )
     assert response.status_code == 404
@@ -339,11 +339,11 @@ def test_delete_user(client: Client) -> None:
     user.save()
 
     response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": user.username, "password": user.password},
     )
 
     if response.status_code == 200:
-        delete_response = client.delete(path="/v1/auth/delete/", data={"pk": user.id})
+        delete_response = client.delete(path="/v1/auth/delete", data={"pk": user.id})
 
         assert delete_response.status_code == 200

--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -10,7 +10,7 @@ from authentication import views
 
 app_name = "authentication"
 
-router = DefaultRouter()
+router = DefaultRouter(trailing_slash=False)
 
 router.register(
     prefix=r"user_flag", viewset=views.UserFlagViewSets, basename="user-flag"
@@ -18,8 +18,8 @@ router.register(
 
 urlpatterns = [
     path("", include(router.urls)),
-    path(route="sign_up/", view=views.SignUpView.as_view(), name="sign_up"),
-    path(route="delete/", view=views.DeleteUserView.as_view(), name="delete"),
-    path(route="sign_in/", view=views.SignInView.as_view(), name="sign_in"),
-    path(route="pwreset/", view=views.PasswordResetView.as_view(), name="pwreset"),
+    path(route="sign_up", view=views.SignUpView.as_view(), name="sign_up"),
+    path(route="delete", view=views.DeleteUserView.as_view(), name="delete"),
+    path(route="sign_in", view=views.SignInView.as_view(), name="sign_in"),
+    path(route="pwreset", view=views.PasswordResetView.as_view(), name="pwreset"),
 ]

--- a/backend/communities/groups/tests/faq/test_group_faq_update.py
+++ b/backend/communities/groups/tests/faq/test_group_faq_update.py
@@ -49,7 +49,7 @@ def test_group_faq_update(client: Client) -> None:
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -61,7 +61,7 @@ def test_group_faq_update(client: Client) -> None:
     token = login_response["token"]
 
     response = client.put(
-        path=f"/v1/communities/group_faqs/{group.id}/",
+        path=f"/v1/communities/group_faqs/{group.id}",
         data={
             "id": test_id,
             "iso": "en",
@@ -81,7 +81,7 @@ def test_group_faq_update(client: Client) -> None:
     test_uuid = uuid4()
 
     response = client.put(
-        path=f"/v1/communities/group_faqs/{test_uuid}/",
+        path=f"/v1/communities/group_faqs/{test_uuid}",
         data={
             "id": test_id,
             "question": test_question,

--- a/backend/communities/groups/tests/flag/test_group_flag_create.py
+++ b/backend/communities/groups/tests/flag/test_group_flag_create.py
@@ -24,7 +24,7 @@ def test_group_flag_create():
     group = GroupFactory()
 
     error_response = client.post(
-        path="/v1/communities/group_flag/",
+        path="/v1/communities/group_flag",
         data={"group": group.id, "created_by": user.id},
     )
 
@@ -37,7 +37,7 @@ def test_group_flag_create():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -48,7 +48,7 @@ def test_group_flag_create():
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
-        path="/v1/communities/group_flag/",
+        path="/v1/communities/group_flag",
         data={"group": group.id, "created_by": user.id},
     )
 

--- a/backend/communities/groups/tests/flag/test_group_flag_delete.py
+++ b/backend/communities/groups/tests/flag/test_group_flag_delete.py
@@ -26,7 +26,7 @@ def test_group_flag_delete():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -36,6 +36,6 @@ def test_group_flag_delete():
     token = login_body["token"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.delete(path=f"/v1/communities/group_flag/{flag.id}/")
+    response = client.delete(path=f"/v1/communities/group_flag/{flag.id}")
 
     assert response.status_code == 204

--- a/backend/communities/groups/tests/flag/test_group_flag_list.py
+++ b/backend/communities/groups/tests/flag/test_group_flag_list.py
@@ -11,6 +11,6 @@ def test_group_flag_list():
     """
     client = APIClient()
 
-    response = client.get(path="/v1/communities/group_flag/")
+    response = client.get(path="/v1/communities/group_flag")
 
     assert response.status_code == 200

--- a/backend/communities/groups/tests/flag/test_group_flag_retrieve.py
+++ b/backend/communities/groups/tests/flag/test_group_flag_retrieve.py
@@ -15,6 +15,6 @@ def test_group_flag_retrieve():
 
     flag = GroupFlagFactory()
 
-    response = client.get(path=f"/v1/communities/group_flag/{flag.id}/")
+    response = client.get(path=f"/v1/communities/group_flag/{flag.id}")
 
     assert response.status_code == 200

--- a/backend/communities/groups/tests/social_link/test_group_social_link_update.py
+++ b/backend/communities/groups/tests/social_link/test_group_social_link_update.py
@@ -46,7 +46,7 @@ def test_group_social_link_update(client: Client) -> None:
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -58,7 +58,7 @@ def test_group_social_link_update(client: Client) -> None:
     token = login_response["token"]
 
     response = client.put(
-        path=f"/v1/communities/group_social_links/{group.id}/",
+        path=f"/v1/communities/group_social_links/{group.id}",
         data=[
             {
                 "link": test_link,
@@ -77,7 +77,7 @@ def test_group_social_link_update(client: Client) -> None:
     test_uuid = uuid4()
 
     response = client.put(
-        path=f"/v1/communities/group_social_links/{test_uuid}/",
+        path=f"/v1/communities/group_social_links/{test_uuid}",
         data=[
             {
                 "link": test_link,

--- a/backend/communities/groups/tests/test_group_api.py
+++ b/backend/communities/groups/tests/test_group_api.py
@@ -15,7 +15,7 @@ from communities.organizations.factories import OrganizationFactory
 from content.factories import EntityLocationFactory
 
 # Endpoint used for these tests:
-GROUPS_URL = "/v1/communities/groups/"
+GROUPS_URL = "/v1/communities/groups"
 
 
 class UserDict(TypedDict):
@@ -37,7 +37,7 @@ def login_user(user_data: UserDict) -> dict[Any, Any]:
     """
     client = APIClient()
     response = client.post(
-        "/v1/auth/sign_in/",
+        "/v1/auth/sign_in",
         {
             "username": user_data["user"].username,
             "password": user_data["plaintext_password"],
@@ -189,7 +189,7 @@ def test_GroupDetailAPIView(logged_in_user, logged_in_created_by_user) -> None:
 
     # MARK: Detail GET
 
-    response = client.get(f"{GROUPS_URL}{new_group.id}/")
+    response = client.get(f"{GROUPS_URL}/{new_group.id}")
     assert response.status_code == 200
     assert response.data["group_name"] == new_group.group_name
 
@@ -197,7 +197,7 @@ def test_GroupDetailAPIView(logged_in_user, logged_in_created_by_user) -> None:
 
     updated_payload = {"group_name": "updated_group_name"}
     response = client.put(
-        f"{GROUPS_URL}{new_group.id}/",
+        f"{GROUPS_URL}/{new_group.id}",
         data=updated_payload,
         format="json",
     )
@@ -205,7 +205,7 @@ def test_GroupDetailAPIView(logged_in_user, logged_in_created_by_user) -> None:
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token_created_by}")
     response = client.put(
-        f"{GROUPS_URL}{new_group.id}/",
+        f"{GROUPS_URL}/{new_group.id}",
         data=updated_payload,
         format="json",
     )
@@ -217,10 +217,10 @@ def test_GroupDetailAPIView(logged_in_user, logged_in_created_by_user) -> None:
     # MARK: Detail DELETE
 
     client.credentials()
-    response = client.delete(f"{GROUPS_URL}{new_group.id}/")
+    response = client.delete(f"{GROUPS_URL}/{new_group.id}")
     assert response.status_code == 401
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token_created_by}")
-    response = client.delete(f"{GROUPS_URL}{new_group.id}/")
+    response = client.delete(f"{GROUPS_URL}/{new_group.id}")
 
     assert response.status_code == 200

--- a/backend/communities/groups/tests/test_group_delete.py
+++ b/backend/communities/groups/tests/test_group_delete.py
@@ -44,7 +44,7 @@ def test_group_delete(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -57,7 +57,7 @@ def test_group_delete(client: Client) -> None:
     token = login_response_body.get("token")
 
     delete_response = client.delete(
-        path=f"/v1/communities/groups/{group.id}/",
+        path=f"/v1/communities/groups/{group.id}",
         headers={"Authorization": f"Token {token}"},
     )
 
@@ -83,7 +83,7 @@ def test_group_delete(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -96,7 +96,7 @@ def test_group_delete(client: Client) -> None:
     token = login_response_body.get("token")
 
     delete_response = client.delete(
-        path=f"/v1/communities/groups/{test_uuid}/",
+        path=f"/v1/communities/groups/{test_uuid}",
         headers={"Authorization": f"Token {token}"},
     )
 
@@ -116,7 +116,7 @@ def test_group_delete(client: Client) -> None:
     group.created_by = user
 
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -129,7 +129,7 @@ def test_group_delete(client: Client) -> None:
     token = login_response_body.get("token")
 
     delete_response = client.delete(
-        path=f"/v1/communities/groups/{group.id}/",
+        path=f"/v1/communities/groups/{group.id}",
         headers={"Authorization": f"Token {token}"},
     )
 

--- a/backend/communities/groups/tests/test_group_list.py
+++ b/backend/communities/groups/tests/test_group_list.py
@@ -23,6 +23,6 @@ def test_group_list(client: Client) -> None:
     None
         This test does not return any value, it only checks the response status code.
     """
-    response = client.get(path="/v1/communities/groups/")
+    response = client.get(path="/v1/communities/groups")
 
     assert response.status_code == 200

--- a/backend/communities/groups/tests/test_group_partial_update.py
+++ b/backend/communities/groups/tests/test_group_partial_update.py
@@ -45,7 +45,7 @@ def test_group_partial_update(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -59,13 +59,13 @@ def test_group_partial_update(client: Client) -> None:
 
     group.created_by = user
 
-    response = client.get(path=f"/v1/communities/groups/{group.id}/")
+    response = client.get(path=f"/v1/communities/groups/{group.id}")
 
     assert response.status_code == 200
 
     # Patch is not implemented and should return 405.
     request_body = client.patch(
-        path=f"/v1/communities/groups/{group.id}/",
+        path=f"/v1/communities/groups/{group.id}",
         data={
             "groupName": "new_test_group",
             "name": "new_test_name",

--- a/backend/communities/groups/tests/test_group_retrieve.py
+++ b/backend/communities/groups/tests/test_group_retrieve.py
@@ -33,7 +33,7 @@ def test_group_retrieve(client: Client) -> None:
     1. Group ID exists in the database.
     """
     response = client.get(
-        path=f"/v1/communities/groups/{group_id}/",
+        path=f"/v1/communities/groups/{group_id}",
     )
 
     assert response.status_code == 200

--- a/backend/communities/groups/tests/test_group_update.py
+++ b/backend/communities/groups/tests/test_group_update.py
@@ -37,7 +37,7 @@ def test_group_update(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -51,11 +51,11 @@ def test_group_update(client: Client) -> None:
 
     group.created_by = user
 
-    response = client.get(path=f"/v1/communities/groups/{group.id}/")
+    response = client.get(path=f"/v1/communities/groups/{group.id}")
     assert response.status_code == 200
 
     request_body = client.put(
-        path=f"/v1/communities/groups/{group.id}/",
+        path=f"/v1/communities/groups/{group.id}",
         data={
             "groupName": "new_test_group",
             "name": "new_test_name",
@@ -87,7 +87,7 @@ def test_group_update(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -101,12 +101,12 @@ def test_group_update(client: Client) -> None:
 
     group.created_by = user
 
-    response = client.get(path=f"/v1/communities/groups/{group.id}/")
+    response = client.get(path=f"/v1/communities/groups/{group.id}")
 
     assert response.status_code == 200
 
     request_body = client.put(
-        path=f"/v1/communities/groups/{group.id}/",
+        path=f"/v1/communities/groups/{group.id}",
         data={
             "groupName": "new_test_group",
             "name": "new_test_name",

--- a/backend/communities/organizations/tests/faq/test_org_faq_update.py
+++ b/backend/communities/organizations/tests/faq/test_org_faq_update.py
@@ -52,7 +52,7 @@ def test_org_faq_update(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -64,7 +64,7 @@ def test_org_faq_update(client: Client) -> None:
     token = login_body["token"]
 
     response = client.put(
-        path=f"/v1/communities/organization_faqs/{org.id}/",
+        path=f"/v1/communities/organization_faqs/{org.id}",
         data={
             "id": test_id,
             "iso": "en",
@@ -83,7 +83,7 @@ def test_org_faq_update(client: Client) -> None:
 
     bad_uuid = uuid4()
     response = client.put(
-        path=f"/v1/communities/organization_faqs/{bad_uuid}/",
+        path=f"/v1/communities/organization_faqs/{bad_uuid}",
         data={
             "id": test_id,
             "question": test_question,

--- a/backend/communities/organizations/tests/flag/test_org_flag_create.py
+++ b/backend/communities/organizations/tests/flag/test_org_flag_create.py
@@ -23,7 +23,7 @@ def test_org_flag_create():
     org = OrganizationFactory()
 
     error_response = client.post(
-        path="/v1/communities/organization_flag/",
+        path="/v1/communities/organization_flag",
         data={"flagged_org": org.id, "created_by": user.id},
         content_type="application/json",
     )
@@ -32,7 +32,7 @@ def test_org_flag_create():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -43,7 +43,7 @@ def test_org_flag_create():
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
-        path="/v1/communities/organization_flag/",
+        path="/v1/communities/organization_flag",
         data={"created_by": user.id, "org": org.id},
     )
 

--- a/backend/communities/organizations/tests/flag/test_org_flag_delete.py
+++ b/backend/communities/organizations/tests/flag/test_org_flag_delete.py
@@ -26,7 +26,7 @@ def test_org_flag_delete():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -36,6 +36,6 @@ def test_org_flag_delete():
     token = login_body["token"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.delete(path=f"/v1/communities/organization_flag/{flag.id}/")
+    response = client.delete(path=f"/v1/communities/organization_flag/{flag.id}")
 
     assert response.status_code == 204

--- a/backend/communities/organizations/tests/flag/test_org_flag_list.py
+++ b/backend/communities/organizations/tests/flag/test_org_flag_list.py
@@ -11,6 +11,6 @@ def test_org_flag_list():
     """
     client = APIClient()
 
-    response = client.get(path="/v1/communities/organization_flag/")
+    response = client.get(path="/v1/communities/organization_flag")
 
     assert response.status_code == 200

--- a/backend/communities/organizations/tests/flag/test_org_flag_retrieve.py
+++ b/backend/communities/organizations/tests/flag/test_org_flag_retrieve.py
@@ -15,6 +15,6 @@ def test_org_flag_retrieve():
 
     flag = OrganizationFlagFactory()
 
-    response = client.get(path=f"/v1/communities/organization_flag/{flag.id}/")
+    response = client.get(path=f"/v1/communities/organization_flag/{flag.id}")
 
     assert response.status_code == 200

--- a/backend/communities/organizations/tests/image/test_org_image_list_list.py
+++ b/backend/communities/organizations/tests/image/test_org_image_list_list.py
@@ -13,7 +13,7 @@ def test_org_image_list(client: Client) -> None:
     org = OrganizationFactory()
 
     response = client.get(
-        path=f"/v1/communities/organizations/{org.id}/images/",
+        path=f"/v1/communities/organizations/{org.id}/images",
     )
 
     assert response.status_code == 200

--- a/backend/communities/organizations/tests/social_link/test_org_social_link_update.py
+++ b/backend/communities/organizations/tests/social_link/test_org_social_link_update.py
@@ -49,7 +49,7 @@ def test_org_social_link_update(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -61,7 +61,7 @@ def test_org_social_link_update(client: Client) -> None:
     token = login_body["token"]
 
     response = client.put(
-        path=f"/v1/communities/organization_social_links/{org.id}/",
+        path=f"/v1/communities/organization_social_links/{org.id}",
         data={"link": test_link, "label": test_label, "order": test_order},
         headers={"Authorization": f"Token {token}"},
         content_type="application/json",
@@ -73,7 +73,7 @@ def test_org_social_link_update(client: Client) -> None:
 
     bad_uuid = uuid4()
     response = client.put(
-        path=f"/v1/communities/organization_social_links/{bad_uuid}/",
+        path=f"/v1/communities/organization_social_links/{bad_uuid}",
         data={"link": test_link, "label": test_label, "order": test_order},
         headers={"Authorization": f"Token {token}"},
         content_type="application/json",

--- a/backend/communities/organizations/tests/test_org_api.py
+++ b/backend/communities/organizations/tests/test_org_api.py
@@ -14,7 +14,7 @@ from communities.organizations.models import Organization, OrganizationApplicati
 from content.factories import EntityLocationFactory
 
 # Endpoint used for these tests:
-ORGS_URL = "/v1/communities/organizations/"
+ORGS_URL = "/v1/communities/organizations"
 
 
 class UserDict(TypedDict):
@@ -36,7 +36,7 @@ def login_user(user_data: UserDict) -> dict:
     """
     client = APIClient()
     response = client.post(
-        "/v1/auth/sign_in/",
+        "/v1/auth/sign_in",
         {
             "username": user_data["user"].username,
             "password": user_data["plaintext_password"],
@@ -188,7 +188,7 @@ def test_organizationDetailAPIView(logged_in_user, logged_in_created_by_user) ->
 
     # MARK: Detail GET
 
-    response = client.get(f"{ORGS_URL}{new_org.id}/")
+    response = client.get(f"{ORGS_URL}/{new_org.id}")
     assert response.status_code == 200
     assert response.data["org_name"] == new_org.org_name
 
@@ -196,7 +196,7 @@ def test_organizationDetailAPIView(logged_in_user, logged_in_created_by_user) ->
 
     updated_payload = {"org_name": "updated_org_name"}
     response = client.put(
-        f"{ORGS_URL}{new_org.id}/",
+        f"{ORGS_URL}/{new_org.id}",
         data=updated_payload,
         format="json",
     )
@@ -204,7 +204,7 @@ def test_organizationDetailAPIView(logged_in_user, logged_in_created_by_user) ->
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token_created_by}")
     response = client.put(
-        f"{ORGS_URL}{new_org.id}/",
+        f"{ORGS_URL}/{new_org.id}",
         data=updated_payload,
         format="json",
     )
@@ -216,10 +216,10 @@ def test_organizationDetailAPIView(logged_in_user, logged_in_created_by_user) ->
     # MARK: Detail DELETE
 
     client.credentials()
-    response = client.delete(f"{ORGS_URL}{new_org.id}/")
+    response = client.delete(f"{ORGS_URL}/{new_org.id}")
     assert response.status_code == 401
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token_created_by}")
-    response = client.delete(f"{ORGS_URL}{new_org.id}/")
+    response = client.delete(f"{ORGS_URL}/{new_org.id}")
 
     assert response.status_code == 200

--- a/backend/communities/organizations/tests/test_org_delete.py
+++ b/backend/communities/organizations/tests/test_org_delete.py
@@ -22,7 +22,7 @@ def test_org_delete(client: Client) -> None:
     Un-authorized user deleting org info.
     """
     response = client.delete(
-        path=f"{ORGS_URL}/{org.id}/",
+        path=f"{ORGS_URL}/{org.id}",
         data={"orgName": "new_org", "name": "test_org"},
     )
 
@@ -43,7 +43,7 @@ def test_org_delete(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -59,7 +59,7 @@ def test_org_delete(client: Client) -> None:
     org.created_by = user
 
     response = client.delete(
-        path=f"{ORGS_URL}/{bad_org_id}/",
+        path=f"{ORGS_URL}/{bad_org_id}",
         headers={"Authorization": f"Token {token}"},
     )
 
@@ -79,7 +79,7 @@ def test_org_delete(client: Client) -> None:
 
     # Login to get token.
     # login_response = client.post(
-    #     path="/v1/auth/sign_in/",
+    #     path="/v1/auth/sign_in",
     #     data={
     #         "username": test_username,
     #         "password": test_password,
@@ -93,7 +93,7 @@ def test_org_delete(client: Client) -> None:
     # org.created_by = user
 
     # response = client.delete(
-    #     path=f"{ORGS_URL}/{org.id}/",
+    #     path=f"{ORGS_URL}/{org.id}",
     #     headers={"Authorization": f"Token {token}"},
     # )
 

--- a/backend/communities/organizations/tests/test_org_list.py
+++ b/backend/communities/organizations/tests/test_org_list.py
@@ -6,6 +6,6 @@ pytestmark = pytest.mark.django_db
 
 
 def test_org_list(client: Client) -> None:
-    response = client.get(path="/v1/communities/organizations/")
+    response = client.get(path="/v1/communities/organizations")
 
     assert response.status_code == 200

--- a/backend/communities/organizations/tests/test_org_retrieve.py
+++ b/backend/communities/organizations/tests/test_org_retrieve.py
@@ -13,13 +13,13 @@ def test_org_retrieve(client: Client) -> None:
     org = OrganizationFactory()
 
     response = client.get(
-        path=f"/v1/communities/organizations/{org.id}/",
+        path=f"/v1/communities/organizations/{org.id}",
     )
 
     assert response.status_code == 200
 
     bad_org_id = uuid4()
-    response = client.get(path=f"/v1/communities/organizations/{bad_org_id}/")
+    response = client.get(path=f"/v1/communities/organizations/{bad_org_id}")
     assert response.status_code == 404
     response_body = response.json()
     assert response_body["detail"] == "Failed to retrieve the organization."

--- a/backend/communities/organizations/tests/test_org_update.py
+++ b/backend/communities/organizations/tests/test_org_update.py
@@ -22,7 +22,7 @@ def test_org_update(client: Client) -> None:
     Un-authorized user updating org info.
     """
     response = client.put(
-        path=f"{ORGS_URL}/{org.id}/",
+        path=f"{ORGS_URL}/{org.id}",
         data={"orgName": "new_org", "name": "test_org"},
     )
 
@@ -42,7 +42,7 @@ def test_org_update(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -58,7 +58,7 @@ def test_org_update(client: Client) -> None:
     org.created_by = user
 
     response = client.put(
-        path=f"{ORGS_URL}/{bad_org_id}/",
+        path=f"{ORGS_URL}/{bad_org_id}",
         data={"orgName": "new_org", "name": "test_org"},
         headers={"Authorization": f"Token {token}"},
         content_type="application/json",
@@ -79,7 +79,7 @@ def test_org_update(client: Client) -> None:
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={
             "username": test_username,
             "password": test_password,
@@ -94,7 +94,7 @@ def test_org_update(client: Client) -> None:
     org.created_by = user
 
     response = client.put(
-        path=f"{ORGS_URL}/{org.id}/",
+        path=f"{ORGS_URL}/{org.id}",
         data={"orgName": "new_org", "name": "test_org"},
         headers={"Authorization": f"Token {token}"},
         content_type="application/json",

--- a/backend/communities/urls.py
+++ b/backend/communities/urls.py
@@ -27,7 +27,7 @@ from communities.views import StatusViewSet
 
 app_name = "communities"
 
-router = DefaultRouter()
+router = DefaultRouter(trailing_slash=False)
 
 # MARK: Main Tables
 
@@ -79,8 +79,8 @@ router.register(
 
 urlpatterns = [
     path("", include(router.urls)),
-    path("groups/", GroupAPIView.as_view()),
-    path("groups/<uuid:id>/", GroupDetailAPIView.as_view()),
-    path("organizations/", OrganizationAPIView.as_view()),
-    path("organizations/<uuid:id>/", OrganizationDetailAPIView.as_view()),
+    path("groups", GroupAPIView.as_view()),
+    path("groups/<uuid:id>", GroupDetailAPIView.as_view()),
+    path("organizations", OrganizationAPIView.as_view()),
+    path("organizations/<uuid:id>", OrganizationDetailAPIView.as_view()),
 ]

--- a/backend/content/tests/discussion/entry/test_discussion_entry_create.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_create.py
@@ -27,7 +27,7 @@ def test_disc_entry_create():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -38,7 +38,7 @@ def test_disc_entry_create():
     # Passing authorization header.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
-        path="/v1/content/discussion_entries/",
+        path="/v1/content/discussion_entries",
         data={"discussion": discussion_thread, "createdBy": user},
     )
 

--- a/backend/content/tests/discussion/entry/test_discussion_entry_delete.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_delete.py
@@ -25,7 +25,7 @@ def test_disc_entry_delete():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -38,7 +38,7 @@ def test_disc_entry_delete():
     # Check of authorized owner deleting the discussion entry.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(
-        path=f"/v1/content/discussion_entries/{discussion_entry.id}/"
+        path=f"/v1/content/discussion_entries/{discussion_entry.id}"
     )
 
     assert response.status_code == 204
@@ -47,7 +47,7 @@ def test_disc_entry_delete():
     unowned_entry = DiscussionEntryFactory()
 
     error_response = client.delete(
-        path=f"/v1/content/discussion_entries/{unowned_entry.id}/"
+        path=f"/v1/content/discussion_entries/{unowned_entry.id}"
     )
 
     assert error_response.status_code == 403

--- a/backend/content/tests/discussion/entry/test_discussion_entry_list.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_list.py
@@ -11,6 +11,6 @@ def test_disc_entry_list():
     """
     client = APIClient()
 
-    response = client.get(path="/v1/content/discussion_entries/")
+    response = client.get(path="/v1/content/discussion_entries")
 
     assert response.status_code == 200

--- a/backend/content/tests/discussion/entry/test_discussion_entry_partial_update.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_partial_update.py
@@ -28,7 +28,7 @@ def test_disc_entry_update():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -39,7 +39,7 @@ def test_disc_entry_update():
     # Authorized owner partial updates the entry.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.patch(
-        path=f"/v1/content/discussion_entries/{entry_instance.id}/",
+        path=f"/v1/content/discussion_entries/{entry_instance.id}",
         data={"discussion": discussion_thread.id},
     )
 
@@ -48,7 +48,7 @@ def test_disc_entry_update():
     # Unauthorized owner partially updates the entry.
     unowned_instance = DiscussionEntryFactory()
     response = client.patch(
-        path=f"/v1/content/discussion_entries/{unowned_instance.id}/",
+        path=f"/v1/content/discussion_entries/{unowned_instance.id}",
         data={"discussion": discussion_thread.id},
     )
     assert response.status_code == 403

--- a/backend/content/tests/discussion/entry/test_discussion_entry_retrieve.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_retrieve.py
@@ -15,6 +15,6 @@ def test_disc_entry_retrieve():
 
     entry_instance = DiscussionEntryFactory()
 
-    response = client.get(path=f"/v1/content/discussion_entries/{entry_instance.id}/")
+    response = client.get(path=f"/v1/content/discussion_entries/{entry_instance.id}")
 
     assert response.status_code == 200

--- a/backend/content/tests/discussion/entry/test_discussion_entry_update.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_update.py
@@ -28,7 +28,7 @@ def test_disc_entry_update():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -40,7 +40,7 @@ def test_disc_entry_update():
     # Authorized owner updates the entry.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(
-        path=f"/v1/content/discussion_entries/{entry_instance.id}/",
+        path=f"/v1/content/discussion_entries/{entry_instance.id}",
         data={"discussion": discussion_thread.id},
     )
 
@@ -49,7 +49,7 @@ def test_disc_entry_update():
     # Authorized non-owner updates the entry.
     unowned_instance = DiscussionEntryFactory()
     response = client.put(
-        path=f"/v1/content/discussion_entries/{unowned_instance.id}/",
+        path=f"/v1/content/discussion_entries/{unowned_instance.id}",
         data={"discussion": discussion_thread.id},
     )
     assert response.status_code == 403

--- a/backend/content/tests/discussion/test_discussion_create.py
+++ b/backend/content/tests/discussion/test_discussion_create.py
@@ -23,7 +23,7 @@ def test_discussion_create():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -34,7 +34,7 @@ def test_discussion_create():
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
-        path="/v1/content/discussions/",
+        path="/v1/content/discussions",
         data={"title": discussion_thread.title, "category": discussion_thread.category},
     )
 

--- a/backend/content/tests/discussion/test_discussion_delete.py
+++ b/backend/content/tests/discussion/test_discussion_delete.py
@@ -26,7 +26,7 @@ def test_discussion_delete():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -37,13 +37,13 @@ def test_discussion_delete():
 
     # Authorized owner deletes the discussion.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.delete(path=f"/v1/content/discussions/{discussion_thread.id}/")
+    response = client.delete(path=f"/v1/content/discussions/{discussion_thread.id}")
 
     assert response.status_code == 204
 
     # Authorized non-owner deletes the discussion.
     response = client.delete(
-        path=f"/v1/content/discussions/{unowned_discussion_thread.id}/"
+        path=f"/v1/content/discussions/{unowned_discussion_thread.id}"
     )
 
     assert response.status_code == 403

--- a/backend/content/tests/discussion/test_discussion_list.py
+++ b/backend/content/tests/discussion/test_discussion_list.py
@@ -6,6 +6,6 @@ pytestmark = pytest.mark.django_db
 
 
 def test_discussion_list(client: Client):
-    response = client.get(path="/v1/content/discussions/")
+    response = client.get(path="/v1/content/discussions")
 
     assert response.status_code == 200

--- a/backend/content/tests/discussion/test_discussion_partial_update.py
+++ b/backend/content/tests/discussion/test_discussion_partial_update.py
@@ -25,7 +25,7 @@ def test_discussion_partial_update():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -39,7 +39,7 @@ def test_discussion_partial_update():
     # Authorized owner partially updates the discussion.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.patch(
-        path=f"/v1/content/discussions/{discussion_thread.id}/",
+        path=f"/v1/content/discussions/{discussion_thread.id}",
         data={"title": "new_title"},
     )
 
@@ -49,7 +49,7 @@ def test_discussion_partial_update():
     unowned_discussion_thread = DiscussionFactory()
 
     response = client.patch(
-        path=f"/v1/content/discussions/{unowned_discussion_thread.id}/",
+        path=f"/v1/content/discussions/{unowned_discussion_thread.id}",
         data={"title": "new_title"},
     )
 

--- a/backend/content/tests/discussion/test_discussion_retrieve.py
+++ b/backend/content/tests/discussion/test_discussion_retrieve.py
@@ -10,6 +10,6 @@ pytestmark = pytest.mark.django_db
 def test_discussion_retrieve(client: Client):
     thread = DiscussionFactory()
 
-    response = client.get(path=f"/v1/content/discussions/{thread.id}/")
+    response = client.get(path=f"/v1/content/discussions/{thread.id}")
 
     assert response.status_code == 200

--- a/backend/content/tests/discussion/test_discussion_update.py
+++ b/backend/content/tests/discussion/test_discussion_update.py
@@ -21,7 +21,7 @@ def test_discussion_update():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -32,7 +32,7 @@ def test_discussion_update():
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(
-        path=f"/v1/content/discussions/{thread.id}/",
+        path=f"/v1/content/discussions/{thread.id}",
         data={"title": thread.title},
     )
 

--- a/backend/content/tests/faq/test_faq.py
+++ b/backend/content/tests/faq/test_faq.py
@@ -129,7 +129,7 @@ def test_organization_faq_list_view(client: APIClient) -> None:
     num_faqs = 3
     OrganizationFaqFactory.create_batch(num_faqs, org=org)
 
-    response = client.get(f"/v1/communities/organizations/{org.id}/")
+    response = client.get(f"/v1/communities/organizations/{org.id}")
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()["faqEntries"]) == num_faqs
@@ -145,7 +145,7 @@ def test_group_faq_list_view(client: APIClient) -> None:
     num_faqs = 3
     GroupFaqFactory.create_batch(num_faqs, group=group)
 
-    response = client.get(f"/v1/communities/groups/{group.id}/")
+    response = client.get(f"/v1/communities/groups/{group.id}")
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()["faqEntries"]) == num_faqs
@@ -161,7 +161,7 @@ def test_event_faq_list_view(client: APIClient) -> None:
     num_faqs = 3
     EventFaqFactory.create_batch(num_faqs, event=event)
 
-    response = client.get(f"/v1/events/events/{event.id}/")
+    response = client.get(f"/v1/events/events/{event.id}")
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()["faqEntries"]) == num_faqs
@@ -192,7 +192,7 @@ def test_organization_faq_create_view(client: APIClient) -> None:
     }
 
     response = client.put(
-        f"/v1/communities/organization_faqs/{org.id}/",
+        f"/v1/communities/organization_faqs/{org.id}",
         formData,
         content_type="application/json",
     )
@@ -225,7 +225,7 @@ def test_group_faq_create_view(client: APIClient) -> None:
     }
 
     response = client.put(
-        f"/v1/communities/group_faqs/{group.id}/",
+        f"/v1/communities/group_faqs/{group.id}",
         formData,
         content_type="application/json",
     )
@@ -258,7 +258,7 @@ def test_event_faq_create_view(client: APIClient) -> None:
     }
 
     response = client.put(
-        f"/v1/events/event_faqs/{event.id}/",
+        f"/v1/events/event_faqs/{event.id}",
         formData,
         content_type="application/json",
     )

--- a/backend/content/tests/image/test_image_upload.py
+++ b/backend/content/tests/image/test_image_upload.py
@@ -109,7 +109,7 @@ def test_image_list_view(client: APIClient) -> None:
     images = ImageFactory.create_batch(3)
     filenames = [image.file_object.name for image in images]
 
-    response = client.get("/v1/content/images/")
+    response = client.get("/v1/content/images")
 
     assert response.status_code == 200
     assert response.json()["count"] == 3
@@ -137,7 +137,7 @@ def test_image_create_single_file_view(client: APIClient) -> None:
 
     data = create_organization_and_image()
 
-    response = client.post("/v1/content/images/", data, format="multipart")
+    response = client.post("/v1/content/images", data, format="multipart")
 
     assert response.status_code == 201, (
         f"Expected status code 201, but got {response.status_code}."
@@ -207,7 +207,7 @@ def test_image_create_multiple_files_view(client: APIClient) -> None:
 
     data = {"organization_id": str(org.id), "file_object": files}
 
-    response = client.post("/v1/content/images/", data, format="multipart")
+    response = client.post("/v1/content/images", data, format="multipart")
 
     # Assert that the response is a 201 status code.
     assert response.status_code == 201
@@ -238,7 +238,7 @@ def test_image_create_missing_file(client: APIClient) -> None:
 
     org = OrganizationFactory()
     data = {"organization_id": str(org.id)}  # no file_object provided
-    response = client.post("/v1/content/images/", data, format="multipart")
+    response = client.post("/v1/content/images", data, format="multipart")
 
     assert response.status_code == 400
     assert "fileObject" in response.json()
@@ -271,7 +271,7 @@ def test_image_create_corrupted_file(client: APIClient) -> None:
 
     data = {"organization_id": str(org.id), "file_object": file}
 
-    response = client.post("/v1/content/images/", data, format="multipart")
+    response = client.post("/v1/content/images", data, format="multipart")
 
     assert response.status_code == 400
     assert (
@@ -303,7 +303,7 @@ def test_image_create_large_file(client: APIClient) -> None:
 
     data = {"organization_id": str(org.id), "file_object": file}
 
-    response = client.post("/v1/content/images/", data, format="multipart")
+    response = client.post("/v1/content/images", data, format="multipart")
 
     assert response.status_code == 400
 
@@ -332,7 +332,7 @@ def test_image_destroy_view(client: APIClient) -> None:
 
     data = create_organization_and_image()
 
-    response = client.post("/v1/content/images/", data, format="multipart")
+    response = client.post("/v1/content/images", data, format="multipart")
     response_data = response.json()
     assert len(response_data) == 1, "Expected one image in response"
     file_id = response_data[0]["id"]
@@ -351,7 +351,7 @@ def test_image_destroy_view(client: APIClient) -> None:
 
     # Delete the image from the database and the file from the file system.
     # The signal to delete the file from the filesystem is triggered in the Image model.
-    response = client.delete(f"/v1/content/images/{file_id}/")
+    response = client.delete(f"/v1/content/images/{file_id}")
 
     # Assert file is deleted from filesystem and the database.
     assert response.status_code == 204
@@ -374,5 +374,5 @@ def test_destroy_non_existent_file_view(client: APIClient) -> None:
 
     non_existent_file_uuid = uuid.uuid4()  # Generates a random UUID
 
-    response = client.delete(f"/v1/content/images/{non_existent_file_uuid}/")
+    response = client.delete(f"/v1/content/images/{non_existent_file_uuid}")
     assert response.status_code == 404

--- a/backend/content/tests/resource/resource_flag/test_resource_flag_create.py
+++ b/backend/content/tests/resource/resource_flag/test_resource_flag_create.py
@@ -22,7 +22,7 @@ def test_resource_flag_create():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -34,7 +34,7 @@ def test_resource_flag_create():
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
     response = client.post(
-        path="/v1/content/resource_flag/",
+        path="/v1/content/resource_flag",
         data={"resource": resource.id, "created_by": user.id},
     )
 

--- a/backend/content/tests/resource/resource_flag/test_resource_flag_delete.py
+++ b/backend/content/tests/resource/resource_flag/test_resource_flag_delete.py
@@ -20,7 +20,7 @@ def test_resource_flag_delete():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -32,6 +32,6 @@ def test_resource_flag_delete():
     flag = ResourceFlagFactory()
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.delete(path=f"/v1/content/resource_flag/{flag.id}/")
+    response = client.delete(path=f"/v1/content/resource_flag/{flag.id}")
 
     assert response.status_code == 204

--- a/backend/content/tests/resource/resource_flag/test_resource_flag_list.py
+++ b/backend/content/tests/resource/resource_flag/test_resource_flag_list.py
@@ -8,6 +8,6 @@ pytestmark = pytest.mark.django_db
 def test_resource_flag_list():
     client = APIClient()
 
-    response = client.get(path="/v1/content/resource_flag/")
+    response = client.get(path="/v1/content/resource_flag")
 
     assert response.status_code == 200

--- a/backend/content/tests/resource/resource_flag/test_resource_flag_retrieve.py
+++ b/backend/content/tests/resource/resource_flag/test_resource_flag_retrieve.py
@@ -20,7 +20,7 @@ def test_resource_flag_retrieve():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -33,6 +33,6 @@ def test_resource_flag_retrieve():
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
-    response = client.get(path=f"/v1/content/resource_flag/{flag.id}/")
+    response = client.get(path=f"/v1/content/resource_flag/{flag.id}")
 
     assert response.status_code == 200

--- a/backend/content/tests/resource/test_resource_create.py
+++ b/backend/content/tests/resource/test_resource_create.py
@@ -25,7 +25,7 @@ def test_resource_create():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -50,6 +50,6 @@ def test_resource_create():
 
     # Authorized user creates resource.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.post(path="/v1/content/resources/", data=payload)
+    response = client.post(path="/v1/content/resources", data=payload)
 
     assert response.status_code == 201

--- a/backend/content/tests/resource/test_resource_delete.py
+++ b/backend/content/tests/resource/test_resource_delete.py
@@ -28,7 +28,7 @@ def test_resource_delete():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -38,12 +38,12 @@ def test_resource_delete():
 
     # Authorized owner tried to delete the resource.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.delete(path=f"/v1/content/resources/{resource.id}/")
+    response = client.delete(path=f"/v1/content/resources/{resource.id}")
 
     assert response.status_code == 204
 
     # Authorized non-owner tries to delete the resource.
-    error_response = client.delete(path=f"/v1/content/resources/{unowned_resource.id}/")
+    error_response = client.delete(path=f"/v1/content/resources/{unowned_resource.id}")
     assert error_response.status_code == 403
 
     error_body = error_response.json()

--- a/backend/content/tests/resource/test_resource_list.py
+++ b/backend/content/tests/resource/test_resource_list.py
@@ -11,6 +11,6 @@ def test_resource_list():
     """
     client = APIClient()
 
-    response = client.get(path="/v1/content/resources/")
+    response = client.get(path="/v1/content/resources")
 
     assert response.status_code == 200

--- a/backend/content/tests/resource/test_resource_partial_update.py
+++ b/backend/content/tests/resource/test_resource_partial_update.py
@@ -29,7 +29,7 @@ def test_resource_partial_update():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -48,13 +48,13 @@ def test_resource_partial_update():
 
     # Authorized owner tries to update the resource.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.patch(path=f"/v1/content/resources/{resource.id}/", data=payload)
+    response = client.patch(path=f"/v1/content/resources/{resource.id}", data=payload)
 
     assert response.status_code == 200
 
     # Authorized non-owner tries to update the resource.
     error_response = client.patch(
-        path=f"/v1/content/resources/{unowned_resource.id}/", data=payload
+        path=f"/v1/content/resources/{unowned_resource.id}", data=payload
     )
     assert error_response.status_code == 403
 

--- a/backend/content/tests/resource/test_resource_retrieve.py
+++ b/backend/content/tests/resource/test_resource_retrieve.py
@@ -24,7 +24,7 @@ def test_resource_retrieve():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -35,6 +35,6 @@ def test_resource_retrieve():
 
     # Passing authorization header.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.get(path=f"/v1/content/resources/{resource.id}/")
+    response = client.get(path=f"/v1/content/resources/{resource.id}")
 
     assert response.status_code == 200

--- a/backend/content/tests/resource/test_resource_update.py
+++ b/backend/content/tests/resource/test_resource_update.py
@@ -29,7 +29,7 @@ def test_resource_update():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_pass},
     )
 
@@ -50,13 +50,13 @@ def test_resource_update():
 
     # Authorized owner tries to update the resources.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.put(path=f"/v1/content/resources/{resource.id}/", data=payload)
+    response = client.put(path=f"/v1/content/resources/{resource.id}", data=payload)
 
     assert response.status_code == 200
 
     # Authorized non-owner tries to update the resources.
     error_response = client.put(
-        path=f"/v1/content/resources/{unowned_resource.id}/", data=payload
+        path=f"/v1/content/resources/{unowned_resource.id}", data=payload
     )
     assert error_response.status_code == 403
 

--- a/backend/content/tests/social_link/test_social_link.py
+++ b/backend/content/tests/social_link/test_social_link.py
@@ -118,7 +118,7 @@ def test_organization_social_link_list_view(client: APIClient) -> None:
     num_links = 3
     OrganizationSocialLinkFactory.create_batch(num_links, org=org)
 
-    response = client.get(f"/v1/communities/organizations/{org.id}/")
+    response = client.get(f"/v1/communities/organizations/{org.id}")
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()["socialLinks"]) == num_links
@@ -134,7 +134,7 @@ def test_group_social_link_list_view(client: APIClient) -> None:
     num_links = 3
     GroupSocialLinkFactory.create_batch(num_links, group=group)
 
-    response = client.get(f"/v1/communities/groups/{group.id}/")
+    response = client.get(f"/v1/communities/groups/{group.id}")
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()["socialLinks"]) == num_links
@@ -150,7 +150,7 @@ def test_event_social_link_list_view(client: APIClient) -> None:
     num_links = 3
     EventSocialLinkFactory.create_batch(num_links, event=event)
 
-    response = client.get(f"/v1/events/events/{event.id}/")
+    response = client.get(f"/v1/events/events/{event.id}")
 
     assert response.status_code == status.HTTP_200_OK
     assert len(response.json()["socialLinks"]) == num_links
@@ -173,7 +173,7 @@ def test_organization_social_link_create_view(client: APIClient) -> None:
     formData = [{"link": "https://example.com", "label": "Example", "order": 1}]
 
     response = client.put(
-        f"/v1/communities/organization_social_links/{org.id}/",
+        f"/v1/communities/organization_social_links/{org.id}",
         formData,
         content_type="application/json",
     )
@@ -199,7 +199,7 @@ def test_group_social_link_create_view(client: APIClient) -> None:
     formData = [{"link": "https://example.com", "label": "Example", "order": 1}]
 
     response = client.put(
-        f"/v1/communities/group_social_links/{group.id}/",
+        f"/v1/communities/group_social_links/{group.id}",
         formData,
         content_type="application/json",
     )
@@ -225,7 +225,7 @@ def test_event_social_link_create_view(client: APIClient) -> None:
     formData = [{"link": "https://example.com", "label": "Example", "order": 1}]
 
     response = client.put(
-        f"/v1/events/event_social_links/{event.id}/",
+        f"/v1/events/event_social_links/{event.id}",
         formData,
         content_type="application/json",
     )

--- a/backend/content/urls.py
+++ b/backend/content/urls.py
@@ -10,7 +10,7 @@ from content import views
 
 app_name = "content"
 
-router = DefaultRouter()
+router = DefaultRouter(trailing_slash=False)
 
 # MARK: Main Tables
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -211,6 +211,7 @@ REST_FRAMEWORK = {
         "djangorestframework_camel_case.parser.CamelCaseMultiPartParser",
         "djangorestframework_camel_case.parser.CamelCaseJSONParser",
     ),
+    "URL_FORMAT_OVERRIDE": None,
 }
 
 # MARK: Spectacular

--- a/backend/core/tests/unit/test_throttling.py
+++ b/backend/core/tests/unit/test_throttling.py
@@ -21,7 +21,7 @@ def test_anon_throttle():
     client = APIClient()
 
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["anon"] = "3/min"
-    endpoint = "/v1/communities/organizations/"
+    endpoint = "/v1/communities/organizations"
 
     for i in range(3):
         print(f"Request {i + 1}")
@@ -57,13 +57,13 @@ def test_auth_throttle():
 
     # Login to get token.
     login_response = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
     token = login_response.json()["token"]
 
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user"] = "5/min"
-    endpoint = "/v1/communities/organizations/"
+    endpoint = "/v1/communities/organizations"
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     for i in range(5):

--- a/backend/events/tests/faq/test_event_faq_update.py
+++ b/backend/events/tests/faq/test_event_faq_update.py
@@ -48,7 +48,7 @@ def test_event_faq_update(client: Client) -> None:
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -60,7 +60,7 @@ def test_event_faq_update(client: Client) -> None:
     token = login_body["token"]
 
     response = client.put(
-        path=f"/v1/events/event_faqs/{event.id}/",
+        path=f"/v1/events/event_faqs/{event.id}",
         data={
             "id": test_id,
             "iso": "en",
@@ -80,7 +80,7 @@ def test_event_faq_update(client: Client) -> None:
     test_uuid = uuid4()
 
     response = client.put(
-        path=f"/v1/events/event_faqs/{test_uuid}/",
+        path=f"/v1/events/event_faqs/{test_uuid}",
         data={
             "id": test_id,
             "question": test_question,

--- a/backend/events/tests/flag/test_event_flag_create.py
+++ b/backend/events/tests/flag/test_event_flag_create.py
@@ -20,7 +20,7 @@ def test_event_flag_create():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -32,7 +32,7 @@ def test_event_flag_create():
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
-        path="/v1/events/event_flag/", data={"event": event.id, "created_by": user.id}
+        path="/v1/events/event_flag", data={"event": event.id, "created_by": user.id}
     )
 
     assert response.status_code == 201

--- a/backend/events/tests/flag/test_event_flag_delete.py
+++ b/backend/events/tests/flag/test_event_flag_delete.py
@@ -21,7 +21,7 @@ def test_event_flag_delete():
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -33,6 +33,6 @@ def test_event_flag_delete():
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
-    response = client.delete(path=f"/v1/events/event_flag/{flag.id}/")
+    response = client.delete(path=f"/v1/events/event_flag/{flag.id}")
 
     assert response.status_code == 204

--- a/backend/events/tests/flag/test_event_flag_list.py
+++ b/backend/events/tests/flag/test_event_flag_list.py
@@ -8,6 +8,6 @@ pytestmark = pytest.mark.django_db
 def test_event_flag_list():
     client = APIClient()
 
-    response = client.get(path="/v1/events/event_flag/")
+    response = client.get(path="/v1/events/event_flag")
 
     assert response.status_code == 200

--- a/backend/events/tests/flag/test_event_flag_retrieve.py
+++ b/backend/events/tests/flag/test_event_flag_retrieve.py
@@ -12,6 +12,6 @@ def test_event_flag_retrieve():
 
     flag = EventFlagFactory()
 
-    response = client.get(path=f"/v1/events/event_flag/{flag.id}/")
+    response = client.get(path=f"/v1/events/event_flag/{flag.id}")
 
     assert response.status_code == 200

--- a/backend/events/tests/social_link/test_event_social_link_update.py
+++ b/backend/events/tests/social_link/test_event_social_link_update.py
@@ -45,7 +45,7 @@ def test_event_social_link_update(client: Client) -> None:
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -57,7 +57,7 @@ def test_event_social_link_update(client: Client) -> None:
     token = login_body["token"]
 
     response = client.put(
-        path=f"/v1/events/event_social_links/{event.id}/",
+        path=f"/v1/events/event_social_links/{event.id}",
         data={
             "link": test_link,
             "label": test_label,
@@ -74,7 +74,7 @@ def test_event_social_link_update(client: Client) -> None:
     test_uuid = uuid4()
 
     response = client.put(
-        path=f"/v1/events/event_social_links/{test_uuid}/",
+        path=f"/v1/events/event_social_links/{test_uuid}",
         data={
             "link": test_link,
             "label": test_label,

--- a/backend/events/tests/test_event_api.py
+++ b/backend/events/tests/test_event_api.py
@@ -12,7 +12,7 @@ from events.factories import EventFactory
 from events.models import Event
 
 # Endpoint used for these tests:
-EVENTS_URL = "/v1/events/events/"
+EVENTS_URL = "/v1/events/events"
 
 
 class UserDict(TypedDict):
@@ -34,7 +34,7 @@ def login_user(user_data: UserDict) -> dict[Any, Any]:
     """
     client = APIClient()
     response = client.post(
-        "/v1/auth/sign_in/",
+        "/v1/auth/sign_in",
         {
             "username": user_data["user"].username,
             "password": user_data["plaintext_password"],
@@ -139,7 +139,7 @@ def test_EventDetailAPIView(logged_in_user) -> None:  # type: ignore[no-untyped-
 
     # MARK: Detail GET
 
-    response = client.get(f"{EVENTS_URL}{new_event.id}/")
+    response = client.get(f"{EVENTS_URL}/{new_event.id}")
 
     assert response.status_code == 200
     assert response.data["name"] == new_event.name
@@ -152,12 +152,12 @@ def test_EventDetailAPIView(logged_in_user) -> None:  # type: ignore[no-untyped-
         "end_time": "2020-09-18T21:39:14",
         "terms_checked": True,
     }
-    response = client.put(f"{EVENTS_URL}{new_event.id}/", data=payload, format="json")
+    response = client.put(f"{EVENTS_URL}/{new_event.id}", data=payload, format="json")
 
     assert response.status_code == 401
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.put(f"{EVENTS_URL}{new_event.id}/", data=payload, format="json")
+    response = client.put(f"{EVENTS_URL}/{new_event.id}", data=payload, format="json")
 
     assert response.status_code == 200
     assert payload["name"] == Event.objects.get(id=new_event.id).name
@@ -165,11 +165,11 @@ def test_EventDetailAPIView(logged_in_user) -> None:  # type: ignore[no-untyped-
     # MARK: Detail DELETE
 
     client.credentials()
-    response = client.delete(f"{EVENTS_URL}{new_event.id}/")
+    response = client.delete(f"{EVENTS_URL}/{new_event.id}")
     assert response.status_code == 401
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    response = client.delete(f"{EVENTS_URL}{new_event.id}/")
+    response = client.delete(f"{EVENTS_URL}/{new_event.id}")
 
     assert response.status_code == 200
     assert not Event.objects.filter(id=new_event.id).exists()

--- a/backend/events/tests/test_event_delete.py
+++ b/backend/events/tests/test_event_delete.py
@@ -21,7 +21,7 @@ def test_event_delete(client: Client) -> None:
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -33,7 +33,7 @@ def test_event_delete(client: Client) -> None:
     event = EventFactory.create()
 
     response = client.delete(
-        path=f"/v1/events/events/{event.id}/",
+        path=f"/v1/events/events/{event.id}",
         headers={"Authorization": f"Token {token}"},
     )
 

--- a/backend/events/tests/test_event_list.py
+++ b/backend/events/tests/test_event_list.py
@@ -9,6 +9,6 @@ def test_event_list(client: Client) -> None:
     """
     List Events.
     """
-    response = client.get(path="/v1/events/events/")
+    response = client.get(path="/v1/events/events")
 
     assert response.status_code == 200

--- a/backend/events/tests/test_event_retrieve.py
+++ b/backend/events/tests/test_event_retrieve.py
@@ -17,6 +17,6 @@ def test_event_retrieve(client: Client) -> None:
     """
     event = EventFactory()
 
-    response = client.get(path=f"/v1/events/events/{event.id}/")
+    response = client.get(path=f"/v1/events/events/{event.id}")
 
     assert response.status_code == 200

--- a/backend/events/tests/test_event_update.py
+++ b/backend/events/tests/test_event_update.py
@@ -25,7 +25,7 @@ def test_event_update(client: Client) -> None:
 
     # Login to get token.
     login = client.post(
-        path="/v1/auth/sign_in/",
+        path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
 
@@ -37,7 +37,7 @@ def test_event_update(client: Client) -> None:
     event = EventFactory.create()
 
     response = client.put(
-        path=f"/v1/events/events/{event.id}/",
+        path=f"/v1/events/events/{event.id}",
         data={
             "name": "test_name",
             "type": "test_type",

--- a/backend/events/urls.py
+++ b/backend/events/urls.py
@@ -16,7 +16,7 @@ from events.views import (
 )
 
 app_name = "events"
-router = DefaultRouter()
+router = DefaultRouter(trailing_slash=False)
 
 # MARK: Bridge Tables
 
@@ -37,6 +37,6 @@ router.register(prefix=r"event_flag", viewset=EventFlagViewSet, basename="event-
 
 urlpatterns = [
     path("", include(router.urls)),
-    path("events/", EventAPIView.as_view()),
-    path("events/<uuid:id>/", EventDetailAPIView.as_view()),
+    path("events", EventAPIView.as_view()),
+    path("events/<uuid:id>", EventDetailAPIView.as_view()),
 ]


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

I removed all trailing slashes from API endpoints to follow the common convention. It's not specified in REST but it's mostly done without trailing slashes (FastAPI, node.js Frameworks,...). 

### Notes

I encouter the pre-commit mypy issue again:

```bash
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check for added large files..............................................Passed
run ruff linting check...................................................Passed
run ruff formatting check................................................Passed
run numpydoc docstring validation........................................Passed
run mypy static type checking............................................Failed
- hook id: mypy-check
- exit code: 1

Der Befehl "mypy" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.

run i18n-check.......................................(no files to check)Skipped
run prettier and eslint checks.......................(no files to check)Skipped
```

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- No related issue
