### PR TITLE
Refactor module import and pre-commit hook execution to fix mypy error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,6 @@ repos:
       - id: prettier-eslint-checks
         name: run prettier and eslint checks
         files: ^frontend/
-        entry: python ./pre_commit_scripts/prettier_eslint_checks.py
+        entry: python -m pre_commit_scripts.prettier_eslint_checks
         language: python
         pass_filenames: false

--- a/pre_commit_scripts/prettier_eslint_checks.py
+++ b/pre_commit_scripts/prettier_eslint_checks.py
@@ -6,7 +6,7 @@ pre-commit hook for checking Prettier formatting.
 import os
 import sys
 
-from utils import run_shell_command
+from .utils import run_shell_command
 
 os.chdir("frontend")
 if not sys.platform.startswith("win"):


### PR DESCRIPTION
### What this PR does
- Refactored import in prettier_eslint_checks.py to use relative import: from .utils import run_shell_command
- Updated pre-commit hook to run the script as a module using python -m
- Fixes mypy static type checking error caused by incorrect import resolution
- Ensures cross-platform compatibility with tools like pre-commit (Windows/Linux/macOS)

### Related issue
Closes #1344  
