### PR TITLE
Replace print() with logger.error() in scrub_exif(#1377)

### DIFF
--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -116,7 +116,8 @@ def scrub_exif(image_file: InMemoryUploadedFile) -> InMemoryUploadedFile:
         )
 
     except Exception as e:
-        print(f"Error scrubbing EXIF: {e}")
+        logger.error(f"Error scrubbing EXIF: {e}")
+
         return image_file  # return original file in case of error
 
 


### PR DESCRIPTION
### Summary

Replaced `print()` in the `scrub_exif()` function inside `backend/content/serializers.py` with `logger.error()` to follow consistent logging practices across the codebase.

### Context

This resolves the logging inconsistency described in issue #1377. The file already uses the Python `logging` module, and switching from `print()` to `logger.error()` ensures better log management and clarity.

### Related issue

- #1377
