### PR TITLE
#682 Update user model in backend to not recreate default field

### DIFF
--- a/backend/authentication/models.py
+++ b/backend/authentication/models.py
@@ -73,6 +73,7 @@ class CustomAccountManager(BaseUserManager["UserModel"]):
                 f"Superuser creation failed for {username}: is_staff must be True"
             )
             raise ValueError("Superuser must be assigned to is_staff=True.")
+
         if other_fields.get("is_superuser") is not True:
             logger.error(
                 f"Superuser creation failed for {username}: is_superuser must be True"
@@ -85,6 +86,7 @@ class CustomAccountManager(BaseUserManager["UserModel"]):
             )
             logger.info(f"Superuser created successfully: {username}")
             return superuser
+
         except Exception as e:
             logger.exception(f"Failed to create superuser {username}: {str(e)}")
             raise
@@ -217,7 +219,7 @@ class UserModel(AbstractUser, PermissionsMixin):
 
     Notes
     -----
-    Extends Django's `AbstractUser` and adds platform-specific fields (default username and password used).
+    Extends Django's `AbstractUser` and adds platform-specific fields (default username, password and email used).
     """
 
     id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
@@ -233,13 +235,12 @@ class UserModel(AbstractUser, PermissionsMixin):
     icon_url = models.ForeignKey(
         "content.Image", on_delete=models.SET_NULL, blank=True, null=True
     )
-    email = models.EmailField(blank=True)
     is_confirmed = models.BooleanField(default=False)
     is_private = models.BooleanField(default=False)
     is_high_risk = models.BooleanField(default=False)
     creation_date = models.DateTimeField(auto_now_add=True)
 
-    # Django specific fields
+    # Django specific fields.
     is_active = models.BooleanField(default=True)
     is_admin = models.BooleanField(default=False)
 

--- a/backend/authentication/models.py
+++ b/backend/authentication/models.py
@@ -217,13 +217,11 @@ class UserModel(AbstractUser, PermissionsMixin):
 
     Notes
     -----
-    Extends Django's `AbstractUser` and adds platform-specific fields.
+    Extends Django's `AbstractUser` and adds platform-specific fields (default username and password used).
     """
 
     id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
-    username = models.CharField(max_length=255, unique=True)
     name = models.CharField(max_length=255, blank=True)
-    password = models.CharField(max_length=255)
     location = models.CharField(max_length=100, blank=True)
     description = models.TextField(max_length=500, blank=True)
     verified = models.BooleanField(default=False)

--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -8,7 +8,6 @@ import re
 from typing import Any, Dict, Union
 
 from django.contrib.auth import authenticate, get_user_model
-from django.utils.translation import gettext as _
 from rest_framework import serializers
 from rest_framework.authtoken.models import Token
 
@@ -63,7 +62,7 @@ class SignUpSerializer(serializers.ModelSerializer[UserModel]):
                 data.get("username", "unknown"),
             )
             raise serializers.ValidationError(
-                _(
+                (
                     "The field password must be at least 12 characters long and contain at least one special character."
                 ),
                 code="invalid_password",
@@ -75,7 +74,7 @@ class SignUpSerializer(serializers.ModelSerializer[UserModel]):
                 data.get("username", "unknown"),
             )
             raise serializers.ValidationError(
-                _("The passwords did not match. Please try again."),
+                ("The passwords did not match. Please try again."),
                 code="invalid_password_confirmation",
             )
 
@@ -254,7 +253,7 @@ class PasswordResetSerializer(serializers.Serializer[UserModel]):
                 "Password reset attempt failed - user not found: %s", identifier
             )
             raise serializers.ValidationError(
-                _("Invalid email address. Please try again."),
+                ("Invalid email address. Please try again."),
                 code="invalid_email",
             )
 

--- a/backend/authentication/tests/test_auth.py
+++ b/backend/authentication/tests/test_auth.py
@@ -61,8 +61,8 @@ def test_sign_up(client: APIClient) -> None:
     """
     logger.info("Starting sign-up test with various scenarios")
     fake = Faker()
-    username = fake.name()
-    second_username = fake.name()
+    username = fake.user_name()
+    second_username = fake.user_name()
     email = fake.email()
     strong_password = fake.password(
         length=12, special_chars=True, digits=True, upper_case=True

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -85,9 +85,10 @@ class SignUpView(APIView):
                     fail_silently=False,
                 )
                 logger.info(f"Verification email sent to {user.email}")
+
             except Exception as e:
                 logger.error(f"Failed to send verification email to {user.email}: {e}")
-                # Continue with user creation even if email fails
+                # Continue with user creation even if email fails.
 
             user.save()
 

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, Union
 
 from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile, UploadedFile
-from django.utils.translation import gettext as _
 from PIL import Image as PILImage
 from rest_framework import serializers
 
@@ -352,13 +351,13 @@ class TopicSerializer(serializers.ModelSerializer[Topic]):
         """
         if data["active"] is True and data.get("deprecation_date") is not None:
             raise serializers.ValidationError(
-                _("Active topics cannot have a deprecation date."),
+                ("Active topics cannot have a deprecation date."),
                 code="active_topic_with_deprecation_error",
             )
 
         if data["active"] is False and data.get("deprecation_date") is None:
             raise serializers.ValidationError(
-                _("Deprecated topics must have a deprecation date."),
+                ("Deprecated topics must have a deprecation date."),
                 code="inactive_topic_no_deprecation_error",
             )
 

--- a/backend/utils/utils.py
+++ b/backend/utils/utils.py
@@ -6,7 +6,6 @@ Utility functions for date formatting and logic validation as well as other comm
 import logging
 from typing import Any
 
-from django.utils.translation import gettext as _
 from rest_framework import serializers
 
 logger = logging.getLogger(__name__)
@@ -37,7 +36,7 @@ def validate_creation_and_deletion_dates(data: Any) -> None:
             data["creation_date"],
         )
         raise serializers.ValidationError(
-            _("The field deletion_date cannot be before creation_date."),
+            ("The field deletion_date cannot be before creation_date."),
             code="invalid_date_order",
         )
 
@@ -69,6 +68,6 @@ def validate_creation_and_deprecation_dates(data: Any) -> None:
             data["creation_date"],
         )
         raise serializers.ValidationError(
-            _("The field deprecation_date cannot be before creation_date."),
+            ("The field deprecation_date cannot be before creation_date."),
             code="invalid_date_order",
         )

--- a/frontend/utils/sidebarUtils.ts
+++ b/frontend/utils/sidebarUtils.ts
@@ -20,7 +20,7 @@ export function getSidebarContentDynamicClass(
 
 export function getSidebarFooterDynamicClass(sidebarHover: Ref<boolean>) {
   return computed(() => ({
-    "md:pl-24 xl:pl-64": sidebar.collapsed || sidebar.collapsedSwitch,
+    "md:pl-24 xl:pl-64": !sidebar.collapsed || !sidebar.collapsedSwitch,
     "md:pl-24 xl:pl-24": sidebar.collapsed && sidebar.collapsedSwitch,
     "blur-sm xl:blur-none":
       sidebar.collapsedSwitch && !sidebar.collapsed && sidebarHover.value,


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Removes three fields from the user model in the backend as they're in the default `AbstractUser` class that we use from Django. Fixed the test for sign up as that was passing a name rather than a username, which was accepted by our original custom field, but not by the default (we were accepting spaces for a full name as a username). Also includes a minor frontend fix from a refactor I did.

Will merge when tests pass :)

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #682
