### PR TITLE
issue1369

### DIFF
--- a/frontend/components/form/text/FormTextInput.vue
+++ b/frontend/components/form/text/FormTextInput.vue
@@ -25,8 +25,9 @@
         @focus="shrinkLabel = true"
         @blur="handleBlur"
         :id="id"
-        class="box-content h-5 w-full bg-transparent py-3 pl-[12px] pr-[10px] text-primary-text outline-none"
+        class="box-content h-5 w-full bg-transparent py-3 pl-[12px] pr-[10px] text-primary-text placeholder-distinct-text outline-none"
         type="text"
+        :Placeholder="label"
         :value="modelValue"
         v-bind="$attrs"
       />

--- a/frontend/components/form/text/FormTextInput.vue
+++ b/frontend/components/form/text/FormTextInput.vue
@@ -27,7 +27,7 @@
         :id="id"
         class="box-content h-5 w-full bg-transparent py-3 pl-[12px] pr-[10px] text-primary-text placeholder-distinct-text outline-none"
         type="text"
-        :Placeholder="label"
+        :placeholder="label"
         :value="modelValue"
         v-bind="$attrs"
       />


### PR DESCRIPTION
Sure! Here's a single unified text version of your pull request message:

---

Thank you for your pull request! 🚀

This pull request fixes the issue where placeholder text in `FormTextInput.vue` did not adapt to light and dark mode themes, making it unreadable in dark mode. The fix involves adding the `placeholder-distinct-text` class and binding the placeholder to the `label` prop to ensure theme-aware styling. Changes have been made on a separate branch, and all necessary frontend tests have been run to verify the fix.

This addresses issue #1369.
