### PR TITLE
fix(normalizePath): split regex to remove alternation and prevent ReDoS (S5850)

### DIFF
--- a/frontend/utils/routeUtils.ts
+++ b/frontend/utils/routeUtils.ts
@@ -7,7 +7,7 @@ const localCodes = locales.map((l) => l.code);
  * Normalize a given path by removing leading and trailing slashes.
  */
 function normalizePath(path: string): string {
-  return path.replace(/^\/|\/$/g, "");
+  return path.replace(/^\/+/g, "").replace(/\/+$/g, "");
 }
 
 /**


### PR DESCRIPTION
### Summary
This PR refactors the `normalizePath` function to replace the use of a single regex with alternation (`|`) by splitting it into two separate regex replacements.  

### Details
- Replaced `/^\/|\/$/g` with two explicit regexes:
  - `/^\/+/g` to remove leading slashes  
  - `/\/+$/g` to remove trailing slashes  
- This avoids the use of alternation (`|`), which was flagged by Sonar (typescript:S5850).  
- Prevents potential Regular Expression Denial of Service (ReDoS) issues.  

### Why
SonarQube/SonarCloud flagged the original regex (`typescript:S5850`) as vulnerable to ReDoS due to alternation. Splitting the regex ensures compliance with Sonar rules and improves regex safety.