### PR TITLE
1389 calendar events view

### DIFF
--- a/FRONTEND_TESTING.md
+++ b/FRONTEND_TESTING.md
@@ -108,5 +108,5 @@ We recommend using mocking for dependencies that are unreliable and/or slow, lik
 
 **Mocks we do recommend:**
 
-* We provide a global mock for `useColorMode`. This is necessary because `useColorMode` currently does not work in Vitest. See example use in [useColorModeImages.spec.ts](frontend/test/composables/useColorModeImages.spec.ts).
+* We provide a global mock for `useColorMode`. This is necessary because `useColorMode` currently does not work in Vitest. See example use in [useColor.spec.ts](frontend/test/composables/useColor.spec.ts).
 * Nuxt provides a `registerEndpoint` function to mock network requests. See example use in [sign-in.spec.ts](frontend/test/pages/auth/sign-in.spec.ts).

--- a/backend/core/management/commands/populate_db.py
+++ b/backend/core/management/commands/populate_db.py
@@ -137,7 +137,7 @@ class Command(BaseCommand):
                         )
 
                         user_org_event = EventFactory(
-                            name=f"{user_topic.name} Event [o{o}:e{e}]",
+                            name=f"{user_topic.name} Event [u{u}:o{o}:e{e}]",
                             tagline=f"{event_type_verb} {user_topic.name}",
                             type=event_type,
                             created_by=user,

--- a/frontend/components/dropdown/DropdownTheme.vue
+++ b/frontend/components/dropdown/DropdownTheme.vue
@@ -43,9 +43,9 @@ defineProps<{
 const colorMode = useColorMode();
 
 const menuButtonIcon = computed(() => {
-  if (colorMode.preference == "system") {
+  if (colorMode.preference === "system") {
     return `${IconMap.COLOR_MODE_SYSTEM}`;
-  } else if (colorMode.preference == "light") {
+  } else if (colorMode.preference === "light") {
     return `${IconMap.COLOR_MODE_LIGHT}`;
   } else return `${IconMap.COLOR_MODE_DARK}`;
 });

--- a/frontend/components/events/EventsCalendar.vue
+++ b/frontend/components/events/EventsCalendar.vue
@@ -1,89 +1,85 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
   <div class="space-y-6 pb-6 pt-3 md:pt-4">
-    <MediaCalendar
-      class="h-[calc(50vh-1rem)] w-full"
-      :calendar-args="calendar"
-    />
+    <MediaCalendar class="h-[calc(50vh-1rem)] w-full" :calendar-args="calendar">
+      <template #default="{ customData }">
+        <div class="bg-[#1e293b] hover:bg-[#334155]">
+          <NuxtLink
+            :to="localePath(`/events/${customData.id}`)"
+            class="flex items-center space-x-1 px-2 py-1"
+          >
+            <span
+              class="text-sm leading-none"
+              :style="{
+                color:
+                  customData.type === 'learn'
+                    ? colorByType.learn
+                    : colorByType.action,
+              }"
+            >
+              ●
+            </span>
+            <span>{{ customData.name }}</span>
+          </NuxtLink>
+        </div>
+      </template>
+    </MediaCalendar>
   </div>
 </template>
 
 <script setup lang="ts">
+import type { PopoverVisibility } from "v-calendar/dist/types/src/utils/popovers.js";
+
 import type { Event } from "~/types/events/event";
 
 import { colorByType, getAllDaysInRange } from "~/utils/utils";
+
 const props = defineProps<{
   events: Event[];
 }>();
+const localePath = useLocalePath();
 const actionEvents = props.events.filter((event) => {
   return event.type === "action";
 });
 const learnEvents = props.events.filter((event) => {
   return event.type === "learn";
 });
-const learnEventsDates = learnEvents.flatMap((event) => {
-  return getAllDaysInRange({
-    start: new Date(event.startTime),
-    end: new Date(event.endTime),
-  });
-});
-const actionEventsDates = actionEvents.flatMap((event) => {
-  return getAllDaysInRange({
-    start: new Date(event.startTime),
-    end: new Date(event.endTime),
-  });
-});
-const learnEventsRange = learnEvents.map((event) => {
-  return {
-    start: new Date(event.startTime),
-    end: new Date(event.endTime),
-  };
-});
-const actionEventsRange = actionEvents.map((event) => {
-  return {
-    start: new Date(event.startTime),
-    end: new Date(event.endTime),
-  };
-});
-const calendar = [
-  {
-    dot: {
-      color: colorByType["action"],
-      dates: actionEventsDates,
+const learnEventsDates = learnEvents.map((event) => ({
+  key: `${event.id}-learn`,
+  customData: event,
+  dot: {
+    style: {
+      backgroundColor: colorByType["learn"],
     },
   },
-  {
-    dot: {
-      color: colorByType["learn"],
-      dates: learnEventsDates,
+  dates: getAllDaysInRange({
+    start: new Date(event.startTime),
+    end: event.endTime ? new Date(event.endTime) : new Date(event.startTime),
+  }),
+  popover: {
+    visibility: "hover-focus" as PopoverVisibility,
+    hideIndicator: true,
+    isInteractive: true,
+  },
+}));
+
+const actionEventsDates = actionEvents.map((event) => ({
+  key: `${event.id}-action`,
+  customData: event,
+  dot: {
+    style: {
+      backgroundColor: colorByType["action"],
     },
   },
-  {
-    highlight: {
-      start: { fillMode: "solid", color: colorByType["action"] },
-      end: { fillMode: "solid", color: colorByType["action"] },
-      base: { fillMode: "solid", color: colorByType["action"] },
-      dates: actionEventsRange,
-    },
+  dates: getAllDaysInRange({
+    start: new Date(event.startTime),
+    end: event.endTime ? new Date(event.endTime) : new Date(event.startTime),
+  }),
+  popover: {
+    visibility: "hover-focus" as PopoverVisibility,
+    hideIndicator: true,
+    isInteractive: true,
   },
-  {
-    highlight: {
-      start: { fillMode: "solid", color: colorByType["learn"] },
-      end: { fillMode: "solid", color: colorByType["learn"] },
-      base: { fillMode: "solid", color: colorByType["learn"] },
-      dates: learnEventsRange,
-    },
-  },
-];
-console.log(calendar);
-// const eventDates = props.events.map((event) => {
-//   return {
-//     start: event.startTime,
-//     end: event.endTime,
-//     title: event.name,
-//     description: event.texts.description,
-//     location: event.offlineLocation?.displayName,
-//     id: event.id,
-//   };
-// });
+}));
+const calendar = [...actionEventsDates, ...learnEventsDates];
 </script>

--- a/frontend/components/events/EventsCalendar.vue
+++ b/frontend/components/events/EventsCalendar.vue
@@ -1,0 +1,89 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<template>
+  <div class="space-y-6 pb-6 pt-3 md:pt-4">
+    <MediaCalendar
+      class="h-[calc(50vh-1rem)] w-full"
+      :calendar-args="calendar"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Event } from "~/types/events/event";
+
+import { colorByType, getAllDaysInRange } from "~/utils/utils";
+const props = defineProps<{
+  events: Event[];
+}>();
+const actionEvents = props.events.filter((event) => {
+  return event.type === "action";
+});
+const learnEvents = props.events.filter((event) => {
+  return event.type === "learn";
+});
+const learnEventsDates = learnEvents.flatMap((event) => {
+  return getAllDaysInRange({
+    start: new Date(event.startTime),
+    end: new Date(event.endTime),
+  });
+});
+const actionEventsDates = actionEvents.flatMap((event) => {
+  return getAllDaysInRange({
+    start: new Date(event.startTime),
+    end: new Date(event.endTime),
+  });
+});
+const learnEventsRange = learnEvents.map((event) => {
+  return {
+    start: new Date(event.startTime),
+    end: new Date(event.endTime),
+  };
+});
+const actionEventsRange = actionEvents.map((event) => {
+  return {
+    start: new Date(event.startTime),
+    end: new Date(event.endTime),
+  };
+});
+const calendar = [
+  {
+    dot: {
+      color: colorByType["action"],
+      dates: actionEventsDates,
+    },
+  },
+  {
+    dot: {
+      color: colorByType["learn"],
+      dates: learnEventsDates,
+    },
+  },
+  {
+    highlight: {
+      start: { fillMode: "solid", color: colorByType["action"] },
+      end: { fillMode: "solid", color: colorByType["action"] },
+      base: { fillMode: "solid", color: colorByType["action"] },
+      dates: actionEventsRange,
+    },
+  },
+  {
+    highlight: {
+      start: { fillMode: "solid", color: colorByType["learn"] },
+      end: { fillMode: "solid", color: colorByType["learn"] },
+      base: { fillMode: "solid", color: colorByType["learn"] },
+      dates: learnEventsRange,
+    },
+  },
+];
+console.log(calendar);
+// const eventDates = props.events.map((event) => {
+//   return {
+//     start: event.startTime,
+//     end: event.endTime,
+//     title: event.name,
+//     description: event.texts.description,
+//     location: event.offlineLocation?.displayName,
+//     id: event.id,
+//   };
+// });
+</script>

--- a/frontend/components/events/EventsCalendar.vue
+++ b/frontend/components/events/EventsCalendar.vue
@@ -3,7 +3,9 @@
   <div class="space-y-6 pb-6 pt-3 md:pt-4">
     <MediaCalendar class="h-[calc(50vh-1rem)] w-full" :calendar-args="calendar">
       <template #default="{ customData }">
-        <div class="bg-[#1e293b] hover:bg-[#334155]">
+        <div
+          class="rounded-sm bg-[#F8FAFC] hover:bg-layer-2 dark:bg-[#1e293b] dark:hover:bg-layer-2"
+        >
           <NuxtLink
             :to="localePath(`/events/${customData.id}`)"
             class="flex items-center space-x-1 px-2 py-1"
@@ -13,8 +15,8 @@
               :style="{
                 color:
                   customData.type === 'learn'
-                    ? colorByType.learn
-                    : colorByType.action,
+                    ? getEventColorByType('learn')
+                    : getEventColorByType('action'),
               }"
             >
               ●
@@ -32,11 +34,12 @@ import type { PopoverVisibility } from "v-calendar/dist/types/src/utils/popovers
 
 import type { Event } from "~/types/events/event";
 
-import { colorByType, getAllDaysInRange } from "~/utils/utils";
+import { getAllDaysInRange } from "~/utils/utils";
 
 const props = defineProps<{
   events: Event[];
 }>();
+const { getEventColorByType } = useColor();
 const localePath = useLocalePath();
 const actionEvents = props.events.filter((event) => {
   return event.type === "action";
@@ -49,7 +52,7 @@ const learnEventsDates = learnEvents.map((event) => ({
   customData: event,
   dot: {
     style: {
-      backgroundColor: colorByType["learn"],
+      backgroundColor: getEventColorByType("learn"),
     },
   },
   dates: getAllDaysInRange({
@@ -68,7 +71,7 @@ const actionEventsDates = actionEvents.map((event) => ({
   customData: event,
   dot: {
     style: {
-      backgroundColor: colorByType["action"],
+      backgroundColor: getEventColorByType("action"),
     },
   },
   dates: getAllDaysInRange({

--- a/frontend/components/media/MediaCalendar.vue
+++ b/frontend/components/media/MediaCalendar.vue
@@ -10,11 +10,7 @@
     >
       <template #day-popover="{ dayTitle, attributes }">
         <ul class="flex flex-col space-y-1">
-          <li
-            v-for="{ key, customData } in attributes"
-            :key="key"
-            class="block bg-red-100 text-xs text-gray-700 dark:text-gray-300"
-          >
+          <li v-for="{ key, customData } in attributes" :key="key">
             <slot v-bind="{ dayTitle, customData }" />
           </li>
         </ul>

--- a/frontend/components/media/MediaCalendar.vue
+++ b/frontend/components/media/MediaCalendar.vue
@@ -1,4 +1,3 @@
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
   <form class="elem-shadow-sm h-full w-full rounded-[0.45em]">
     <Calendar
@@ -6,39 +5,54 @@
       :color="colorModePreference"
       trim-weeks
       expanded
-      :attributes="attributes"
-    ></Calendar>
+      :attributes="calendarArgs"
+    >
+      <template #day-popover="{ day, customData }">
+        <slot v-bind="{ day, customData }" />
+      </template>
+    </Calendar>
   </form>
 </template>
 
 <script setup lang="ts">
 import { Calendar } from "v-calendar";
 import "v-calendar/style.css";
+type CalendarAttribute<T = unknown> = {
+  key?: string | number;
+  dates: Date[] | { start: Date; end?: Date }[] | undefined;
+  customData?: T;
+  popover?: {
+    label?: string;
+    visibility?: "click" | "hover" | "hover-focus" | "focus";
+  };
+  dot?: {
+    color?: string;
+    class?: string;
+    dates: Date[] | { start: Date; end?: Date }[] | undefined;
+  };
+  highlight?: {
+    start?: { fillMode?: string; color?: string };
+    end?: { fillMode?: string; color?: string };
+    base?: { fillMode?: string; color?: string };
+    class?: string;
+    dates: Date[] | { start: Date; end?: Date }[] | undefined;
+  };
+  bar?: {
+    color?: string;
+    class?: string;
+    dates: Date[] | { start: Date; end?: Date }[] | undefined;
+  };
+  order?: number;
+  pinPage?: boolean;
+};
 
-const date = new Date();
-const year = date.getFullYear();
-const month = date.getMonth();
+interface Props {
+  calendarArgs: CalendarAttribute[];
+}
+defineProps<Props>();
 
 const colorMode = useColorMode();
 const colorModePreference = colorMode.preference == "light" ? "light" : "dark";
-
-const attributes = ref([
-  {
-    key: "today",
-    dot: "orange",
-    dates: [new Date()],
-  },
-  {
-    highlight: {
-      color: "orange",
-    },
-    dates: [
-      //Put the dates that should be highlighted here.
-      new Date(year, month, 13),
-      new Date(year, month, 14),
-    ],
-  },
-]);
 </script>
 
 <style>

--- a/frontend/components/media/MediaCalendar.vue
+++ b/frontend/components/media/MediaCalendar.vue
@@ -5,10 +5,18 @@
       :color="colorModePreference"
       trim-weeks
       expanded
-      :attributes="calendarArgs"
+      :attributes="calendar"
     >
-      <template #day-popover="{ day, customData }">
-        <slot v-bind="{ day, customData }" />
+      <template #day-popover="{ dayTitle, attributes }">
+        <ul class="flex flex-col space-y-1">
+          <li
+            v-for="{ key, customData } in attributes"
+            :key="key"
+            class="block bg-red-100 text-xs text-gray-700 dark:text-gray-300"
+          >
+            <slot v-bind="{ dayTitle, customData }" />
+          </li>
+        </ul>
       </template>
     </Calendar>
   </form>
@@ -17,40 +25,25 @@
 <script setup lang="ts">
 import { Calendar } from "v-calendar";
 import "v-calendar/style.css";
-type CalendarAttribute<T = unknown> = {
-  key?: string | number;
-  dates: Date[] | { start: Date; end?: Date }[] | undefined;
-  customData?: T;
-  popover?: {
-    label?: string;
-    visibility?: "click" | "hover" | "hover-focus" | "focus";
-  };
-  dot?: {
-    color?: string;
-    class?: string;
-    dates: Date[] | { start: Date; end?: Date }[] | undefined;
-  };
-  highlight?: {
-    start?: { fillMode?: string; color?: string };
-    end?: { fillMode?: string; color?: string };
-    base?: { fillMode?: string; color?: string };
-    class?: string;
-    dates: Date[] | { start: Date; end?: Date }[] | undefined;
-  };
-  bar?: {
-    color?: string;
-    class?: string;
-    dates: Date[] | { start: Date; end?: Date }[] | undefined;
-  };
-  order?: number;
-  pinPage?: boolean;
-};
+type CalendarProps = InstanceType<typeof Calendar>["$props"];
+type InferredAttributes = CalendarProps extends { attributes?: infer A }
+  ? A
+  : never;
+type CalendarAttribute = InferredAttributes extends Array<infer U> ? U : never;
 
 interface Props {
   calendarArgs: CalendarAttribute[];
 }
-defineProps<Props>();
+const props = defineProps<Props>();
 
+const calendar = ref<CalendarAttribute[]>(props.calendarArgs || []);
+watch(
+  () => props.calendarArgs,
+  (newArgs) => {
+    calendar.value = newArgs;
+  },
+  { immediate: true }
+);
 const colorMode = useColorMode();
 const colorModePreference = colorMode.preference == "light" ? "light" : "dark";
 </script>

--- a/frontend/components/media/MediaCalendar.vue
+++ b/frontend/components/media/MediaCalendar.vue
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
   <form class="elem-shadow-sm h-full w-full rounded-[0.45em]">
     <Calendar

--- a/frontend/components/media/map/MediaMapEvent.vue
+++ b/frontend/components/media/map/MediaMapEvent.vue
@@ -11,7 +11,7 @@
 import type { Event, EventType } from "~/types/events/event";
 
 import { MapType, type Pointer } from "~/types/map";
-import { colorByType } from "~/utils/mapUtils";
+import { colorByType } from "~/utils/utils";
 const organizationIcon = `/icons/map/tooltip_organization.png`;
 const calendarIcon = `/icons/map/tooltip_datetime.png`;
 const locationIcon = `/icons/map/tooltip_location.png`;

--- a/frontend/components/media/map/MediaMapEvent.vue
+++ b/frontend/components/media/map/MediaMapEvent.vue
@@ -11,10 +11,12 @@
 import type { Event, EventType } from "~/types/events/event";
 
 import { MapType, type Pointer } from "~/types/map";
-import { colorByType } from "~/utils/utils";
+
 const organizationIcon = `/icons/map/tooltip_organization.png`;
 const calendarIcon = `/icons/map/tooltip_datetime.png`;
 const locationIcon = `/icons/map/tooltip_location.png`;
+const { getEventColorByType } = useColor();
+
 const props = defineProps<{
   event: Event;
 }>();
@@ -64,7 +66,7 @@ const buildExpandedTooltip = () => {
 };
 const pointer: Pointer = {
   id: event.id,
-  color: colorByType[event.type as EventType],
+  color: getEventColorByType(event.type as EventType),
   location: event.offlineLocation || {
     displayName: event.name,
     lat: "0",

--- a/frontend/components/media/map/MediaMapEvents.vue
+++ b/frontend/components/media/map/MediaMapEvents.vue
@@ -21,7 +21,6 @@ import {
   type PointerCluster,
   type PopupContent,
 } from "~/types/map";
-import { colorByType } from "~/utils/utils";
 
 const props = defineProps<{
   events: Event[];
@@ -33,6 +32,7 @@ const locationIcon = `/icons/map/tooltip_location.png`;
 
 const { events } = props;
 const i18n = useI18n();
+const { getEventColorByType } = useColor();
 
 const buildExpandedTooltipPointer = (pointer: unknown) => {
   const root = document.createElement("div");
@@ -134,7 +134,7 @@ const buildExpandedTooltipCluster = (pointer: unknown) => {
 const pointers: PointerCluster[] = events.map((event) => {
   return {
     id: event.id,
-    color: colorByType[event.type as EventType],
+    color: getEventColorByType(event.type as EventType),
     location: event.offlineLocation || {
       displayName: event.name,
       lat: "0",
@@ -154,11 +154,11 @@ const pointers: PointerCluster[] = events.map((event) => {
 const clusterProperties: ClusterProperties = {
   cluster: {
     learn: {
+      color: getEventColorByType("learn"),
       logic: ["+", ["case", ["==", ["get", "type"], "learn"], 1, 0]],
-      color: colorByType.learn,
     },
     action: {
-      color: colorByType.action,
+      color: getEventColorByType("action"),
       logic: ["+", ["case", ["==", ["get", "type"], "action"], 1, 0]],
     },
   },
@@ -167,7 +167,7 @@ const clusterProperties: ClusterProperties = {
       return "";
     }
     // This function is used to get the pointer color when there is only one in the cluster.
-    return colorByType[props.type as EventType];
+    return getEventColorByType(props.type as EventType);
   },
   getIndividualDonutProps: (props: GeoJsonProperties) => {
     if (!props) {
@@ -175,10 +175,13 @@ const clusterProperties: ClusterProperties = {
     }
     // This function is used to get the individual donut props when there is only one in the cluster.
     return [
-      { value: +(props.type === "learn"), color: colorByType.learn as string },
+      {
+        value: +(props.type === "learn"),
+        color: getEventColorByType("learn") as string,
+      },
       {
         value: +(props.type === "action"),
-        color: colorByType.action as string,
+        color: getEventColorByType("action") as string,
       },
     ];
   },
@@ -187,8 +190,8 @@ const clusterProperties: ClusterProperties = {
       return [];
     }
     return [
-      { value: props.learn, color: colorByType.learn as string },
-      { value: props.action, color: colorByType.action as string },
+      { value: props.learn, color: getEventColorByType("learn") as string },
+      { value: props.action, color: getEventColorByType("action") as string },
     ];
   },
 };

--- a/frontend/components/media/map/MediaMapEvents.vue
+++ b/frontend/components/media/map/MediaMapEvents.vue
@@ -21,7 +21,7 @@ import {
   type PointerCluster,
   type PopupContent,
 } from "~/types/map";
-import { colorByType } from "~/utils/mapUtils";
+import { colorByType } from "~/utils/utils";
 
 const props = defineProps<{
   events: Event[];

--- a/frontend/composables/useColor.ts
+++ b/frontend/composables/useColor.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { EventType } from "~/types/events/event";
+
+import { ColorByEventType } from "~/types/color";
+
+type ColorKey = `${EventType}_${"light" | "dark"}`;
+
+const colorByType: Record<ColorKey, ColorByEventType> = {
+  learn_light: ColorByEventType.LEARN_LIGHT,
+  action_light: ColorByEventType.ACTION_LIGHT,
+  learn_dark: ColorByEventType.LEARN_DARK,
+  action_dark: ColorByEventType.ACTION_DARK,
+};
+
+export const useColor = () => {
+  const getColorModeImages = (path: string, ext: string = ".png") => {
+    return `${path}_${useColorMode().value}${ext}`;
+  };
+
+  const getEventColorByType = (eventType: EventType) => {
+    const colorMode = useColorMode();
+    const suffix = colorMode.preference === "light" ? "light" : "dark";
+    const key = `${eventType}_${suffix}` as ColorKey;
+    return colorByType[key];
+  };
+
+  return { getColorModeImages, getEventColorByType };
+};

--- a/frontend/composables/useColorModeImages.ts
+++ b/frontend/composables/useColorModeImages.ts
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-or-later
-export default function useColorModeImages(): (
-  path: string,
-  ext?: string
-) => string {
-  return (path, ext = ".png") => `${path}_${useColorMode().value}${ext}`;
-}

--- a/frontend/composables/useMap.ts
+++ b/frontend/composables/useMap.ts
@@ -4,6 +4,7 @@ import maplibregl, { type LayerSpecification } from "maplibre-gl";
 
 import { useClusterMap } from "./useClusterMap";
 import { usePointerMap } from "./usePointerMap";
+
 export const useMap = () => {
   const { createMapForPointerTypeMap } = usePointerMap();
   const { createMapForClusterTypeMap } = useClusterMap();

--- a/frontend/pages/events/index.vue
+++ b/frontend/pages/events/index.vue
@@ -15,9 +15,12 @@
     <div v-if="events.length > 0">
       <EventsList v-if="viewType === ViewType.LIST" :events="events" />
       <EventsMap v-else-if="viewType === ViewType.MAP" :events="events" />
-      <EmptyState v-else pageType="events" :permission="false" />
+      <EventsCalendar
+        v-else-if="viewType === ViewType.CALENDAR"
+        :events="events"
+      />
     </div>
-    <EmptyState v-else pageType="events" :permission="false" />
+    <EmptyState v-else pageType="events" :permission="false" /> -->
   </div>
 </template>
 

--- a/frontend/pages/events/index.vue
+++ b/frontend/pages/events/index.vue
@@ -20,7 +20,7 @@
         :events="events"
       />
     </div>
-    <EmptyState v-else pageType="events" :permission="false" /> -->
+    <EmptyState v-else pageType="events" :permission="false" />
   </div>
 </template>
 

--- a/frontend/test/composables/useColor.spec.ts
+++ b/frontend/test/composables/useColor.spec.ts
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import useColorModeImages from "@/composables/useColorModeImages";
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
 
 mockNuxtImport("useColorMode", () => useColorModeMock);
@@ -11,8 +10,8 @@ describe("useColorModeImage", () => {
       value: "light",
     }));
 
-    const getImage = useColorModeImages();
-    expect(getImage("/path/to/image", ".png")).toEqual(
+    const { getColorModeImages } = useColor();
+    expect(getColorModeImages("/path/to/image", ".png")).toEqual(
       "/path/to/image_light.png"
     );
   });
@@ -20,8 +19,8 @@ describe("useColorModeImage", () => {
   it("adds _dark to image path", () => {
     // window.useColorModeMock.mockImplementation(() => ({ value: 'dark' }));
 
-    const getImage = useColorModeImages();
-    expect(getImage("/path/to/image", ".png")).toEqual(
+    const { getColorModeImages } = useColor();
+    expect(getColorModeImages("/path/to/image", ".png")).toEqual(
       "/path/to/image_dark.png"
     );
   });
@@ -32,7 +31,9 @@ describe("useColorModeImage", () => {
       value: "light",
     }));
 
-    const getImage = useColorModeImages();
-    expect(getImage("/path/to/image")).toEqual("/path/to/image_light.png");
+    const { getColorModeImages } = useColor();
+    expect(getColorModeImages("/path/to/image")).toEqual(
+      "/path/to/image_light.png"
+    );
   });
 });

--- a/frontend/types/color.ts
+++ b/frontend/types/color.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 export enum ColorByEventType {
-  ACTION = "#BA3D3B",
-  LEARN = "#2176AE",
+  ACTION_LIGHT = "#BA3D3B",
+  LEARN_LIGHT = "#2176AE",
+  ACTION_DARK = "#EE5A58",
+  LEARN_DARK = "#3E92CC",
 }

--- a/frontend/types/color.ts
+++ b/frontend/types/color.ts
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+export enum ColorByEventType {
+  ACTION = "#BA3D3B",
+  LEARN = "#2176AE",
+}

--- a/frontend/utils/utils.ts
+++ b/frontend/utils/utils.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { ColorByEventType } from "~/types/color";
+export const colorByType = {
+  learn: ColorByEventType.LEARN,
+  action: ColorByEventType.ACTION,
+};
+export const getAllDaysInRange = (range: {
+  start: Date;
+  end: Date;
+}): Date[] => {
+  const dates: Date[] = [];
+  const currentDate = new Date(range.start);
+  while (currentDate <= range.end) {
+    dates.push(new Date(currentDate));
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+  return dates;
+};

--- a/frontend/utils/utils.ts
+++ b/frontend/utils/utils.ts
@@ -1,9 +1,4 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { ColorByEventType } from "~/types/color";
-export const colorByType = {
-  learn: ColorByEventType.LEARN,
-  action: ColorByEventType.ACTION,
-};
 export const getAllDaysInRange = (range: {
   start: Date;
   end: Date;


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

Adding a popover slot for each day so consumers can inject custom content when a day is clicked or hovered.

Introducing new props for passing event data into the calendar, enabling more flexible and contextual rendering.

Creating a dedicated calendar view for events, allowing users to visualize and interact with event data directly in the calendar UI.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- Closes #1389 
