### PR TITLE
feat: make FAQ entries draggable across orgs, groups, and events

### DIFF
--- a/frontend/components/card/CardFAQEntry.vue
+++ b/frontend/components/card/CardFAQEntry.vue
@@ -1,65 +1,72 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
-  <Disclosure v-slot="{ open }" as="div" class="card-style">
-    <DisclosureButton class="focus-brand w-full rounded-md px-4 py-2">
-      <div
-        class="flex gap-3"
-        :class="{ 'items-center': !open, 'items-start': open }"
-      >
-        <div class="text-primary-text">
-          <Icon v-if="open" :name="IconMap.CHEVRON_UP" />
-          <Icon v-else :name="IconMap.CHEVRON_DOWN" />
-        </div>
-        <div class="flex-col">
-          <div
-            class="flex select-text items-center gap-3 text-left text-primary-text"
-          >
-            <p>{{ faqEntry.question }}</p>
-            <IconEdit
-              @click.stop="
-                useModalHandlers(
-                  `ModalEditFaqEntry${props.pageType.charAt(0).toUpperCase() + props.pageType.slice(1)}` +
-                    props.faqEntry.id
-                ).openModal()
-              "
-              @keydown.enter="
-                useModalHandlers(
-                  `ModalEditFaqEntry${props.pageType.charAt(0).toUpperCase() + props.pageType.slice(1)}` +
-                    props.faqEntry.id
-                ).openModal()
-              "
-            />
-            <ModalEditFaqEntryOrganization
-              v-if="pageType === 'organization'"
-              :faqEntry="faqEntry"
-            />
-            <ModalEditFaqEntryGroup
-              v-else-if="pageType === 'group'"
-              :faqEntry="faqEntry"
-            />
-            <ModalEditFaqEntryEvent
-              v-else-if="pageType === 'event'"
-              :faqEntry="faqEntry"
-            />
+  <Disclosure v-slot="{ open }" as="div" class="card-style flex items-start">
+    <div
+      class="cursor-grab p-2 text-gray-400 hover:text-gray-600"
+      title="Drag to reorder"
+      @mousedown.stop
+    >
+    </div>
+
+    <div class="flex-1">
+      <DisclosureButton class="focus-brand w-full rounded-md px-4 py-2">
+        <div
+          class="flex gap-3"
+          :class="{ 'items-center': !open, 'items-start': open }"
+        >
+          <div class="text-primary-text">
+            <Icon v-if="open" :name="IconMap.CHEVRON_UP" />
+            <Icon v-else :name="IconMap.CHEVRON_DOWN" />
           </div>
-          <DisclosurePanel
-            class="mt-2 border-t border-section-div py-2 focus-within:border-0"
-          >
-            <p class="select-text text-left">
-              {{ faqEntry.answer }}
-            </p>
-          </DisclosurePanel>
+          <div class="flex-col">
+            <div
+              class="flex select-text items-center gap-3 text-left text-primary-text"
+            >
+              <p>{{ faqEntry.question }}</p>
+              <IconEdit
+                @click.stop="
+                  useModalHandlers(
+                    `ModalEditFaqEntry${props.pageType.charAt(0).toUpperCase() + props.pageType.slice(1)}` +
+                      props.faqEntry.id
+                  ).openModal()
+                "
+                @keydown.enter="
+                  useModalHandlers(
+                    `ModalEditFaqEntry${props.pageType.charAt(0).toUpperCase() + props.pageType.slice(1)}` +
+                      props.faqEntry.id
+                  ).openModal()
+                "
+              />
+              <ModalEditFaqEntryOrganization
+                v-if="pageType === 'organization'"
+                :faqEntry="faqEntry"
+              />
+              <ModalEditFaqEntryGroup
+                v-else-if="pageType === 'group'"
+                :faqEntry="faqEntry"
+              />
+              <ModalEditFaqEntryEvent
+                v-else-if="pageType === 'event'"
+                :faqEntry="faqEntry"
+              />
+            </div>
+            <DisclosurePanel
+              class="mt-2 border-t border-section-div py-2 focus-within:border-0"
+            >
+              <p class="select-text text-left">
+                {{ faqEntry.answer }}
+              </p>
+            </DisclosurePanel>
+          </div>
         </div>
-      </div>
-    </DisclosureButton>
+      </DisclosureButton>
+    </div>
   </Disclosure>
 </template>
 
 <script setup lang="ts">
 import { Disclosure, DisclosureButton, DisclosurePanel } from "@headlessui/vue";
-
 import type { FaqEntry } from "~/types/content/faq-entry";
-
 import { IconMap } from "~/types/icon-map";
 
 const props = defineProps<{

--- a/frontend/pages/organizations/[orgId]/faq.vue
+++ b/frontend/pages/organizations/[orgId]/faq.vue
@@ -1,48 +1,82 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
-  <div class="flex flex-col bg-layer-0 px-4 xl:px-8">
-    <Head>
-      <Title>{{ organization.name }}&nbsp;{{ $t("i18n._global.faq") }}</Title>
-    </Head>
-    <HeaderAppPageOrganization
-      :header="organization.name + ' ' + $t('i18n._global.faq')"
-      :tagline="$t('i18n.pages._global.faq_tagline')"
-      :underDevelopment="false"
-    >
-      <div class="flex space-x-2 lg:space-x-3">
-        <BtnAction
-          @click.stop="
-            useModalHandlers('ModalAddFaqEntryOrganization').openModal()
-          "
-          @keydown.enter="
-            useModalHandlers('ModalAddFaqEntryOrganization').openModal()
-          "
-          class="w-max"
-          :cta="true"
-          label="i18n.pages._global.new_faq"
-          fontSize="sm"
-          :leftIcon="IconMap.PLUS"
-          iconSize="1.35em"
-          ariaLabel="i18n.pages._global.new_faq_aria_label"
-        />
-        <ModalAddFaqEntryOrganization />
+  <div v-if="props.organization">
+    <div class="flex flex-col bg-layer-0 px-4 xl:px-8">
+      <Head>
+        <Title>{{ props.organization.name }}&nbsp;{{ $t("i18n._global.faq") }}</Title>
+      </Head>
+
+      <HeaderAppPageOrganization
+        :header="props.organization.name + ' ' + $t('i18n._global.faq')"
+        :tagline="$t('i18n.pages._global.faq_tagline')"
+        :underDevelopment="false"
+      >
+        <div class="flex space-x-2 lg:space-x-3">
+          <BtnAction
+            @click.stop="useModalHandlers('ModalAddFaqEntryOrganization').openModal()"
+            @keydown.enter="useModalHandlers('ModalAddFaqEntryOrganization').openModal()"
+            class="w-max"
+            :cta="true"
+            label="i18n.pages._global.new_faq"
+            fontSize="sm"
+            :leftIcon="IconMap.PLUS"
+            iconSize="1.35em"
+            ariaLabel="i18n.pages._global.new_faq_aria_label"
+          />
+          <ModalAddFaqEntryOrganization />
+        </div>
+      </HeaderAppPageOrganization>
+
+      <div v-if="props.organization.faqEntries?.length" class="py-4">
+        <draggable
+          v-model="faqList"
+          item-key="id"
+          @end="onDragEnd"
+          class="space-y-4"
+        >
+          <template #item="{ element }">
+            <CardFAQEntry pageType="organization" :faqEntry="element" />
+          </template>
+        </draggable>
       </div>
-    </HeaderAppPageOrganization>
-    <div v-if="organization.faqEntries!.length > 0" class="py-4">
-      <div v-for="f in organization.faqEntries" class="mb-4">
-        <CardFAQEntry :pageType="'organization'" :faqEntry="f" />
-      </div>
+
+      <EmptyState
+        v-else
+        pageType="faq"
+        :permission="false"
+        class="py-4"
+      />
     </div>
-    <EmptyState v-else pageType="faq" :permission="false" class="py-4" />
   </div>
 </template>
 
 <script setup lang="ts">
 import type { Organization } from "~/types/communities/organization";
-
+import type { FaqEntry } from "~/types/content/faq-entry";
 import { IconMap } from "~/types/icon-map";
+import draggable from "vuedraggable";
+import { ref, watch } from "vue";
+import { useOrganizationStore } from "~/stores/organization";
 
-defineProps<{
-  organization: Organization;
-}>();
+const props = defineProps<{ organization: Organization }>();
+
+const orgStore = useOrganizationStore();
+
+const faqList = ref<FaqEntry[]>([...(props.organization.faqEntries || [])]);
+
+watch(
+  () => props.organization.faqEntries,
+  (newVal) => {
+    faqList.value = newVal?.slice() ?? [];
+  },
+  { immediate: true }
+);
+
+const onDragEnd = async () => {
+  faqList.value.forEach((faq, index) => {
+    faq.order = index; 
+  })
+
+  await orgStore.reorderFaqEntries(props.organization, faqList.value)
+}
 </script>

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/faq.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/faq.vue
@@ -5,12 +5,14 @@
     :selectors="groupSubPages"
     :selectedRoute="3"
   />
+
   <div class="flex flex-col bg-layer-0 px-4 xl:px-8">
     <Head>
-      <Title>{{ group.name }}&nbsp;{{ $t("i18n._global.faq") }}</Title>
+      <Title>{{ props.group.name }}&nbsp;{{ $t("i18n._global.faq") }}</Title>
     </Head>
+
     <HeaderAppPageGroup
-      :header="group.name + ' ' + $t('i18n._global.faq')"
+      :header="props.group.name + ' ' + $t('i18n._global.faq')"
       :tagline="$t('i18n.pages._global.faq_tagline')"
       :underDevelopment="false"
     >
@@ -29,23 +31,48 @@
         <ModalAddFaqEntryGroup />
       </div>
     </HeaderAppPageGroup>
-    <div v-if="group.faqEntries!.length > 0" class="py-4">
-      <div v-for="f in group.faqEntries" class="mb-4">
-        <CardFAQEntry :pageType="'group'" :faqEntry="f" />
-      </div>
+
+    <div v-if="props.group.faqEntries?.length" class="py-4">
+      <draggable
+        v-model="faqList"
+        item-key="id"
+        @end="onDragEnd"
+        class="space-y-4"
+      >
+        <template #item="{ element }">
+          <CardFAQEntry pageType="group" :faqEntry="element" />
+        </template>
+      </draggable>
     </div>
+
     <EmptyState v-else pageType="faq" :permission="false" />
   </div>
 </template>
 
 <script setup lang="ts">
 import type { Group } from "~/types/communities/group";
-
+import type { FaqEntry } from "~/types/content/faq-entry";
 import { IconMap } from "~/types/icon-map";
+import draggable from "vuedraggable";
+import { ref, watch } from "vue";
+import { useGroupStore } from "~/stores/group"; // ✅ assumes you have this
 
-defineProps<{
-  group: Group;
-}>();
+const props = defineProps<{ group: Group }>();
 
 const groupSubPages = getGroupSubPages();
+const groupStore = useGroupStore();
+
+const faqList = ref<FaqEntry[]>([...(props.group.faqEntries || [])]);
+
+watch(
+  () => props.group.faqEntries,
+  (newVal) => {
+    faqList.value = newVal?.slice() ?? [];
+  },
+  { immediate: true }
+);
+
+const onDragEnd = async () => {
+  await groupStore.reorderFaqEntries(props.group, faqList.value);
+};
 </script>

--- a/frontend/stores/event.ts
+++ b/frontend/stores/event.ts
@@ -185,7 +185,7 @@ export const useEventStore = defineStore("event", {
     async updateTexts(event: Event, formData: EventUpdateTextFormData) {
       this.loading = true;
 
-      const responseEventTexts = await $fetch(
+      const responseEventTexts = await useFetch(
         BASE_BACKEND_URL + `/events/event_texts/${event.texts.id}`,
         {
           method: "PUT",
@@ -436,5 +436,50 @@ export const useEventStore = defineStore("event", {
 
       this.loading = false;
     },
+
+    // MARK: Reorder FAQ entries
+    async reorderFaqEntries(event: Event, faqEntries: FaqEntry[]) {
+      this.loading = true;
+      try {
+        const responses: boolean[] = [];
+
+        for (let i = 0; i < faqEntries.length; i++) {
+          const faq = faqEntries[i];
+          const response = await useFetch(
+            `${BASE_BACKEND_URL}/events/event_faqs/${faq.id}`,
+            {
+              method: "PUT",
+              body: JSON.stringify({
+                id: faq.id,
+                order: i + 1,
+              }),
+              headers: {
+                Authorization: `${token.value}`,
+              },
+            }
+          );
+
+          if (response.data.value) {
+            responses.push(true);
+          } else {
+            responses.push(false);
+          }
+        }
+
+        if (responses.every(Boolean)) {
+          await this.fetchById(event.id);
+          this.loading = false;
+          return true;
+        } else {
+          this.loading = false;
+          return false;
+        }
+      } catch (error) {
+        console.error("Error reordering event FAQs:", error);
+        this.loading = false;
+        return false;
+      }
+    }
+
   },
 });

--- a/frontend/stores/group.ts
+++ b/frontend/stores/group.ts
@@ -182,7 +182,7 @@ export const useGroupStore = defineStore("group", {
     async updateTexts(group: Group, formData: GroupUpdateTextFormData) {
       this.loading = true;
 
-      const responseOrgTexts = await $fetch(
+      const responseOrgTexts = await useFetch(
         BASE_BACKEND_URL + `/communities/group_texts/${group.texts.id}`,
         {
           method: "PUT",
@@ -433,5 +433,51 @@ export const useGroupStore = defineStore("group", {
 
       this.loading = false;
     },
+
+    // MARK: Reorder FAQ entries
+    async reorderFaqEntries(group: Group, faqEntries: FaqEntry[]) {
+      this.loading = true;
+      try {
+        const responses: boolean[] = [];
+
+        for (let i = 0; i < faqEntries.length; i++) {
+          const faq = faqEntries[i];
+
+          const response = await useFetch(
+            `${BASE_BACKEND_URL}/communities/group_faqs/${faq.id}`,
+            {
+              method: "PUT",
+              body: JSON.stringify({
+                id: faq.id,
+                order: i + 1, 
+              }),
+              headers: {
+                Authorization: `${token.value}`,
+              },
+            }
+          );
+
+          if (response.data.value) {
+            responses.push(true);
+          } else {
+            responses.push(false);
+          }
+        }
+
+        if (responses.every((r) => r)) {
+          await this.fetchById(group.id);
+          this.loading = false;
+          return true;
+        } else {
+          this.loading = false;
+          return false;
+        }
+      } catch (error) {
+        console.error("Error reordering group FAQs:", error);
+        this.loading = false;
+        return false;
+      }
+    }
+
   },
 });

--- a/frontend/stores/organization.ts
+++ b/frontend/stores/organization.ts
@@ -190,7 +190,7 @@ export const useOrganizationStore = defineStore("organization", {
     ) {
       this.loading = true;
 
-      const responseOrgTexts = await $fetch(
+      const responseOrgTexts = await useFetch(
         BASE_BACKEND_URL + `/communities/organization_texts/${org.texts.id}`,
         {
           method: "PUT",
@@ -444,5 +444,46 @@ export const useOrganizationStore = defineStore("organization", {
 
       this.loading = false;
     },
+
+    // MARK: Reorder FAQ entries
+    async reorderFaqEntries(org: Organization, reorderedFaqs: FaqEntry[]) {
+      this.loading = true;
+
+      const responses: boolean[] = [];
+
+      for (const faq of reorderedFaqs) {
+        const response = await useFetch(
+          `${BASE_BACKEND_URL}/communities/organization_faqs/${faq.id}`,
+          {
+            method: "PUT",
+            body: JSON.stringify({
+              id: faq.id,
+              order: faq.order, 
+            }),
+            headers: {
+              Authorization: `${token.value}`,
+            },
+          }
+        );
+
+        const responseData = response.data.value as unknown as Organization;
+        if (responseData) {
+          responses.push(true);
+        } else {
+          responses.push(false);
+        }
+      }
+
+      if (responses.every((r) => r === true)) {
+        await this.fetchById(org.id);
+        this.loading = false;
+        return true;
+      } else {
+        this.loading = false;
+        return false;
+      }
+    }
+
+    
   },
 });


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch  
---

### Description

This PR implements draggable functionality for FAQ entries, improving the user experience when reordering FAQs.

Currently, users can only edit FAQ text and must manually copy-paste content to change the order. With this change, FAQs can now be **dragged and reordered directly**, similar to how images are managed in `ModalUploadImages.vue`.

**Changes made:**
- Added draggable support to FAQ pages in:  
  - `frontend/pages/organizations/[orgId]/faq`  
  - `frontend/pages/organizations/[orgId]/groups/[groupId]/faq`  
  - `frontend/pages/events/[eventId]/faq`  
- Ensured updated FAQ order is reflected in both the frontend and backend.  

---

### Related issue

Closes #1424
