### PR TITLE
#841 Fix e2e tests for sign in and event page + update share icon location + org create styling

### DIFF
--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
@@ -26,7 +26,7 @@
         class="flex max-h-[40px] w-full items-center"
         :cta="true"
         label="i18n._global.share"
-        :leftIcon="IconMap.SHARE"
+        :rightIcon="IconMap.SHARE"
         fontSize="lg"
         ariaLabel="i18n._global.share_event_aria_label"
       />

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultGroup.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultGroup.vue
@@ -28,7 +28,7 @@
         class="flex max-h-[40px] w-full items-center"
         :cta="true"
         label="i18n._global.share"
-        :leftIcon="IconMap.SHARE"
+        :rightIcon="IconMap.SHARE"
         fontSize="lg"
         ariaLabel="i18n._global.share_organization_aria_label"
       />

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultOrganization.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultOrganization.vue
@@ -28,7 +28,7 @@
         class="flex max-h-[40px] w-full items-center"
         :cta="true"
         label="i18n._global.share"
-        :leftIcon="IconMap.SHARE"
+        :rightIcon="IconMap.SHARE"
         fontSize="lg"
         ariaLabel="i18n._global.share_organization_aria_label"
       />

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultResource.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultResource.vue
@@ -18,7 +18,7 @@
         class="flex max-h-[40px] w-full items-center"
         :cta="true"
         label="i18n._global.share"
-        :leftIcon="IconMap.SHARE"
+        :rightIcon="IconMap.SHARE"
         fontSize="lg"
         ariaLabel="i18n._global.share"
       />

--- a/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultUser.vue
+++ b/frontend/components/tooltip/menu-search-result/TooltipMenuSearchResultUser.vue
@@ -18,7 +18,7 @@
         class="flex max-h-[40px] w-full items-center"
         :cta="true"
         label="i18n._global.share"
-        :leftIcon="IconMap.SHARE"
+        :rightIcon="IconMap.SHARE"
         fontSize="lg"
         :ariaLabel="
           $t(

--- a/frontend/pages/auth/sign-up.vue
+++ b/frontend/pages/auth/sign-up.vue
@@ -63,7 +63,13 @@
       </FormItem>
 
       <FormItem
-        v-slot="{ id, handleChange, handleBlur, errorMessage }"
+        v-slot="{
+          id,
+          value: confirmPassword,
+          handleChange,
+          handleBlur,
+          errorMessage,
+        }"
         name="confirmPassword"
       >
         <FormTextInputPassword
@@ -77,15 +83,17 @@
             <span>
               <Icon
                 :name="
+                  confirmPassword.value &&
                   errorMessage.value !==
-                  t('i18n.pages.auth._global.password_not_matched')
+                    t('i18n.pages.auth._global.password_not_matched')
                     ? IconMap.CHECK
                     : IconMap.X_LG
                 "
                 size="1.2em"
                 :color="
+                  confirmPassword.value &&
                   errorMessage.value !==
-                  t('i18n.pages.auth._global.password_not_matched')
+                    t('i18n.pages.auth._global.password_not_matched')
                     ? '#3BA55C'
                     : '#BA3D3B'
                 "

--- a/frontend/pages/events/[eventId]/about.vue
+++ b/frontend/pages/events/[eventId]/about.vue
@@ -38,7 +38,7 @@
           :label="shareButtonLabel"
           :hideLabelOnMobile="false"
           fontSize="sm"
-          :leftIcon="IconMap.SHARE"
+          :rightIcon="IconMap.SHARE"
           iconSize="1.45em"
           ariaLabel="i18n._global.share_event_aria_label"
         />
@@ -49,7 +49,7 @@
           :cta="true"
           label="i18n.pages.events.about.subscribe_to_event"
           fontSize="sm"
-          :leftIcon="IconMap.DATE"
+          :rightIcon="IconMap.DATE"
           iconSize="1.25em"
           ariaLabel="i18n._global.subscribe_to_event_aria_label"
         />

--- a/frontend/pages/organizations/[orgId]/about.vue
+++ b/frontend/pages/organizations/[orgId]/about.vue
@@ -38,7 +38,7 @@
             :label="shareButtonLabel"
             :hideLabelOnMobile="false"
             fontSize="sm"
-            :leftIcon="IconMap.SHARE"
+            :rightIcon="IconMap.SHARE"
             iconSize="1.45em"
             ariaLabel="i18n._global.share_organization_aria_label"
           />

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/about.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/about.vue
@@ -42,7 +42,7 @@
           :label="shareButtonLabel"
           :hideLabelOnMobile="false"
           fontSize="sm"
-          :leftIcon="IconMap.SHARE"
+          :rightIcon="IconMap.SHARE"
           iconSize="1.45em"
           ariaLabel="i18n.pages.organizations.groups.about.share_group_aria_label"
         />

--- a/frontend/pages/organizations/create.vue
+++ b/frontend/pages/organizations/create.vue
@@ -24,7 +24,7 @@
         id="organization-create-form"
         :schema="schema"
         class="flex w-full flex-col items-center justify-center pt-4"
-        class-button="ml-[3.5rem] mb-4"
+        class-button="mb-4"
         submit-label="i18n.pages.organizations.create.complete_application"
       >
         <!-- First card: Name and Location -->

--- a/frontend/test-e2e/page-objects/SignInPage.ts
+++ b/frontend/test-e2e/page-objects/SignInPage.ts
@@ -11,7 +11,7 @@ export const newSignInPage = (page: Page) => ({
     getEnglishText("i18n.pages.auth.sign_in.enter_user_name")
   ),
   passwordInput: page.getByLabel(getEnglishText("i18n._global.enter_password")),
-  showPasswordToggle: page.locator("#sign-in-password-show-password"),
+  showPasswordToggle: page.locator("#form-item-password-show-password"),
   captcha: page.locator("#sign-in-captcha"),
 
   // Currently a button but should be a link
@@ -23,6 +23,6 @@ export const newSignInPage = (page: Page) => ({
   }),
 
   signInButton: page.getByRole("button", {
-    name: new RegExp(getEnglishText("i18n._global.sign_in_aria_label"), "i"),
+    name: getEnglishText("i18n.components.submit_aria_label"),
   }),
 });

--- a/frontend/test-e2e/specs/desktop/events-page.spec.ts
+++ b/frontend/test-e2e/specs/desktop/events-page.spec.ts
@@ -4,27 +4,21 @@ import { expect, test } from "playwright/test";
 import { getEnglishText } from "~/utils/i18n";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/events");
+  await page.goto("/events?view=list");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(/events/i);
 });
 
 test.describe("Events Page", { tag: "@desktop" }, () => {
-  // User can share the events page.
-  test("User can share the event page", async ({ page }) => {
-    const shareButton = page
+  test("User can navigate to an event about page", async ({ page }) => {
+    const eventImage = page
       .getByRole("link", {
         name: getEnglishText(
           "i18n.components.card_search_result.navigate_to_event_aria_label"
         ),
       })
-      .locator("xpath=following-sibling::div")
-      .getByRole("button")
       .first();
-    await shareButton.click();
-    await expect(shareButton.locator("div.tooltip")).toBeVisible();
-    await shareButton.locator("div.tooltip").locator("button").click();
 
-    const shareModal = page.locator("#search-modal").first();
-    await expect(shareModal).toBeVisible();
+    await eventImage.click();
+    await page.waitForURL("**/events/**/about");
   });
 });

--- a/frontend/test-e2e/specs/mobile/events-page.spec.ts
+++ b/frontend/test-e2e/specs/mobile/events-page.spec.ts
@@ -4,27 +4,21 @@ import { expect, test } from "playwright/test";
 import { getEnglishText } from "~/utils/i18n";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/events");
+  await page.goto("/events?view=list");
   await expect(page.getByRole("heading", { level: 1 })).toHaveText(/events/i);
 });
 
 test.describe("Events Page", { tag: "@mobile" }, () => {
-  test("Share button opens in mobile share sheet", async ({ page }) => {
-    const shareButton = page
+  test("User can navigate to an event about page", async ({ page }) => {
+    const eventImage = page
       .getByRole("link", {
         name: getEnglishText(
           "i18n.components.card_search_result.navigate_to_event_aria_label"
         ),
       })
-      .locator("xpath=following-sibling::div")
-      .getByRole("button")
       .first();
 
-    await shareButton.click();
-    await expect(shareButton.locator("div.tooltip")).toBeVisible();
-    await shareButton.locator("div.tooltip").locator("button").click();
-
-    const shareModal = page.locator("#search-modal").first();
-    await expect(shareModal).toBeVisible();
+    await eventImage.click();
+    await page.waitForURL("**/events/**/about");
   });
 });


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Various changes within this PR:
- Fixes the e2e tests via the new form components
- Share icons were all moved over to the right
- The submit button for organization creation had a left margin that was removed

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #841 
