### PR TITLE
feat: make FAQ entries draggable across orgs, groups, and events

### DIFF
--- a/frontend/components/Tabs.vue
+++ b/frontend/components/Tabs.vue
@@ -3,26 +3,22 @@
   <div class="h-fit w-full">
     <TabGroup @change="changeTab" manual :default-index="defaultIndex">
       <TabList class="flex flex-row">
-        <Tab v-for="selector in selectors" :key="selector.id" class="w-full">
+        <Tab v-for="tab in tabs" :key="tab.id" class="w-full">
           <NuxtLink
             class="focus-brand flex w-full items-center justify-center rounded-none border-[1px] border-primary-text px-3 py-1"
             :class="{
               'bg-menu-selection text-layer-1 hover:bg-menu-selection/90':
-                selector.id == props.selectedRoute,
+                tab.id == props.selectedTab,
               'bg-layer-2 text-primary-text hover:bg-highlight':
-                selector.id != props.selectedRoute,
+                tab.id != props.selectedTab,
             }"
-            :to="localePath(selector.routeUrl)"
+            :to="localePath(tab.routeUrl)"
           >
             <div v-if="!aboveMediumBP">
-              <Icon
-                v-if="selector.iconName"
-                :name="selector.iconName"
-                size="1em"
-              />
+              <Icon v-if="tab.iconName" :name="tab.iconName" size="1em" />
             </div>
-            <p v-if="!selector.iconName || aboveMediumBP">
-              {{ selector.label }}
+            <p v-if="!tab.iconName || aboveMediumBP">
+              {{ tab.label }}
             </p>
           </NuxtLink>
         </Tab>
@@ -37,8 +33,8 @@ import { Tab, TabGroup, TabList } from "@headlessui/vue";
 import type { TabPage } from "~/types/tab";
 
 const props = defineProps<{
-  selectors: TabPage[];
-  selectedRoute: number;
+  tabs: TabPage[];
+  selectedTab: number;
 }>();
 
 const aboveMediumBP = useBreakpoint("md");
@@ -48,13 +44,13 @@ const nuxtApp = useNuxtApp();
 const router = useRouter();
 
 const defaultIndex = computed(() => {
-  return props.selectors.findIndex((selector) => selector.selected) || 0;
+  return props.tabs.findIndex((tab) => tab.selected) || 0;
 });
 
 function changeTab(index: number) {
-  const selectedRoute = props.selectors[index]?.routeUrl;
-  if (selectedRoute) {
-    router.push(nuxtApp.$localePath(selectedRoute));
+  const selectedTab = props.tabs[index]?.routeUrl;
+  if (selectedTab) {
+    router.push(nuxtApp.$localePath(selectedTab));
   }
 }
 </script>

--- a/frontend/components/card/CardFAQEntry.vue
+++ b/frontend/components/card/CardFAQEntry.vue
@@ -6,6 +6,12 @@
         class="flex gap-3"
         :class="{ 'items-center': !open, 'items-start': open }"
       >
+        <Icon
+          class="drag-handle -mr-2 cursor-grab select-none"
+          :name="IconMap.GRIP"
+          size="1em"
+          :aria-label="$t('i18n.components._global.draggable_element')"
+        />
         <div class="text-primary-text">
           <Icon v-if="open" :name="IconMap.CHEVRON_UP" />
           <Icon v-else :name="IconMap.CHEVRON_DOWN" />

--- a/frontend/components/form/FormSocialLink.vue
+++ b/frontend/components/form/FormSocialLink.vue
@@ -26,12 +26,12 @@
         >
           <template #item="{ index }">
             <div class="flex items-center space-x-5">
-              <span
+              <Icon
                 class="drag-handle -mr-2 cursor-grab select-none"
-                title="Drag to reorder"
-              >
-                <Icon :name="IconMap.GRIP" size="1em" />
-              </span>
+                :name="IconMap.GRIP"
+                size="1em"
+                :aria-label="$t('i18n.components._global.draggable_element')"
+              />
               <IconClose @click="handleRemoveByIndex(index)" />
               <FormItem
                 v-slot="{ id, handleChange, handleBlur, errorMessage, value }"

--- a/frontend/components/modal/faq-entry/ModalFaqEntryEvent.vue
+++ b/frontend/components/modal/faq-entry/ModalFaqEntryEvent.vue
@@ -18,9 +18,7 @@ const props = defineProps<{
 }>();
 
 const isAddMode = !props.faqEntry;
-const modalName = isAddMode
-  ? "ModalAddFaqEntryEvent"
-  : "ModalFaqEntryEvent" + props.faqEntry!.id;
+const modalName = "ModalFaqEntryEvent" + props.faqEntry?.id;
 const { handleCloseModal } = useModalHandlers(modalName);
 
 const paramsEventId = useRoute().params.eventId;

--- a/frontend/components/modal/faq-entry/ModalFaqEntryGroup.vue
+++ b/frontend/components/modal/faq-entry/ModalFaqEntryGroup.vue
@@ -18,9 +18,7 @@ const props = defineProps<{
 }>();
 
 const isAddMode = !props.faqEntry;
-const modalName = isAddMode
-  ? "ModalAddFaqEntryGroup"
-  : "ModalFaqEntryGroup" + props.faqEntry!.id;
+const modalName = "ModalFaqEntryGroup" + props.faqEntry?.id;
 const { handleCloseModal } = useModalHandlers(modalName);
 
 const paramsGroupId = useRoute().params.groupId;

--- a/frontend/components/modal/faq-entry/ModalFaqEntryOrganization.vue
+++ b/frontend/components/modal/faq-entry/ModalFaqEntryOrganization.vue
@@ -18,9 +18,7 @@ const props = defineProps<{
 }>();
 
 const isAddMode = !props.faqEntry;
-const modalName = isAddMode
-  ? "ModalAddFaqEntryOrganization"
-  : "ModalFaqEntryOrganization" + props.faqEntry!.id;
+const modalName = "ModalFaqEntryOrganization" + props.faqEntry?.id;
 const { handleCloseModal } = useModalHandlers(modalName);
 
 const paramsOrgId = useRoute().params.orgId;

--- a/frontend/i18n/en-US.json
+++ b/frontend/i18n/en-US.json
@@ -59,6 +59,7 @@
   "i18n.components._global.connect": "Connect",
   "i18n.components._global.control_tooltip_label": "Press \"^ + k\" to jump to a page",
   "i18n.components._global.documentation": "Documentation",
+  "i18n.components._global.draggable_element": "Draggable page element",
   "i18n.components._global.get_involved": "Get involved",
   "i18n.components._global.github": "GitHub",
   "i18n.components._global.github_aria_label": "Visit the activist GitHub repository",

--- a/frontend/pages/events/[eventId]/faq.vue
+++ b/frontend/pages/events/[eventId]/faq.vue
@@ -12,8 +12,8 @@
     >
       <div class="flex space-x-2 lg:space-x-3">
         <BtnAction
-          @click.stop="useModalHandlers('ModalAddFaqEntryEvent').openModal()"
-          @keydown.enter="useModalHandlers('ModalAddFaqEntryEvent').openModal()"
+          @click.stop="useModalHandlers('ModalFaqEntryEvent').openModal()"
+          @keydown.enter="useModalHandlers('ModalFaqEntryEvent').openModal()"
           class="w-max"
           :cta="true"
           label="i18n.pages._global.new_faq"
@@ -22,7 +22,7 @@
           iconSize="1.35em"
           ariaLabel="i18n.pages._global.new_faq_aria_label"
         />
-        <ModalAddFaqEntryEvent />
+        <ModalFaqEntryEvent />
       </div>
     </HeaderAppPageOrganization>
 
@@ -55,6 +55,7 @@ import { useEventStore } from "~/stores/event";
 import { IconMap } from "~/types/icon-map";
 
 const props = defineProps<{ event: Event }>();
+
 const eventStore = useEventStore();
 
 const faqList = ref<FaqEntry[]>([]);

--- a/frontend/pages/organizations/[orgId]/faq.vue
+++ b/frontend/pages/organizations/[orgId]/faq.vue
@@ -12,10 +12,10 @@
       <div class="flex space-x-2 lg:space-x-3">
         <BtnAction
           @click.stop="
-            useModalHandlers('ModalAddFaqEntryOrganization').openModal()
+            useModalHandlers('ModalFaqEntryOrganization').openModal()
           "
           @keydown.enter="
-            useModalHandlers('ModalAddFaqEntryOrganization').openModal()
+            useModalHandlers('ModalFaqEntryOrganization').openModal()
           "
           class="w-max"
           :cta="true"

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/about.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/about.vue
@@ -2,7 +2,7 @@
 <template>
   <ModalSocialLinksGroup />
   <ModalTextGroup />
-  <Tabs class="pt-2 md:pt-0" :selectors="groupSubPages" :selectedRoute="0" />
+  <Tabs class="pt-2 md:pt-0" :tabs="groupTabs" :selectedTab="0" />
   <div class="flex flex-col bg-layer-0 px-4 xl:px-8">
     <Head>
       <Title>{{ group.name }}</Title>
@@ -88,7 +88,6 @@ import type { EntityType } from "~/types/entity";
 
 import { BreakpointMap } from "~/types/breakpoint-map";
 import { IconMap } from "~/types/icon-map";
-import { getGroupTabs } from "~/utils/groupSubPages";
 
 defineProps<{
   group: Group;
@@ -96,7 +95,7 @@ defineProps<{
 
 const aboveLargeBP = useBreakpoint("lg");
 
-const groupSubPages = getGroupTabs();
+const groupTabs = getGroupTabs();
 
 const textExpanded = ref(false);
 const expandReduceText = () => {

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/events.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/events.vue
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
-  <Tabs class="pt-2 md:pt-0" :selectors="groupSubPages" :selectedRoute="1" />
+  <Tabs class="pt-2 md:pt-0" :tabs="groupTabs" :selectedTab="1" />
   <div class="flex flex-col bg-layer-0 px-4 xl:px-8">
     <Head>
       <Title>
@@ -62,7 +62,7 @@ defineProps<{
   group: Group;
 }>();
 
-const groupSubPages = getGroupTabs();
+const groupTabs = getGroupTabs();
 
 const downloadCalendarEntries = () => {};
 </script>

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/faq.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/faq.vue
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
-  <Tabs class="pt-2 md:pt-0" :selectors="groupSubPages" :selectedRoute="3" />
+  <Tabs class="pt-2 md:pt-0" :tabs="groupTabs" :selectedTab="3" />
   <div class="flex flex-col bg-layer-0 px-4 xl:px-8">
     <Head>
       <Title>{{ props.group.name }}&nbsp;{{ $t("i18n._global.faq") }}</Title>
@@ -13,8 +13,8 @@
     >
       <div class="flex space-x-2 pb-3 lg:space-x-3 lg:pb-4">
         <BtnAction
-          @click.stop="useModalHandlers('ModalAddFaqEntryGroup').openModal()"
-          @keydown.enter="useModalHandlers('ModalAddFaqEntryGroup').openModal()"
+          @click.stop="useModalHandlers('ModalFaqEntryGroup').openModal()"
+          @keydown.enter="useModalHandlers('ModalFaqEntryGroup').openModal()"
           class="w-max"
           :cta="true"
           label="i18n.pages._global.new_faq"
@@ -23,7 +23,7 @@
           iconSize="1.35em"
           ariaLabel="i18n.pages._global.new_faq_aria_label"
         />
-        <ModalAddFaqEntryGroup />
+        <ModalFaqEntryGroup />
       </div>
     </HeaderAppPageGroup>
 
@@ -56,7 +56,7 @@ import { IconMap } from "~/types/icon-map";
 
 const props = defineProps<{ group: Group }>();
 
-const groupSubPages = getGroupTabs();
+const groupTabs = getGroupTabs();
 const groupStore = useGroupStore();
 
 const faqList = ref<FaqEntry[]>([...(props.group.faqEntries || [])]);

--- a/frontend/pages/organizations/[orgId]/groups/[groupId]/resources.vue
+++ b/frontend/pages/organizations/[orgId]/groups/[groupId]/resources.vue
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <template>
-  <Tabs class="pt-2 md:pt-0" :selectors="groupSubPages" :selectedRoute="2" />
+  <Tabs class="pt-2 md:pt-0" :tabs="groupTabs" :selectedTab="2" />
   <div class="flex flex-col bg-layer-0 px-4 xl:px-8">
     <Head>
       <Title>
@@ -44,5 +44,5 @@ defineProps<{
   group: Group;
 }>();
 
-const groupSubPages = getGroupTabs();
+const groupTabs = getGroupTabs();
 </script>

--- a/frontend/stores/group.ts
+++ b/frontend/stores/group.ts
@@ -539,47 +539,44 @@ export const useGroupStore = defineStore("group", {
       this.loading = false;
     },
 
-    // MARK: Reorder FAQ entries
+    // MARK: Reorder FAQs
+
     async reorderFaqEntries(group: Group, faqEntries: FaqEntry[]) {
       this.loading = true;
-      try {
-        const responses: boolean[] = [];
+      const responses: boolean[] = [];
 
-        for (let i = 0; i < faqEntries.length; i++) {
-          const faq = faqEntries[i];
+      const responseFAQs = await Promise.all(
+        faqEntries.map((faq) =>
+          useFetch(`${BASE_BACKEND_URL}/communities/group_faqs/${faq.id}`, {
+            method: "PUT",
+            body: JSON.stringify({
+              id: faq.id,
+              order: faq.order,
+            }),
+            headers: {
+              Authorization: `${token.value}`,
+            },
+          })
+        )
+      );
 
-          const response = await useFetch(
-            `${BASE_BACKEND_URL}/communities/group_faqs/${faq.id}`,
-            {
-              method: "PUT",
-              body: JSON.stringify({
-                id: faq.id,
-                order: i + 1,
-              }),
-              headers: {
-                Authorization: `${token.value}`,
-              },
-            }
-          );
+      const responseFAQsData = responseFAQs.map(
+        (item) => item.data.value as unknown as Group
+      );
+      if (responseFAQsData) {
+        responses.push(true);
+      } else {
+        responses.push(false);
+      }
 
-          if (response.data.value) {
-            responses.push(true);
-          } else {
-            responses.push(false);
-          }
-        }
-
-        if (responses.every((r) => r)) {
-          await this.fetchById(group.id);
-          this.loading = false;
-          return true;
-        } else {
-          this.loading = false;
-          return false;
-        }
-      } catch (error) {
+      if (responses.every((r) => r === true)) {
+        // Fetch updated group data after successful updates to update the frontend.
+        await this.fetchById(group.id);
         this.loading = false;
-        throw new Error(`Error reordering group FAQs: ${error}`);
+        return true;
+      } else {
+        this.loading = false;
+        return false;
       }
     },
   },

--- a/frontend/stores/organization.ts
+++ b/frontend/stores/organization.ts
@@ -580,36 +580,41 @@ export const useOrganizationStore = defineStore("organization", {
       this.loading = false;
     },
 
-    // MARK: Reorder FAQ entries
-    async reorderFaqEntries(org: Organization, reorderedFaqs: FaqEntry[]) {
-      this.loading = true;
+    // MARK: Reorder FAQ
 
+    async reorderFaqEntries(org: Organization, faqEntries: FaqEntry[]) {
+      this.loading = true;
       const responses: boolean[] = [];
 
-      for (const faq of reorderedFaqs) {
-        const response = await useFetch(
-          `${BASE_BACKEND_URL}/communities/organization_faqs/${faq.id}`,
-          {
-            method: "PUT",
-            body: JSON.stringify({
-              id: faq.id,
-              order: faq.order,
-            }),
-            headers: {
-              Authorization: `${token.value}`,
-            },
-          }
-        );
+      const responseFAQs = await Promise.all(
+        faqEntries.map((faq) =>
+          useFetch(
+            `${BASE_BACKEND_URL}/communities/organization_faqs/${faq.id}`,
+            {
+              method: "PUT",
+              body: JSON.stringify({
+                id: faq.id,
+                order: faq.order,
+              }),
+              headers: {
+                Authorization: `${token.value}`,
+              },
+            }
+          )
+        )
+      );
 
-        const responseData = response.data.value as unknown as Organization;
-        if (responseData) {
-          responses.push(true);
-        } else {
-          responses.push(false);
-        }
+      const responseFAQsData = responseFAQs.map(
+        (item) => item.data.value as unknown as Organization
+      );
+      if (responseFAQsData) {
+        responses.push(true);
+      } else {
+        responses.push(false);
       }
 
       if (responses.every((r) => r === true)) {
+        // Fetch updated group data after successful updates to update the frontend.
         await this.fetchById(org.id);
         this.loading = false;
         return true;


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch  
---

### Description

This PR implements draggable functionality for FAQ entries, improving the user experience when reordering FAQs.

Currently, users can only edit FAQ text and must manually copy-paste content to change the order. With this change, FAQs can now be **dragged and reordered directly**, similar to how images are managed in `ModalUploadImages.vue`.

**Changes made:**
- Added draggable support to FAQ pages in:  
  - `frontend/pages/organizations/[orgId]/faq`  
  - `frontend/pages/organizations/[orgId]/groups/[groupId]/faq`  
  - `frontend/pages/events/[eventId]/faq`  
- Ensured updated FAQ order is reflected in both the frontend and backend.  

---

### Related issue

Closes #1424
