### PR TITLE
Fix sidebar icon hover issue 1401

### DIFF
--- a/frontend/components/form/text/FormTextInputPassword.vue
+++ b/frontend/components/form/text/FormTextInputPassword.vue
@@ -9,8 +9,8 @@
     <template #icons>
       <slot name="icons"></slot>
       <button
-        type="button"
         :id="`${id}-show-password`"
+        type="button"
         @click="changeInputType"
       >
         <Icon

--- a/frontend/components/form/text/FormTextInputPassword.vue
+++ b/frontend/components/form/text/FormTextInputPassword.vue
@@ -8,7 +8,7 @@
   >
     <template #icons>
       <slot name="icons"></slot>
-      <button @click="changeInputType" :id="`${id}-show-password`">
+      <button type="button" @click="changeInputType" :id="`${id}-show-password`">
         <Icon
           :name="isPassword ? IconMap.VISIBLE : IconMap.HIDDEN"
           size="1.4em"

--- a/frontend/components/form/text/FormTextInputPassword.vue
+++ b/frontend/components/form/text/FormTextInputPassword.vue
@@ -9,8 +9,8 @@
     <template #icons>
       <slot name="icons"></slot>
       <button
-        :id="`${id}-show-password`"
         @click="changeInputType"
+        :id="`${id}-show-password`"
         type="button"
       >
         <Icon

--- a/frontend/components/form/text/FormTextInputPassword.vue
+++ b/frontend/components/form/text/FormTextInputPassword.vue
@@ -10,8 +10,8 @@
       <slot name="icons"></slot>
       <button
         :id="`${id}-show-password`"
-        type="button"
         @click="changeInputType"
+        type="button"
       >
         <Icon
           :name="isPassword ? IconMap.VISIBLE : IconMap.HIDDEN"

--- a/frontend/components/form/text/FormTextInputPassword.vue
+++ b/frontend/components/form/text/FormTextInputPassword.vue
@@ -8,7 +8,11 @@
   >
     <template #icons>
       <slot name="icons"></slot>
-      <button type="button" @click="changeInputType" :id="`${id}-show-password`">
+      <button
+        type="button"
+        :id="`${id}-show-password`"
+        @click="changeInputType"
+      >
         <Icon
           :name="isPassword ? IconMap.VISIBLE : IconMap.HIDDEN"
           size="1.4em"

--- a/frontend/components/menu/MenuItemLabel.vue
+++ b/frontend/components/menu/MenuItemLabel.vue
@@ -17,7 +17,10 @@
       v-if="iconName"
       :name="iconName"
       size="1em"
-      :class="{ 'h-5 w-5 flex-shrink-0': isSideLeftMenu }"
+      :class="{
+        'h-5 w-5 flex-shrink-0': isSideLeftMenu,
+        'dark:group-hover:fill-cta-orange': !active,
+      }"
     />
     <Transition>
       <component


### PR DESCRIPTION
## Description
  Fixes #1401

This PR fixes the issue where sidebar menu option icons were not changing color on initial hover. The icons now respond immediately to the group hover state, matching the text behavior.

  ## Changes
  - Added `dark:group-hover:fill-cta-orange` class to the Icon component in MenuItemLabel.vue
  - Icons now change color simultaneously with text on hover in dark mode

  ## Testing
  - [x] Tested in dark mode - icons and text change color together on hover
  - [x] Tested in light mode - no regressions
  - [x] Verified hover state returns to default when mouse moves away
  - [x] Tested in user dropdown menu
  
  
<img width="217" height="66" alt="image" src="https://github.com/user-attachments/assets/db939332-4211-41cb-a183-6d44a680e820" />

<img width="221" height="64" alt="image" src="https://github.com/user-attachments/assets/8f029e11-70f6-4b23-9539-1eae71527ddf" />
