### PR TITLE
fix(frontend): resolve social links drag-and-drop data loss issue

### DIFF
--- a/frontend/components/form/FormSocialLink.vue
+++ b/frontend/components/form/FormSocialLink.vue
@@ -114,7 +114,10 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   addLink: [link: SocialLinkItem];
-  updateList: [list: SocialLinkItem[]];
+  updateList: [
+    list: SocialLinkItem[],
+    operationType: "drag" | "remove" | "add",
+  ];
 }>();
 
 const { t } = useI18n();
@@ -144,12 +147,12 @@ const { reindex, removeByIndex } = useSortableList(socialLinks);
 // Wrapper functions to emit changes back to parent.
 const handleReindex = () => {
   reindex();
-  emit("updateList", socialLinks.value);
+  emit("updateList", socialLinks.value, "drag");
 };
 
 const handleRemoveByIndex = (index: number) => {
   removeByIndex(index);
-  emit("updateList", socialLinks.value);
+  emit("updateList", socialLinks.value, "remove");
 };
 
 function addNewLink() {
@@ -158,11 +161,9 @@ function addNewLink() {
     label: "",
     order: socialLinks.value.length,
     id: "",
-    key: String(Date.now()) + "-" + socialLinks.value.length,
+    key: `new-${Date.now()}`,
   };
-
-  socialLinks.value?.push(newLink);
-  emit("addLink", newLink);
-  emit("updateList", socialLinks.value);
+  socialLinks.value.push(newLink);
+  emit("updateList", socialLinks.value, "add");
 }
 </script>

--- a/frontend/components/modal/social-links/ModalSocialLinksOrganization.vue
+++ b/frontend/components/modal/social-links/ModalSocialLinksOrganization.vue
@@ -55,29 +55,51 @@ interface SocialLinksValue {
 }
 
 // Handle updates from FormSocialLink (dragging, removing, adding).
-function updateSocialLinksRef(updatedList: SocialLinkItem[]) {
-  const oldLength = socialLinksRef.value?.length || 0;
-  const newLength = updatedList.length;
-  const isAddOperation = newLength > oldLength;
-
+function updateSocialLinksRef(
+  updatedList: SocialLinkItem[],
+  operationType: "drag" | "remove" | "add"
+) {
   socialLinksRef.value = updatedList as SocialLinkWithKey[];
 
-  // Only reset form for drag/remove operations, not for add operations.
-  if (!isAddOperation) {
-    formKey.value++;
+  // Only reset form for drag/remove operations involving saved links only
+  // This preserves user input for new links while allowing order changes to be saved
+  if (operationType === "drag" || operationType === "remove") {
+    const hasUnsavedLinks = updatedList.some((link) => !link.id);
+    if (!hasUnsavedLinks) {
+      formKey.value++;
+    }
   }
 }
 
 // Attn: Currently we're deleting the social links and rewriting all of them.
 async function handleSubmit(values: unknown) {
   const socialLinks = socialLinksRef.value?.map((socialLink, index) => {
-    const formLink = (values as SocialLinksValue).socialLinks[index];
+    let formLink;
+    const formValues = (values as SocialLinksValue).socialLinks;
+
+    if (!socialLink.id) {
+      // For new links (no id), find the form entry that doesn't match any existing socialLink
+      const existingSocialLinks =
+        socialLinksRef.value?.filter((sl) => sl.id) || [];
+      formLink = formValues.find((fv) => {
+        // Find form value that doesn't match any existing socialLink
+        return !existingSocialLinks.some(
+          (esl) => esl.label === fv.label && esl.link === fv.link
+        );
+      });
+    } else {
+      // For existing links, find the form entry that matches this socialLink's label and link
+      formLink = formValues.find(
+        (fv) => fv.label === socialLink.label && fv.link === socialLink.link
+      );
+    }
+
     return {
       id: socialLink.id,
-      // Use form values if they exist in the form, otherwise use socialLink values.
-      link: formLink ? formLink.link : socialLink.link,
-      label: formLink ? formLink.label : socialLink.label,
-      order: socialLink.order,
+      // Use form values if they exist, otherwise use socialLink values
+      link: formLink?.link || socialLink.link,
+      label: formLink?.label || socialLink.label,
+      order: index, // Use current array position as order
     };
   });
 


### PR DESCRIPTION


<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
- Fix data loss when dragging newly added social links before saving
- Implement operation-type aware form reset logic (drag/remove/add)
- Add content-based form data mapping instead of index-based approach
- Preserve user input for unsaved links while allowing order changes
- Apply smart form reset only when no unsaved links are present
- Use array index for final position assignment after dragging

Resolves issue where dragging unsaved social links would clear label and URL fields due to form reset misalignment. The solution uses content matching to map form values to correct socialLink items regardless of array positions, ensuring all scenarios work correctly: drag existing links, add new links, drag new links before saving, and mixed operations

Fixes #1446