### PR TITLE
fix(menu): sync icon and text hover colors in dark mode

### DIFF
--- a/frontend/components/menu/MenuItemLabel.vue
+++ b/frontend/components/menu/MenuItemLabel.vue
@@ -67,18 +67,18 @@ const infoLabel = computed(() => {
   return props.isButton
     ? {
         is: "p",
-        class: "pl-2 pr-2",
+        class: "pl-2 pr-2 pl-2 pr-2 dark:group-hover:text-cta-orange",
       }
     : props.isSideLeftMenu
       ? {
           is: "p",
           class:
-            "select-none whitespace-nowrap hover:menu-selection dark:hover:menu-selection",
+            "select-none whitespace-nowrap hover:menu-selection dark:group-hover:text-cta-orange",
         }
       : props.iconName
         ? {
             is: "p",
-            class: "pl-2 pr-2",
+            class: "pl-2 pr-2 dark:group-hover:text-cta-orange",
           }
         : {
             is: "span",

--- a/frontend/components/sidebar/left/SidebarLeftSelector.vue
+++ b/frontend/components/sidebar/left/SidebarLeftSelector.vue
@@ -2,15 +2,27 @@
 <template>
   <MenuLinkWrapper :id="id" :to="routeUrl" :selected="selected">
     <div
-      class="relative z-0 flex w-full items-center space-x-2 text-left text-sm font-medium"
+      class="group relative z-0 flex w-full items-center space-x-2 text-left text-sm font-medium"
     >
       <span class="pl-1">
-        <Icon v-if="iconUrl" class="h-5 w-5 flex-shrink-0" :name="iconUrl" />
+        <Icon
+          v-if="iconUrl"
+          class="h-5 w-5 flex-shrink-0"
+          :class="{
+            'dark:group-hover:fill-cta-orange': !selected, 
+            'fill-layer-1': selected,
+          }"
+          :name="iconUrl"
+        />
       </span>
       <Transition>
         <p
           v-if="sidebar.collapsed == false || sidebar.collapsedSwitch == false"
           class="select-none whitespace-nowrap"
+          :class="{
+            'dark:group-hover:text-cta-orange': !selected,
+            'text-layer-1': selected,
+          }"
         >
           <span class="sr-only">{{ $t("i18n._global.navigate_to") }}</span>
           {{ $t(label) }}


### PR DESCRIPTION


### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch  
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This pull request addresses a visual inconsistency where the sidebar menu item **text color** was not syncing with the **icon color** on hover, especially in dark mode.

The changes ensure that:
- Both the text and the icon now change to the correct `cta-orange` color when hovered.
- The active item styling remains unaffected and does not revert to orange on hover.

Tested locally on Docker in dark mode and verified that both the icon and the text respond to hover as expected.

### Related issue

- #1374

