### PR TITLE
Fix Safari favicon display issue

### DIFF
--- a/frontend/head.ts
+++ b/frontend/head.ts
@@ -61,7 +61,18 @@ export default {
     {
       rel: "icon",
       type: "image/svg+xml",
-      href: "icons/favicons/favicon.svg",
+      href: "/icons/favicons/favicon.svg",
+    },
+    {
+      rel: "icon",
+      type: "image/png",
+      sizes: "32x32",
+      href: "/icons/favicons/faviconLight.png",
+    },
+    {
+      rel: "apple-touch-icon",
+      sizes: "180x180",
+      href: "/icons/favicons/faviconLight.png",
     },
     {
       hid: "canonical",


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

-[x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
-[x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description


- Fix favicon path by adding leading slash for absolute path
- Add PNG fallback favicon for Safari and Brave compatibility
- Add Apple touch icon for iOS Safari support

Closes #605

🤖 Generated with [Claude Code](https://claude.ai/code)


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #605
