### PR TITLE
fix: sidebar menu option icons not receiving CSS group hover actions

### DIFF
--- a/frontend/components/card/CardMetricsOverview.vue
+++ b/frontend/components/card/CardMetricsOverview.vue
@@ -20,14 +20,14 @@
         :number="metrics['action events']"
         textColor="text-primary-text dark:text-action-red"
         borderColor="border-primary-text dark:border-action-red"
-        backgroundColor="bg-action-red/60 dark:bg-action-red/20 hover:bg-action-red/50 hover:dark:bg-action-red/30 active:bg-action-red/60 active:dark:bg-action-red/20"
+        backgroundColor="bg-action-red/60 dark:bg-action-red/20 hover:bg-action-red/50 dark:hover:bg-action-red/30 active:bg-action-red/60 active:dark:bg-action-red/20"
       />
       <CardMetric
         :text="$t('i18n.components._global.learn')"
         :number="metrics['learn events']"
         textColor="text-primary-text dark:text-learn-blue"
         borderColor="border-primary-text dark:border-learn-blue"
-        backgroundColor="bg-learn-blue/60 dark:bg-learn-blue/20 hover:bg-learn-blue/50 hover:dark:bg-learn-blue/30 active:bg-learn-blue/60 active:dark:bg-learn-blue/20"
+        backgroundColor="bg-learn-blue/60 dark:bg-learn-blue/20 hover:bg-learn-blue/50 dark:hover:bg-learn-blue/30 active:bg-learn-blue/60 active:dark:bg-learn-blue/20"
       />
       <CardMetric
         :text="$t('i18n.components.card_metrics_overview.new_organizations')"

--- a/frontend/components/menu/MenuItemLabel.vue
+++ b/frontend/components/menu/MenuItemLabel.vue
@@ -17,7 +17,10 @@
       v-if="iconName"
       :name="iconName"
       size="1em"
-      :class="{ 'h-5 w-5 flex-shrink-0': isSideLeftMenu }"
+      :class="{
+        'h-5 w-5 flex-shrink-0': isSideLeftMenu,
+        'dark:group-hover:fill-cta-orange': !active,
+      }"
     />
     <Transition>
       <component

--- a/frontend/components/menu/MenuItemLabel.vue
+++ b/frontend/components/menu/MenuItemLabel.vue
@@ -9,7 +9,8 @@
     :class="{
       'group py-2 pl-4 pr-3': !isSideLeftMenu,
       'bg-cta-orange/80 dark:bg-cta-orange/25 dark:text-cta-orange': active,
-      'text-primary-text': !active,
+      'text-primary-text hover:bg-cta-orange/80 dark:hover:bg-cta-orange/25 dark:hover:fill-cta-orange dark:hover:text-cta-orange':
+        !active,
       'relative z-0 space-x-2 p-2 text-left font-medium': isSideLeftMenu,
     }"
   >
@@ -19,7 +20,6 @@
       size="1em"
       :class="{
         'h-5 w-5 flex-shrink-0': isSideLeftMenu,
-        'dark:group-hover:fill-cta-orange': !active,
       }"
     />
     <Transition>


### PR DESCRIPTION
- Added 'dark:group-hover:fill-cta-orange' class to Icon component in MenuItemLabel.vue
- Icons now change color simultaneously with text on hover in dark mode
- Fixes issue where icons required mouse movement to trigger color change

Fixes #1401
<img width="217" height="66" alt="Screenshot 2025-08-03 154003" src="https://github.com/user-attachments/assets/a7db9054-f024-4491-a729-ff4bd8cbdc12" />
<img width="221" height="64" alt="Screenshot 2025-08-03 154032" src="https://github.com/user-attachments/assets/b14cd0a0-c57c-4185-a40d-d182ce6a9e28" />
