### PR TITLE
chore:update styleguide with new text stying guide section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 # **Contents**
 
 - [Our goals](#our-goals)
-- [Preview Video](#preview-video)
+- [Preview video](#preview-video)
 - [Contributing](#contributing)
 - [Environment setup](#environment-setup)
 - [Design and accessibility](#design-a11y)

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -255,7 +255,7 @@ The fonts for activist are [Red Hat Text and Red Hat Display](https://www.redhat
 <h1 class="font-bold">Page Header</h1>
 ```
 
-### Text Colors
+### Text colors
 
 Text color is controlled using semantic utility classes defined in `@layer components` in `frontend/assets/css/tailwind.css`. These classes are designed to work consistently across light and dark modes, using CSS variables defined in your theme.
 
@@ -347,7 +347,7 @@ Localization keys should be defined based on the file in which they're used with
 
 <a id="images-icons"></a>
 
-## Images and Icons [`⇧`](#contents)
+## Images and icons [`⇧`](#contents)
 
 Please define all routes for images and icons in the respective [url registry utils file](frontend/utils/imageURLRegistry.s.ts) and [icon map enum](frontend/types/icon-map.ts).
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -10,18 +10,25 @@ If you have questions or would like to communicate with the team, please [join u
 
 ## **Contents**
 
-- [Vue and Nuxt](#vue-and-nuxt)
-- [TypeScript](#typescript)
-- [Tailwind](#tailwind)
-- [Common styles](#common-styles)
-- [Formatting](#formatting)
-- [Colors](#colors)
-- [Font](#font)
-- [Text size](#text-size)
-- [Localization](#localization)
-- [Images and Icons](#images-icons)
-- [Tab size](#tab-size)
-- [Padding](#padding)
+- [Style Guidelines for activist.org](#style-guidelines-for-activistorg)
+  - [**Contents**](#contents)
+  - [Vue and Nuxt `⇧`](#vue-and-nuxt-)
+    - [Page Routing](#page-routing)
+    - [Breakpoints](#breakpoints)
+  - [TypeScript `⇧`](#typescript-)
+    - [Vue Single File Component (.vue file) Guidelines](#vue-single-file-component-vue-file-guidelines)
+  - [Tailwind `⇧`](#tailwind-)
+  - [Common styles `⇧`](#common-styles-)
+  - [Formatting `⇧`](#formatting-)
+  - [Colors `⇧`](#colors-)
+  - [Text styles `⇧`](#text-styles-)
+    - [Font `⇧`](#font-)
+    - [Text size `⇧`](#text-size-)
+    - [Text Colors](#text-colors)
+  - [Localization `⇧`](#localization-)
+  - [Images and Icons `⇧`](#images-and-icons-)
+  - [Tab size `⇧`](#tab-size-)
+  - [Padding `⇧`](#padding-)
 
 <a id="vue-and-nuxt"></a>
 
@@ -197,15 +204,55 @@ Note further that Tailwind allows for alpha components for opacity to be applied
 <div class="bg-cta-orange/40"></div>
 ```
 
+
+<a id="text-styles"></a>
+
+## Text styles [`⇧`](#contents)
+
+The activist frontend applies consistent global styles to semantic HTML tags like `h1`, `h2`, `p`, `ul`, and `ol` via Tailwind classes inside `frontend/assets/css/tailwind.css`. This ensures that text styling is predictable, accessible, and visually cohesive across the platform.
+
+These styles are **defined globally** using Tailwind’s `@layer components` and should be relied upon by all contributors instead of re-applying utility classes manually.
+
+**Do use semantic tags with global styles:**
+
+```html
+<h1>Organize for impact</h1>
+<p>Start building your campaign with tools built for activists.</p>
+```
+
+No need to add text classes like `text-xl` or `text-gray-800` — they’re already applied globally.
+
+**Don’t manually override text styles:**
+
+```html
+<!-- Avoid this unless absolutely necessary -->
+<h1 class="text-xl text-gray-700">Organize for impact</h1>
+```
+
+Only add utility overrides if absolutely necessary for a unique layout or design request. In general, styling for typography should be handled globally through semantic elements and in the lower sections it will define different variation of styling that is predefined.
+
+**Example of globally applied styles:**
+
+| Element | Applied classes                                   |
+| ------- | ------------------------------------------------- |
+| `h1`    | `responsive-h1 text-primary-text`                 |
+| `h2`    | `responsive-h2 text-primary-text`                 |
+| `p`     | `text-base text-primary-text`                     |
+| `ul`    | `text-base text-primary-text`                     |
+| `a`     | *(opted out globally; use `link-text` as needed)* |
+
+> \[!NOTE]
+> Global styles for headings and body text help ensure accessibility, dark mode support, and visual consistency. Avoid duplicating or overriding them unless necessary.
+
 <a id="font"></a>
 
-## Font [`⇧`](#contents)
+### Font [`⇧`](#contents)
 
 The fonts for activist are [Red Hat Text and Red Hat Display](https://www.redhat.com/en/about/brand/standards/typography) as defined in [frontend/tailwind.config.ts](frontend/tailwind.config.ts). `Red Hat Text` is applied throughout the website and `Red Hat Display` is used for all headers by applying `font-display`. As headers are defined by `responsive-h#` custom classes that include `font-display` being applied globally to their corresponding `h#` HTML, it will be rare that you'll need to apply it directly. See the next section for more details.
 
 <a id="text-size"></a>
 
-## Text size [`⇧`](#contents)
+### Text size [`⇧`](#contents)
 
 [frontend/assets/css/tailwind.css](frontend/assets/css/tailwind.css) defines custom combinations of default and activist defined Tailwind header sizes. Responsive header classes all have `font-display` applied to them and are globally applied to the corresponding HTML `h#` tag. Note that headers should generally have a `bold` style applied to them as well, with for example page headers being defined as follows:
 
@@ -213,6 +260,45 @@ The fonts for activist are [Red Hat Text and Red Hat Display](https://www.redhat
 <!-- The size and weight styles for page headers. -->
 <h1 class="font-bold">Page Header</h1>
 ```
+
+### Text Colors
+
+Text color is controlled using semantic utility classes defined in `@layer components` in `frontend/assets/css/tailwind.css`. These classes are designed to work consistently across light and dark modes, using CSS variables defined in your theme.
+
+Avoid using raw Tailwind color utilities like `text-gray-500` or `text-white`. Instead, use the predefined text color classes listed below.
+
+| Utility Class       | Description                                     |
+| ------------------- | ----------------------------------------------- |
+| `text-primary-text` | Default text color (used in `p`, `ul`, etc.)    |
+| `distinct-text`     | De-emphasized text, slightly lighter or grayer  |
+| `link-text`         | Link color in both light and dark modes         |
+| `link-text-hover`   | Applied on `:hover` to links for interaction    |
+| `error-text`        | Text indicating an error (e.g. form validation) |
+| `warn-text`         | Warning or alert text                           |
+
+**Example usage:**
+
+```html
+<p>This uses the default text color.</p>
+
+<p class="distinct-text">
+  This is secondary or less prominent text.
+</p>
+
+<a href="#" class="link-text">
+  Click here
+</a>
+
+<p class="error-text">
+  Please enter a valid email.
+</p>
+```
+
+These utility classes are responsive to theme changes (light/dark) and should be used instead of inline or raw utility colors.
+
+> \[!TIP]
+> Need a new text color variant? Add it to `@layer components` and ensure it maps to a CSS variable for both themes.
+
 
 <a id="localization"></a>
 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -10,29 +10,29 @@ If you have questions or would like to communicate with the team, please [join u
 
 ## **Contents**
 
-- [Style Guidelines for activist.org](#style-guidelines-for-activistorg)
-  - [**Contents**](#contents)
-  - [Vue and Nuxt `⇧`](#vue-and-nuxt-)
-    - [Page Routing](#page-routing)
-    - [Breakpoints](#breakpoints)
-  - [TypeScript `⇧`](#typescript-)
-    - [Vue Single File Component (.vue file) Guidelines](#vue-single-file-component-vue-file-guidelines)
-  - [Tailwind `⇧`](#tailwind-)
-  - [Common styles `⇧`](#common-styles-)
-  - [Formatting `⇧`](#formatting-)
-  - [Colors `⇧`](#colors-)
-  - [Text styles `⇧`](#text-styles-)
-    - [Font `⇧`](#font-)
-    - [Text size `⇧`](#text-size-)
-    - [Text Colors](#text-colors)
-  - [Localization `⇧`](#localization-)
-  - [Images and Icons `⇧`](#images-and-icons-)
-  - [Tab size `⇧`](#tab-size-)
-  - [Padding `⇧`](#padding-)
+- [Vue and Nuxt](#vue-and-nuxt)
+  - [Page routing](#page-routing)
+  - [Breakpoints](#breakpoints)
+- [TypeScript](#typescript)
+- [Tailwind](#tailwind)
+- [Common styles](#common-styles)
+- [Formatting](#formatting)
+- [Colors](#colors)
+- [Text styles](#text-styles)
+  - [Font](#font)
+  - [Text size](#text-size)
+  - [Text colors](#text-colors)
+- [Localization](#localization)
+- [Images and icons](#images-and-icons)
+- [Tab size](#tab-size)
+- [Padding](#padding)
 
 <a id="vue-and-nuxt"></a>
 
 ## Vue and Nuxt [`⇧`](#contents)
+
+> [!NOTE]
+> For VS Code users: it is recommended to install [Vue extension](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to enable in-editor type-checking:
 
 The frontend for activist is written in the framework [Vue.js](https://vuejs.org/) and specifically the meta-framework [Nuxt.js](https://nuxt.com/). The team chose Vue because of its broad usage across the development industry as well as relative ease of use and adoption for new contributors. Most of all we appreciate the structure that Vue adds to a project by leveraging the order of HTML and adding scripting and styling on top. Nuxt expands on Vue seamlessly and includes many [modules](https://nuxt.com/modules) to make development much easier.
 
@@ -96,15 +96,6 @@ activist uses Tailwind for CSS, and some parts of components will be conditional
 <a id="typescript"></a>
 
 ## TypeScript [`⇧`](#contents)
-
-PRs are always welcome to improve the developer experience and project infrastructure!
-
-> [!NOTE]
-> For VS Code users: it is recommended to install Vue extensions to enable in-editor type-checking:
->
-> - [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar)
-
-### Vue Single File Component (.vue file) Guidelines
 
 - Create general frontend types in the [frontend/types](frontend/types) directory
 - When typing Arrays, use `arrayElementType[]` rather than the generic type `Array<T>` unless [extending](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#arrays):
@@ -209,6 +200,9 @@ Note further that Tailwind allows for alpha components for opacity to be applied
 
 ## Text styles [`⇧`](#contents)
 
+> [!IMPORTANT]
+> The examples below use plain text to be easily understandable, but note that all texts should be defined using i18n keys in the `frontend/i18n` JSON files. Please see the [Localization](#localization) section below to learn more.
+
 The activist frontend applies consistent global styles to semantic HTML tags like `h1`, `h2`, `p`, `ul`, and `ol` via Tailwind classes inside `frontend/assets/css/tailwind.css`. This ensures that text styling is predictable, accessible, and visually cohesive across the platform.
 
 These styles are **defined globally** using Tailwind’s `@layer components` and should be relied upon by all contributors instead of re-applying utility classes manually.
@@ -225,7 +219,7 @@ No need to add text classes like `text-xl` or `text-gray-800` — they’re alre
 **Don’t manually override text styles:**
 
 ```html
-<!-- Avoid this unless absolutely necessary -->
+<!-- Avoid this unless absolutely necessary. -->
 <h1 class="text-xl text-gray-700">Organize for impact</h1>
 ```
 
@@ -241,7 +235,7 @@ Only add utility overrides if absolutely necessary for a unique layout or design
 | `ul`    | `text-base text-primary-text`                     |
 | `a`     | *(opted out globally; use `link-text` as needed)* |
 
-> \[!NOTE]
+> [!NOTE]
 > Global styles for headings and body text help ensure accessibility, dark mode support, and visual consistency. Avoid duplicating or overriding them unless necessary.
 
 <a id="font"></a>
@@ -296,9 +290,8 @@ Avoid using raw Tailwind color utilities like `text-gray-500` or `text-white`. I
 
 These utility classes are responsive to theme changes (light/dark) and should be used instead of inline or raw utility colors.
 
-> \[!TIP]
+> [!NOTE]
 > Need a new text color variant? Add it to `@layer components` and ensure it maps to a CSS variable for both themes.
-
 
 <a id="localization"></a>
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This PR adds a new section to the style guide under the name Text styles, explaining how global typography is handled using semantic HTML tags (h1, h2, p, etc.) with Tailwind classes applied at the component level. This addition aims to encourage consistent use of predefined styles rather than applying utility classes individually on each element.

It also introduces a subsection for Text Colors, documenting semantic utility classes like distinct-text, link-text, error-text, and warn-text.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1341 
