### PR TITLE
feat: Moving from token authentication to JWT authentication. Added Session GET views

### DIFF
--- a/backend/authentication/admin.py
+++ b/backend/authentication/admin.py
@@ -29,7 +29,7 @@ admin.site.register(SupportEntityType)
 # MARK: User Creation
 
 
-class UserCreationForm(forms.ModelForm[UserModel]):
+class UserCreationForm(forms.ModelForm):
     """
     A form for creating new users.
 
@@ -92,7 +92,7 @@ class UserCreationForm(forms.ModelForm[UserModel]):
 # MARK: User Change
 
 
-class UserChangeForm(forms.ModelForm[UserModel]):
+class UserChangeForm(forms.ModelForm):
     """
     A form for updating users.
 
@@ -110,7 +110,7 @@ class UserChangeForm(forms.ModelForm[UserModel]):
 # MARK: User
 
 
-class UserAdmin(BaseUserAdmin[UserModel]):
+class UserAdmin(BaseUserAdmin):
     # The forms to add and change user instances.
     """
     Custom admin interface for the UserModel.
@@ -118,11 +118,15 @@ class UserAdmin(BaseUserAdmin[UserModel]):
     This class configures the fields, filters, and forms displayed in the Django admin panel.
     """
 
+    class Meta:
+        model = UserModel
+        fields = "__all__"
+
     form = UserChangeForm
     add_form = UserCreationForm
 
     def save_model(
-        self, request: HttpRequest, obj: UserModel, form: ModelForm[Any], change: bool
+        self, request: HttpRequest, obj: UserModel, form: ModelForm, change: bool
     ) -> None:
         """
         Override to add logging for user updates.
@@ -210,15 +214,19 @@ class UserAdmin(BaseUserAdmin[UserModel]):
 # MARK: Flag
 
 
-class UserFlagAdmin(admin.ModelAdmin[UserFlag]):
+class UserFlagAdmin(admin.ModelAdmin):
     """
     Admin table for displaying User flags.
     """
 
+    class Meta:
+        model = UserModel
+        fields = "__all__"
+
     list_display = ["user", "created_by", "creation_date"]
 
     def save_model(
-        self, request: HttpRequest, obj: UserFlag, form: ModelForm[Any], change: bool
+        self, request: HttpRequest, obj: UserFlag, form: ModelForm, change: bool
     ) -> None:
         """
         Override to add logging for user flag operations.

--- a/backend/authentication/factories.py
+++ b/backend/authentication/factories.py
@@ -9,7 +9,13 @@ from typing import Any
 
 import factory
 
-from authentication.models import Support, SupportEntityType, UserFlag, UserModel
+from authentication.models import (
+    SessionModel,
+    Support,
+    SupportEntityType,
+    UserFlag,
+    UserModel,
+)
 
 # MARK: Support
 
@@ -49,8 +55,9 @@ class SupportFactory(factory.django.DjangoModelFactory):
 
     # MARK: Session
 
-    # class SessionFactory(factory.django.DjangoModelFactory):
-    """"
+
+class SessionFactory(factory.django.DjangoModelFactory):
+    """
     Factory for creating Session model instances.
 
     Notes
@@ -59,13 +66,13 @@ class SupportFactory(factory.django.DjangoModelFactory):
     It requires a `UserModel` instance to be created or provided.
     """
 
-    # class Meta:
-    #     model = SessionModel
+    class Meta:
+        model = SessionModel
 
-    # user = factory.SubFactory("authentication.factories.UserFactory")
-    # last_activity = factory.LazyFunction(
-    #     lambda: datetime.datetime.now(tz=datetime.timezone.utc)
-    # )
+    user = factory.SubFactory("authentication.factories.UserFactory")
+    last_activity = factory.LazyFunction(
+        lambda: datetime.datetime.now(tz=datetime.timezone.utc)
+    )
 
 
 # MARK: User

--- a/backend/authentication/models.py
+++ b/backend/authentication/models.py
@@ -202,7 +202,7 @@ class SessionModel(models.Model):
 
     id = models.UUIDField(primary_key=True, default=uuid4, editable=False)
     user = models.ForeignKey("authentication.UserModel", on_delete=models.CASCADE)
-    session_key = models.CharField(max_length=40, unique=True)
+    # session_key = models.CharField(max_length=40, unique=True)
     created_at = models.DateTimeField(auto_now_add=True)
     last_activity = models.DateTimeField(auto_now=True)
 

--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -5,13 +5,14 @@ Serializers for the authentication app.
 
 import logging
 import re
+from datetime import timedelta
 from typing import Any, Dict, Union
 
 from django.contrib.auth import authenticate, get_user_model
 from rest_framework import serializers
-from rest_framework.authtoken.models import Token
+from rest_framework_simplejwt.tokens import RefreshToken
 
-from authentication.models import UserFlag, UserModel
+from authentication.models import SessionModel, UserFlag, UserModel
 
 logger = logging.getLogger(__name__)
 USER = get_user_model()
@@ -126,7 +127,6 @@ class SignInSerializer(serializers.Serializer[UserModel]):
     email = serializers.EmailField(required=False)
     username = serializers.CharField(required=False)
     password = serializers.CharField(write_only=True)
-    session_id = serializers.UUIDField(required=False, allow_null=True)
 
     def validate(self, data: Dict[str, Union[str, Any]]) -> Dict[str, Union[str, Any]]:
         """
@@ -186,8 +186,12 @@ class SignInSerializer(serializers.Serializer[UserModel]):
         data["user"] = authenticated_user
 
         try:
-            token, _ = Token.objects.get_or_create(user=user)
-            data["token"] = token.key
+            refresh_token = RefreshToken.for_user(authenticated_user)
+            access_token = refresh_token.access_token
+            access_token.set_exp(lifetime=timedelta(minutes=5))
+
+            data["access"] = str(access_token)
+            data["refresh"] = str(refresh_token)
             data["user"] = user
             logger.info(
                 "User signed in successfully: %s (ID: %s)", user.username, user.id
@@ -204,15 +208,14 @@ class SignInSerializer(serializers.Serializer[UserModel]):
         return data
 
 
-# class SessionSerializer(serializers.ModelSerializer[SessionModel]):
-#     """
-#     Serializer for the session model.
-#     """
+class SessionSerializer(serializers.ModelSerializer[SessionModel]):
+    """
+    Serializer for the session model.
+    """
 
-#     class Meta:
-#         model = SessionModel
-#         fields = ("id", "user", "session_key", "created_at")
-#         read_only_fields = ("id", "created_at")
+    class Meta:
+        model = SessionModel
+        fields = "__all__"
 
 
 # MARK: Pass Reset

--- a/backend/authentication/tests/flag/test_user_flag_create.py
+++ b/backend/authentication/tests/flag/test_user_flag_create.py
@@ -37,7 +37,7 @@ def test_user_flag_create():
     logger.debug(f"Login successful, status: {login.status_code}")
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
     logger.debug("Creating user flag")

--- a/backend/authentication/tests/flag/test_user_flag_delete.py
+++ b/backend/authentication/tests/flag/test_user_flag_delete.py
@@ -43,10 +43,12 @@ def test_user_flag_delete():
     logger.debug("User login successful")
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     logger.debug(f"Attempting to delete user flag with ID: {flagged_user.id}")
-    response = client.delete(path=f"/v1/auth/user_flag/{flagged_user.id}")
+    response = client.delete(
+        path=f"/v1/auth/user_flag/{flagged_user.id}",
+    )
 
     assert response.status_code == 204
     logger.info("User flag deletion test completed successfully")
@@ -81,7 +83,8 @@ def test_user_flag_delete_does_not_exist():
         f"Attempting to delete non-existent user flag with UUID: {bad_flagged_user_uuid}"
     )
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
+
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(path=f"/v1/auth/user_flag/{bad_flagged_user_uuid}")
     response_body = response.json()

--- a/backend/authentication/tests/flag/test_user_flag_list.py
+++ b/backend/authentication/tests/flag/test_user_flag_list.py
@@ -36,7 +36,7 @@ def test_user_flag_list():
     logger.debug(f"Login successful with status code: {login.status_code}")
     login_body = login.json()
 
-    token = login_body["token"]
+    token = login_body["access"]
     logger.debug("Setting authorization token for subsequent requests")
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 

--- a/backend/authentication/tests/flag/test_user_flag_retrieve.py
+++ b/backend/authentication/tests/flag/test_user_flag_retrieve.py
@@ -40,7 +40,7 @@ def test_user_flag_retrieve():
     logger.debug("User login successful")
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     logger.debug("Set authorization token for API client")
 
@@ -77,7 +77,7 @@ def test_user_flag_retrieve_does_not_exist():
     logger.debug("User login successful")
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     logger.debug("Set authorization token for API client")
 

--- a/backend/authentication/tests/session/test_session_delete.py
+++ b/backend/authentication/tests/session/test_session_delete.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# import pytest
+# from rest_framework.test import APIClient
+
+# from authentication.factories import SessionFactory, UserFactory
+# from authentication.models import SessionModel
+
+# pytestmark = pytest.mark.django_db
+
+
+# def test_session_delete():
+#     client = APIClient()
+
+#     test_username = "test_user"
+#     test_password = "test_pass"
+#     user = UserFactory(username=test_username, plaintext_password=test_password)
+#     user.is_confirmed = True
+#     user.verified = True
+#     user.save()
+
+#     login = client.post(
+#         path="/v1/auth/sign_in",
+#         data={"username": test_username, "password": test_password},
+#     )
+
+#     assert login.status_code == 200
+
+#     login_body = login.json()
+#     token = login_body["access"]
+
+#     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+#     response = client.delete(path="/v1/auth/session", data={"user": user.id})
+
+#     assert response.status_code == 204

--- a/backend/authentication/tests/session/test_session_post.py
+++ b/backend/authentication/tests/session/test_session_post.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# import pytest
+# from rest_framework.test import APIClient
+
+# from authentication.factories import UserFactory
+
+# pytestmark = pytest.mark.django_db
+
+
+# def test_session_post():
+#     client = APIClient()
+
+#     test_username = "test_user"
+#     test_password = "test_pass"
+#     user = UserFactory(username=test_username, plaintext_password=test_password)
+#     user.is_confirmed = True
+#     user.verified = True
+#     user.save()
+
+#     login = client.post(
+#         path="/v1/auth/sign_in",
+#         data={"username": test_username, "password": test_password},
+#     )
+
+#     assert login.status_code == 200
+
+#     login_body = login.json()
+#     token = login_body["access"]
+
+#     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+#     response = client.post(path="/v1/auth/session", data={"user": uuid4()})
+
+#     print(response.json())
+#     assert response.status_code == 201
+
+
+# def test_session_post_401():
+#     client = APIClient()
+
+#     test_username = "test_user"
+#     test_password = "test_pass"
+#     user = UserFactory(username=test_username, plaintext_password=test_password)
+#     user.is_confirmed = True
+#     user.verified = True
+
+#     response = client.post(path="/v1/auth/session", data={"user": user.id})
+
+#     assert response.status_code == 401

--- a/backend/authentication/tests/test_auth.py
+++ b/backend/authentication/tests/test_auth.py
@@ -377,7 +377,7 @@ def test_delete_user() -> None:
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     # User deletes themselves.
     logger.info("Testing user self-deletion")

--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -5,6 +5,7 @@ URL configuration for the authentication app.
 
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
+from rest_framework_simplejwt.views import TokenRefreshView
 
 from authentication import views
 
@@ -23,5 +24,6 @@ urlpatterns = [
         route="user_flag/<uuid:id>",
         view=views.UserFlagDetailAPIView.as_view(),
     ),
-    path(route="get_session", view=views.GetSessionView.as_view(), name="get_session"),
+    path(route="session", view=views.SessionView.as_view(), name="get_session"),
+    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
 ]

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -22,17 +22,17 @@ from drf_spectacular.utils import (
     extend_schema,
 )
 from rest_framework import status
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from authentication.models import UserFlag, UserModel
+from authentication.models import SessionModel, UserFlag, UserModel
 from authentication.serializers import (
     DeleteUserResponseSerializer,
     PasswordResetSerializer,
+    SessionSerializer,
     SignInSerializer,
     SignUpSerializer,
     UserFlagSerializers,
@@ -149,39 +149,119 @@ class SignInView(APIView):
 
         return Response(
             {
-                "token": serializer.validated_data.get("token"),
+                "access": serializer.validated_data.get("access"),
                 "message": "User was logged in successfully.",
             },
             status=status.HTTP_200_OK,
         )
 
 
-# MARK: Get Session
+# MARK: Session
 
 
-class GetSessionView(APIView):
-    # serializer_class = SessionSerializer
-    # permission_classes = (IsAuthenticated,)
-    # queryset = UserModel.objects.all()
-    # authentication_classes = (TokenAuthentication,)
-    def get(self, request: Request) -> Response:
-        #     session = request.user.session_set.first()
-        #     if not session:
-        #         return Response(
-        #             {"detail": "No active session found."},
-        #             status=status.HTTP_404_NOT_FOUND,
-        #         )
+class SessionView(APIView):
+    serializer_class = SessionSerializer
+    permission_classes = [IsAuthenticated]
+    queryset = SessionModel.objects.all()
 
-        #     serializer = SessionSerializer(session)
-        #     return Response(serializer.data, status=status.HTTP_200_OK)
-        data = {
-            "user": {"id": "1", "username": "admin", "is_admin": "false"},
-            "id": "1",
+    @extend_schema(
+        responses={
+            200: SessionSerializer,
+            401: OpenApiResponse(response={"detail": "You are not authenticated."}),
+            404: OpenApiResponse(response={"detail": "User not found."}),
         }
-        return Response(
-            data,
-            status=status.HTTP_200_OK,
-        )
+    )
+    def get(self, request: Request) -> Response:
+        if request.user.is_authenticated:
+            user = request.query_params.get("user")
+            try:
+                session = SessionModel.objects.get(user=user)
+            except SessionModel.DoesNotExist:
+                return Response(
+                    {"detail": "User not found."}, status=status.HTTP_404_NOT_FOUND
+                )
+
+            serializer = SessionSerializer(session)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        else:
+            return Response(
+                {"detail": "You are not authenticated."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+    # @extend_schema(
+    #     responses={
+    #         201: OpenApiResponse(response={"message": "Session created."}),
+    #         400: OpenApiResponse(
+    #             response={"detail": "Failed to create session within the database."}
+    #         ),
+    #         401: OpenApiResponse(response={"detail": "You are not authorized."}),
+    #     }
+    # )
+    # def post(self, request: Request) -> Response:
+    #     if request.user.is_authenticated:
+    #         user_id = request.query_params.get("user")
+    #         # session_key = request.query_params.get("session_key")
+
+    #         try:
+    #             session = SessionModel.objects.create(user=user_id)
+    #             session.save()
+    #         except (IntegrityError, OperationalError):
+    #             return Response(
+    #                 {"detail": "Failed to create session within the database."},
+    #                 status=status.HTTP_400_BAD_REQUEST,
+    #             )
+
+    #         return Response(
+    #             {"message": "Session created."}, status=status.HTTP_201_CREATED
+    #         )
+
+    #     else:
+    #         return Response(
+    #             {"detail": "You are not authorized."},
+    #             status=status.HTTP_401_UNAUTHORIZED,
+    #         )
+
+    # @extend_schema(
+    #     responses={
+    #         204: OpenApiResponse(response={"message": "User session deleted."}),
+    #         400: OpenApiResponse(response={"detail": "Invalid request."}),
+    #         401: OpenApiResponse(
+    #             response={"detail": "You are not authorized to delete this session"}
+    #         ),
+    #         403: OpenApiResponse(response={"detail": "You cannot delete this session"}),
+    #         404: OpenApiResponse(response={"detail": "User session not found."}),
+    #     }
+    # )
+    # def delete(self, request: Request) -> Response:
+    #     user = request.query_params.get("user")
+    #     if request.user.is_authenticated:
+    #         if user is None:
+    #             return Response(
+    #                 {"detail": "Invalid request."}, status=status.HTTP_400_BAD_REQUEST
+    #             )
+    #         try:
+    #             session = SessionModel.objects.get(user=user)
+    #         except SessionModel.DoesNotExist:
+    #             return Response(
+    #                 {"detail": "User session not found."},
+    #                 status=status.HTTP_404_NOT_FOUND,
+    #             )
+
+    #         if session.user == request.user.id:
+    #             session.delete()
+    #         else:
+    #             return Response(
+    #                 {"detail": "You cannot delete this session"},
+    #                 status=status.HTTP_403_FORBIDDEN,
+    #             )
+
+    #     else:
+    #         return Response(
+    #             {"detail": "You are not authorized to delete this session"},
+    #             status=status.HTTP_401_UNAUTHORIZED,
+    #         )
 
 
 # MARK: Pass Reset
@@ -272,7 +352,6 @@ class DeleteUserView(APIView):
     queryset = UserModel.objects.all()
     permission_classes = [IsAuthenticated]
     serializer_class = DeleteUserResponseSerializer
-    authentication_classes = [TokenAuthentication]
 
     @extend_schema(
         summary="Delete own account",
@@ -378,7 +457,6 @@ class UserFlagAPIView(GenericAPIView[UserFlag]):
 class UserFlagDetailAPIView(GenericAPIView[UserFlag]):
     queryset = UserFlag.objects.all()
     serializer_class = UserFlagSerializers
-    authentication_classes = [TokenAuthentication]
     permission_classes = [IsAdminStaffCreatorOrReadOnly]
 
     @extend_schema(

--- a/backend/communities/admin.py
+++ b/backend/communities/admin.py
@@ -40,12 +40,15 @@ admin.site.register(StatusType)
 # MARK: Group
 
 
-class GroupAdmin(admin.ModelAdmin[Group]):
+class GroupAdmin(admin.ModelAdmin):
     """
     Admin interface for the Group model.
 
     Displays the group's internal name and display name in the admin list view.
     """
+
+    class Meta:
+        model = Group
 
     list_display = ["group_name", "name"]
 
@@ -53,12 +56,15 @@ class GroupAdmin(admin.ModelAdmin[Group]):
 # MARK: Group Text
 
 
-class GroupTextAdmin(admin.ModelAdmin[GroupText]):
+class GroupTextAdmin(admin.ModelAdmin):
     """
     Admin interface for the GroupText model.
 
     Displays the ID and associated Group in the admin list view.
     """
+
+    class Meta:
+        model = GroupText
 
     list_display = ["id", "group"]
 
@@ -66,12 +72,15 @@ class GroupTextAdmin(admin.ModelAdmin[GroupText]):
 # MARK: Group Flag
 
 
-class GroupFlagAdmin(admin.ModelAdmin[GroupFlag]):
+class GroupFlagAdmin(admin.ModelAdmin):
     """
     Admin panel for the GroupFlag model.
 
     Displays the Groups which have been flagged and the users who flagged it.
     """
+
+    class Meta:
+        model = GroupFlag
 
     list_display = ["group", "created_by", "creation_date"]
 
@@ -79,12 +88,15 @@ class GroupFlagAdmin(admin.ModelAdmin[GroupFlag]):
 # MARK: Org
 
 
-class OrganizationAdmin(admin.ModelAdmin[Organization]):
+class OrganizationAdmin(admin.ModelAdmin):
     """
     Admin interface for the Organization model.
 
     Displays the organization's internal name and display name in the admin list view.
     """
+
+    class Meta:
+        model = Organization
 
     list_display = ["org_name", "name"]
 
@@ -92,12 +104,15 @@ class OrganizationAdmin(admin.ModelAdmin[Organization]):
 # MARK: Org Text
 
 
-class OrganizationTextAdmin(admin.ModelAdmin[OrganizationText]):
+class OrganizationTextAdmin(admin.ModelAdmin):
     """
     Admin interface for the OrganizationText model.
 
     Displays only the ID in the admin list view.
     """
+
+    class Meta:
+        model = OrganizationText
 
     list_display = ["id"]
 
@@ -105,12 +120,15 @@ class OrganizationTextAdmin(admin.ModelAdmin[OrganizationText]):
 # MARK: Org Flag
 
 
-class OrganizationFlagAdmin(admin.ModelAdmin[OrganizationFlag]):
+class OrganizationFlagAdmin(admin.ModelAdmin):
     """
     Admin interface for OrganizationFlag model.
 
     Displays only the Organization and users who flagged it.
     """
+
+    class Meta:
+        model = OrganizationFlag
 
     list_display = [
         "org",

--- a/backend/communities/groups/tests/faq/test_group_faq_create.py
+++ b/backend/communities/groups/tests/faq/test_group_faq_create.py
@@ -59,7 +59,7 @@ def test_group_faq_create() -> None:
     # MARK: Update Success
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 

--- a/backend/communities/groups/tests/faq/test_group_faq_update.py
+++ b/backend/communities/groups/tests/faq/test_group_faq_update.py
@@ -59,7 +59,7 @@ def test_group_faq_update() -> None:
     # MARK: Update Success
 
     login_response = login.json()
-    token = login_response["token"]
+    token = login_response["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(

--- a/backend/communities/groups/tests/flag/test_group_flag_create.py
+++ b/backend/communities/groups/tests/flag/test_group_flag_create.py
@@ -31,7 +31,7 @@ def test_group_flag_create():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
         path="/v1/communities/group_flag",

--- a/backend/communities/groups/tests/flag/test_group_flag_delete.py
+++ b/backend/communities/groups/tests/flag/test_group_flag_delete.py
@@ -36,7 +36,7 @@ def test_group_flag_delete():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(path=f"/v1/communities/group_flag/{flag.id}")
@@ -65,7 +65,7 @@ def test_group_flag_does_not_exist():
 
     bad_flagged_group_uuid = uuid4()
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(
         path=f"/v1/communities/group_flag/{bad_flagged_group_uuid}"

--- a/backend/communities/groups/tests/flag/test_group_flag_list.py
+++ b/backend/communities/groups/tests/flag/test_group_flag_list.py
@@ -28,7 +28,7 @@ def test_group_flag_list():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path="/v1/communities/group_flag")
 

--- a/backend/communities/groups/tests/flag/test_group_flag_retrieve.py
+++ b/backend/communities/groups/tests/flag/test_group_flag_retrieve.py
@@ -34,7 +34,7 @@ def test_group_flag_retrieve():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path=f"/v1/communities/group_flag/{flag.id}")
 
@@ -61,7 +61,7 @@ def test_group_flag_retrieve_error():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path=f"/v1/communities/group_flag/{flag}")
     response_body = response.json()

--- a/backend/communities/groups/tests/social_link/test_group_social_link_update.py
+++ b/backend/communities/groups/tests/social_link/test_group_social_link_update.py
@@ -55,7 +55,7 @@ def test_group_social_link_update(client: Client) -> None:
     # MARK: Update Success
 
     login_response = login.json()
-    token = login_response["token"]
+    token = login_response["access"]
 
     response = client.put(
         path=f"/v1/communities/group_social_links/{social_links.id}",
@@ -120,7 +120,7 @@ def test_group_social_link_not_creator_or_admin():
     # MARK: Access Failure
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(

--- a/backend/communities/groups/tests/test_group_api.py
+++ b/backend/communities/groups/tests/test_group_api.py
@@ -45,7 +45,7 @@ def login_user(user_data: UserDict) -> dict[Any, Any]:
         },
     )
     assert response.status_code == 200
-    return {"user": user_data["user"], "token": response.data["token"]}
+    return {"user": user_data["user"], "access": response.data["access"]}
 
 
 @pytest.fixture(scope="session")
@@ -136,7 +136,7 @@ def test_GroupAPIView(logged_in_user, status_types):
     org = OrganizationFactory.create(org_name="test_org", terms_checked=True)
     new_group = GroupFactory.build(group_name="new_group", terms_checked=True)
     location = EntityLocationFactory.build()
-    token = logged_in_user["token"]
+    token = logged_in_user["access"]
 
     payload = {
         "org_id": org.id,
@@ -185,7 +185,7 @@ def test_GroupDetailAPIView(logged_in_user, logged_in_created_by_user) -> None:
     """
     client = APIClient()
 
-    created_by_user, token_created_by = logged_in_created_by_user.values()
+    created_by_user, access = logged_in_created_by_user.values()
 
     new_group = GroupFactory.create(created_by=created_by_user)
     assert Group.objects.filter(group_name=new_group.group_name).exists()
@@ -206,7 +206,7 @@ def test_GroupDetailAPIView(logged_in_user, logged_in_created_by_user) -> None:
     )
     assert response.status_code == 401
 
-    client.credentials(HTTP_AUTHORIZATION=f"Token {token_created_by}")
+    client.credentials(HTTP_AUTHORIZATION=f"Token {access}")
     response = client.put(
         f"{GROUPS_URL}/{new_group.id}",
         data=updated_payload,
@@ -223,7 +223,7 @@ def test_GroupDetailAPIView(logged_in_user, logged_in_created_by_user) -> None:
     response = client.delete(f"{GROUPS_URL}/{new_group.id}")
     assert response.status_code == 401
 
-    client.credentials(HTTP_AUTHORIZATION=f"Token {token_created_by}")
+    client.credentials(HTTP_AUTHORIZATION=f"Token {access}")
     response = client.delete(f"{GROUPS_URL}/{new_group.id}")
 
     assert response.status_code == 200

--- a/backend/communities/groups/tests/test_group_delete.py
+++ b/backend/communities/groups/tests/test_group_delete.py
@@ -54,7 +54,7 @@ def test_group_delete(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_body = login_response.json()
-    token = login_response_body.get("token")
+    token = login_response_body.get("access")
 
     delete_response = client.delete(
         path=f"/v1/communities/groups/{group.id}",
@@ -93,7 +93,7 @@ def test_group_delete(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_body = login_response.json()
-    token = login_response_body.get("token")
+    token = login_response_body.get("access")
 
     delete_response = client.delete(
         path=f"/v1/communities/groups/{test_uuid}",
@@ -126,7 +126,7 @@ def test_group_delete(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_body = login_response.json()
-    token = login_response_body.get("token")
+    token = login_response_body.get("access")
 
     delete_response = client.delete(
         path=f"/v1/communities/groups/{group.id}",

--- a/backend/communities/groups/tests/test_group_partial_update.py
+++ b/backend/communities/groups/tests/test_group_partial_update.py
@@ -55,7 +55,7 @@ def test_group_partial_update(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_body = login_response.json()
-    token = login_response_body.get("token")
+    token = login_response_body.get("access")
 
     group.created_by = user
 

--- a/backend/communities/groups/tests/test_group_update.py
+++ b/backend/communities/groups/tests/test_group_update.py
@@ -47,7 +47,7 @@ def test_group_update(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_body = login_response.json()
-    token = login_response_body.get("token")
+    token = login_response_body.get("access")
 
     group.created_by = user
 
@@ -97,7 +97,7 @@ def test_group_update(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_body = login_response.json()
-    token = login_response_body.get("token")
+    token = login_response_body.get("access")
 
     group.created_by = user
 

--- a/backend/communities/groups/tests/text/test_group_text_update.py
+++ b/backend/communities/groups/tests/text/test_group_text_update.py
@@ -32,7 +32,7 @@ def test_group_text_update():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(
@@ -65,7 +65,7 @@ def test_group_text_update_403():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(
@@ -102,7 +102,7 @@ def test_event_text_update_404():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(

--- a/backend/communities/groups/views.py
+++ b/backend/communities/groups/views.py
@@ -11,7 +11,6 @@ from uuid import UUID
 from django.db.utils import IntegrityError, OperationalError
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status, viewsets
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import (
     SAFE_METHODS,
@@ -52,7 +51,6 @@ class GroupAPIView(GenericAPIView[Group]):
     queryset = Group.objects.all().order_by("id")
     serializer_class = GroupSerializer
     pagination_class = CustomPagination
-    authentication_classes = [TokenAuthentication]
     permission_classes: List[Type[BasePermission]] = [IsAuthenticatedOrReadOnly]
 
     def get_permissions(self) -> List[BasePermission]:
@@ -125,7 +123,6 @@ class GroupAPIView(GenericAPIView[Group]):
 class GroupDetailAPIView(GenericAPIView[Group]):
     queryset = Group.objects.all()
     serializer_class = GroupSerializer
-    authentication_classes = [TokenAuthentication]
     permission_classes = [IsAdminStaffCreatorOrReadOnly]
 
     @extend_schema(
@@ -277,7 +274,6 @@ class GroupFlagAPIView(GenericAPIView[GroupFlag]):
 class GroupFlagDetailAPIView(GenericAPIView[GroupFlag]):
     queryset = GroupFlag.objects.all()
     serializer_class = GroupFlagSerializer
-    authentication_classes = [TokenAuthentication]
     permission_classes = [IsAdminStaffCreatorOrReadOnly]
 
     @extend_schema(

--- a/backend/communities/organizations/tests/faq/test_org_faq_create.py
+++ b/backend/communities/organizations/tests/faq/test_org_faq_create.py
@@ -59,7 +59,7 @@ def test_org_faq_create() -> None:
     # MARK: Update Success
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 

--- a/backend/communities/organizations/tests/faq/test_org_faq_update.py
+++ b/backend/communities/organizations/tests/faq/test_org_faq_update.py
@@ -62,7 +62,7 @@ def test_org_faq_update() -> None:
     # MARK: Update Success
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     response = client.put(
         path=f"/v1/communities/organization_faqs/{test_id}",

--- a/backend/communities/organizations/tests/flag/test_org_flag_create.py
+++ b/backend/communities/organizations/tests/flag/test_org_flag_create.py
@@ -32,7 +32,7 @@ def test_org_flag_create():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
         path="/v1/communities/organization_flag",

--- a/backend/communities/organizations/tests/flag/test_org_flag_delete.py
+++ b/backend/communities/organizations/tests/flag/test_org_flag_delete.py
@@ -35,7 +35,7 @@ def test_org_flag_delete():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(path=f"/v1/communities/organization_flag/{flag.id}")
 
@@ -63,7 +63,7 @@ def test_org_flag_delete_does_not_exist():
 
     bad_flagged_org_uuid = uuid4()
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(
         path=f"/v1/communities/organization_flag/{bad_flagged_org_uuid}"

--- a/backend/communities/organizations/tests/flag/test_org_flag_list.py
+++ b/backend/communities/organizations/tests/flag/test_org_flag_list.py
@@ -28,7 +28,7 @@ def test_org_flag_list():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path="/v1/communities/organization_flag")
 

--- a/backend/communities/organizations/tests/flag/test_org_flag_retrieve.py
+++ b/backend/communities/organizations/tests/flag/test_org_flag_retrieve.py
@@ -32,7 +32,7 @@ def test_org_flag_retrieve():
     )
     assert login.status_code == 200
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path=f"/v1/communities/organization_flag/{flag.id}")
@@ -63,7 +63,7 @@ def test_org_flag_retrieve_does_not_exist():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path=f"/v1/communities/organization_flag/{flag}")
     response_body = response.json()

--- a/backend/communities/organizations/tests/social_link/test_org_social_link_update.py
+++ b/backend/communities/organizations/tests/social_link/test_org_social_link_update.py
@@ -58,7 +58,7 @@ def test_org_social_link_update(client: Client) -> None:
     # MARK: Update Success
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     response = client.put(
         path=f"/v1/communities/organization_social_links/{social_links.id}",
@@ -114,7 +114,7 @@ def test_org_social_link_not_creator_or_admin():
     # MARK: Access Failure
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(

--- a/backend/communities/organizations/tests/test_org_api.py
+++ b/backend/communities/organizations/tests/test_org_api.py
@@ -44,7 +44,7 @@ def login_user(user_data: UserDict) -> dict:
         },
     )
     assert response.status_code == 200
-    return {"user": user_data["user"], "token": response.data["token"]}
+    return {"user": user_data["user"], "access": response.data["access"]}
 
 
 @pytest.fixture(scope="session")
@@ -134,7 +134,7 @@ def test_OrganizationAPIView(logged_in_user, status_types) -> None:
     # Authenticated and successful.
     new_org = OrganizationFactory.build(org_name="new_org", terms_checked=True)
     location = EntityLocationFactory.build()
-    token = logged_in_user["token"]
+    access = logged_in_user["access"]
 
     payload = {
         "location": {
@@ -151,7 +151,7 @@ def test_OrganizationAPIView(logged_in_user, status_types) -> None:
         "is_high_risk": new_org.is_high_risk,
     }
 
-    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    client.credentials(HTTP_AUTHORIZATION=f"Token {access}")
     response = client.post(ORGS_URL, data=payload, format="json")
 
     assert response.status_code == 201
@@ -184,7 +184,7 @@ def test_organizationDetailAPIView(logged_in_user, logged_in_created_by_user) ->
     """
     client = APIClient()
 
-    created_by_user, token_created_by = logged_in_created_by_user.values()
+    created_by_user, access = logged_in_created_by_user.values()
 
     new_org = OrganizationFactory.create(created_by=created_by_user)
     assert Organization.objects.filter(org_name=new_org.org_name).exists()
@@ -205,13 +205,13 @@ def test_organizationDetailAPIView(logged_in_user, logged_in_created_by_user) ->
     )
     assert response.status_code == 401
 
-    client.credentials(HTTP_AUTHORIZATION=f"Token {token_created_by}")
+    client.credentials(HTTP_AUTHORIZATION=f"Token {access}")
     response = client.put(
         f"{ORGS_URL}/{new_org.id}",
         data=updated_payload,
         format="json",
     )
-    assert response.status_code == 200
+    assert response.status_code == 200  # MARK:Fix
 
     updated_org = Organization.objects.get(id=new_org.id)
     assert updated_org.org_name == "updated_org_name"
@@ -222,7 +222,7 @@ def test_organizationDetailAPIView(logged_in_user, logged_in_created_by_user) ->
     response = client.delete(f"{ORGS_URL}/{new_org.id}")
     assert response.status_code == 401
 
-    client.credentials(HTTP_AUTHORIZATION=f"Token {token_created_by}")
+    client.credentials(HTTP_AUTHORIZATION=f"Token {access}")
     response = client.delete(f"{ORGS_URL}/{new_org.id}")
 
     assert response.status_code == 200

--- a/backend/communities/organizations/tests/test_org_delete.py
+++ b/backend/communities/organizations/tests/test_org_delete.py
@@ -53,7 +53,7 @@ def test_org_delete(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_json = login_response.json()
-    token = login_response_json["token"]
+    token = login_response_json["access"]
 
     bad_org_id = uuid4()
     org.created_by = user

--- a/backend/communities/organizations/tests/test_org_update.py
+++ b/backend/communities/organizations/tests/test_org_update.py
@@ -52,7 +52,7 @@ def test_org_update(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_json = login_response.json()
-    token = login_response_json["token"]
+    token = login_response_json["access"]
 
     bad_org_id = uuid4()
     org.created_by = user
@@ -89,7 +89,7 @@ def test_org_update(client: Client) -> None:
     assert login_response.status_code == 200
 
     login_response_json = login_response.json()
-    token = login_response_json["token"]
+    token = login_response_json["access"]
 
     org.created_by = user
 

--- a/backend/communities/organizations/tests/text/test_org_text_update.py
+++ b/backend/communities/organizations/tests/text/test_org_text_update.py
@@ -35,7 +35,7 @@ def test_org_text_update():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(
@@ -71,7 +71,7 @@ def test_org_text_update_403():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(
@@ -108,7 +108,7 @@ def test_org_text_update_404():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(

--- a/backend/communities/organizations/views.py
+++ b/backend/communities/organizations/views.py
@@ -16,7 +16,6 @@ from drf_spectacular.utils import (
     extend_schema,
 )
 from rest_framework import status, viewsets
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
@@ -53,7 +52,6 @@ class OrganizationAPIView(GenericAPIView[Organization]):
     queryset = Organization.objects.all().order_by("id")
     serializer_class = OrganizationSerializer
     pagination_class = CustomPagination
-    authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     @extend_schema(
@@ -362,7 +360,6 @@ class OrganizationFlagAPIView(GenericAPIView[OrganizationFlag]):
 class OrganizationFlagDetailAPIView(GenericAPIView[OrganizationFlag]):
     queryset = OrganizationFlag.objects.all()
     serializer_class = OrganizationFlagSerializer
-    authentication_classes = [TokenAuthentication]
     permission_classes = [IsAdminStaffCreatorOrReadOnly]
 
     @extend_schema(

--- a/backend/content/admin.py
+++ b/backend/content/admin.py
@@ -35,10 +35,13 @@ admin.site.register(DiscussionEntry)
 # MARK: Resource Flag
 
 
-class ResourceFlagAdmin(admin.ModelAdmin[ResourceFlag]):
+class ResourceFlagAdmin(admin.ModelAdmin):
     """
     Displays the flagged resources and the users who flagged it in the admin table.
     """
+
+    class Meta:
+        model = ResourceFlag
 
     list_display = ["resource", "created_by", "creation_date"]
 

--- a/backend/content/tests/discussion/entry/test_discussion_entry_create.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_create.py
@@ -33,7 +33,7 @@ def test_disc_entry_create():
 
     assert login_response.status_code == 200
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     # Passing authorization header.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")

--- a/backend/content/tests/discussion/entry/test_discussion_entry_delete.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_delete.py
@@ -31,7 +31,7 @@ def test_disc_entry_delete():
 
     assert login_response.status_code == 200
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     discussion_entry = DiscussionEntryFactory(created_by=user)
 

--- a/backend/content/tests/discussion/entry/test_discussion_entry_partial_update.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_partial_update.py
@@ -34,7 +34,7 @@ def test_disc_entry_update():
 
     assert login_response.status_code == 200
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     # Authorized owner partial updates the entry.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")

--- a/backend/content/tests/discussion/entry/test_discussion_entry_update.py
+++ b/backend/content/tests/discussion/entry/test_discussion_entry_update.py
@@ -35,7 +35,7 @@ def test_disc_entry_update():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     # Authorized owner updates the entry.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")

--- a/backend/content/tests/discussion/test_discussion_create.py
+++ b/backend/content/tests/discussion/test_discussion_create.py
@@ -31,7 +31,7 @@ def test_discussion_create():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(

--- a/backend/content/tests/discussion/test_discussion_delete.py
+++ b/backend/content/tests/discussion/test_discussion_delete.py
@@ -33,7 +33,7 @@ def test_discussion_delete():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     # Authorized owner deletes the discussion.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")

--- a/backend/content/tests/discussion/test_discussion_partial_update.py
+++ b/backend/content/tests/discussion/test_discussion_partial_update.py
@@ -32,7 +32,7 @@ def test_discussion_partial_update():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     discussion_thread = DiscussionFactory(created_by=user)
 

--- a/backend/content/tests/discussion/test_discussion_update.py
+++ b/backend/content/tests/discussion/test_discussion_update.py
@@ -29,7 +29,7 @@ def test_discussion_update():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(

--- a/backend/content/tests/faq/test_faq.py
+++ b/backend/content/tests/faq/test_faq.py
@@ -210,7 +210,7 @@ def test_organization_faq_create_view() -> None:
     # MARK: Update Success
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
@@ -268,7 +268,7 @@ def test_group_faq_create_view() -> None:
     # MARK: Update Success
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 
@@ -325,7 +325,7 @@ def test_event_faq_create_view() -> None:
     # MARK: Update Success
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 

--- a/backend/content/tests/resource/resource_flag/test_resource_flag_create.py
+++ b/backend/content/tests/resource/resource_flag/test_resource_flag_create.py
@@ -29,7 +29,7 @@ def test_resource_flag_create():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
         path="/v1/content/resource_flag",

--- a/backend/content/tests/resource/resource_flag/test_resource_flag_delete.py
+++ b/backend/content/tests/resource/resource_flag/test_resource_flag_delete.py
@@ -30,7 +30,7 @@ def test_resource_flag_delete():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     flag = ResourceFlagFactory()
 
@@ -61,7 +61,7 @@ def test_resource_flag_delete_does_not_exist():
 
     bad_flagged_resource_uuid = uuid4()
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(
         path=f"/v1/content/resource_flag/{bad_flagged_resource_uuid}"

--- a/backend/content/tests/resource/resource_flag/test_resource_flag_list.py
+++ b/backend/content/tests/resource/resource_flag/test_resource_flag_list.py
@@ -25,7 +25,7 @@ def test_resource_flag_list():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path="/v1/content/resource_flag")
 

--- a/backend/content/tests/resource/resource_flag/test_resource_flag_retrieve.py
+++ b/backend/content/tests/resource/resource_flag/test_resource_flag_retrieve.py
@@ -29,7 +29,7 @@ def test_resource_flag_retrieve():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     flag = ResourceFlagFactory()
 
@@ -60,7 +60,7 @@ def test_resource_flag_retrieve_does_not_exist():
 
     bad_flagged_resource_uuid = uuid4()
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path=f"/v1/content/resource_flag/{bad_flagged_resource_uuid}")
     response_body = response.json()

--- a/backend/content/tests/resource/test_resource_create.py
+++ b/backend/content/tests/resource/test_resource_create.py
@@ -32,7 +32,7 @@ def test_resource_create():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     resource_instance = ResourceFactory(created_by=user)
     location = EntityLocationFactory()

--- a/backend/content/tests/resource/test_resource_delete.py
+++ b/backend/content/tests/resource/test_resource_delete.py
@@ -35,7 +35,7 @@ def test_resource_delete():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     # Authorized owner tried to delete the resource.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")

--- a/backend/content/tests/resource/test_resource_partial_update.py
+++ b/backend/content/tests/resource/test_resource_partial_update.py
@@ -36,7 +36,7 @@ def test_resource_partial_update():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     payload = {
         "name": "new_resource",

--- a/backend/content/tests/resource/test_resource_retrieve.py
+++ b/backend/content/tests/resource/test_resource_retrieve.py
@@ -31,7 +31,7 @@ def test_resource_retrieve():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     # Passing authorization header.
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")

--- a/backend/content/tests/resource/test_resource_update.py
+++ b/backend/content/tests/resource/test_resource_update.py
@@ -36,7 +36,7 @@ def test_resource_update():
     assert login_response.status_code == 200
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     payload = {
         "name": "new_resource",

--- a/backend/content/tests/social_link/test_social_link.py
+++ b/backend/content/tests/social_link/test_social_link.py
@@ -189,7 +189,7 @@ def test_organization_social_link_create_view(client: APIClient) -> None:
         data={"username": test_username, "password": test_password},
     )
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     formData = {"link": "https://example.com", "label": "Example", "order": 1}
 
@@ -231,7 +231,7 @@ def test_group_social_link_create_view(client: APIClient) -> None:
         data={"username": test_username, "password": test_password},
     )
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     formData = {"link": "https://example.com", "label": "Example", "order": 1}
 
@@ -273,7 +273,7 @@ def test_event_social_link_create_view(client: APIClient) -> None:
         data={"username": test_username, "password": test_password},
     )
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     formData = {"link": "https://example.com", "label": "Example", "order": 1}
 

--- a/backend/content/views.py
+++ b/backend/content/views.py
@@ -11,7 +11,6 @@ from django.db import IntegrityError, OperationalError
 from django.db.models import Q
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status, viewsets
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.generics import GenericAPIView
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import (
@@ -345,7 +344,6 @@ class ResourceFlagAPIView(GenericAPIView[ResourceFlag]):
 class ResourceFlagDetailAPIView(GenericAPIView[ResourceFlag]):
     queryset = ResourceFlag.objects.all()
     serializer_class = ResourceFlagSerializer
-    authentication_classes = [TokenAuthentication]
     permission_classes = [IsAdminStaffCreatorOrReadOnly]
 
     @extend_schema(

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -10,8 +10,10 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
 import os
+from datetime import timedelta
 from pathlib import Path
 
+import django
 import django_stubs_ext
 import dotenv
 
@@ -69,6 +71,7 @@ INSTALLED_APPS = [
     "communities",
     "content",
     "events",
+    "rest_framework_simplejwt",
 ]
 
 # MARK: Middleware
@@ -199,9 +202,9 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "DEFAULT_PAGINATION_ORDERS_OBJECTS": False,
     "PAGE_SIZE": 20,
-    "DEFAULT_AUTHENTICATION_CLASSES": [
-        "rest_framework.authentication.TokenAuthentication",
-    ],
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ),
     "EXCEPTION_HANDLER": "core.exception_handler.bad_request_logger",
     "DEFAULT_RENDERER_CLASSES": (
         "djangorestframework_camel_case.render.CamelCaseJSONRenderer",
@@ -261,11 +264,49 @@ LOGGING = {
     },
 }
 
+# MARK: Simple JWT
+
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
+    "ROTATE_REFRESH_TOKENS": False,
+    "BLACKLIST_AFTER_ROTATION": False,
+    "UPDATE_LAST_LOGIN": False,
+    "ALGORITHM": "HS256",
+    "SIGNING_KEY": SECRET_KEY,
+    "VERIFYING_KEY": "",
+    "AUDIENCE": None,
+    "ISSUER": None,
+    "JSON_ENCODER": None,
+    "JWK_URL": None,
+    "LEEWAY": 0,
+    "AUTH_HEADER_TYPES": ("Token",),
+    "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
+    "USER_ID_FIELD": "id",
+    "USER_ID_CLAIM": "user_id",
+    "USER_AUTHENTICATION_RULE": "rest_framework_simplejwt.authentication.default_user_authentication_rule",
+    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
+    "TOKEN_TYPE_CLAIM": "token_type",
+    "TOKEN_USER_CLASS": "rest_framework_simplejwt.models.TokenUser",
+    "JTI_CLAIM": "jti",
+    "SLIDING_TOKEN_REFRESH_EXP_CLAIM": "refresh_exp",
+    "SLIDING_TOKEN_LIFETIME": timedelta(minutes=5),
+    "SLIDING_TOKEN_REFRESH_LIFETIME": timedelta(days=1),
+    "TOKEN_OBTAIN_SERIALIZER": "rest_framework_simplejwt.serializers.TokenObtainPairSerializer",
+    "TOKEN_REFRESH_SERIALIZER": "rest_framework_simplejwt.serializers.TokenRefreshSerializer",
+    "TOKEN_VERIFY_SERIALIZER": "rest_framework_simplejwt.serializers.TokenVerifySerializer",
+    "TOKEN_BLACKLIST_SERIALIZER": "rest_framework_simplejwt.serializers.TokenBlacklistSerializer",
+    "SLIDING_TOKEN_OBTAIN_SERIALIZER": "rest_framework_simplejwt.serializers.TokenObtainSlidingSerializer",
+    "SLIDING_TOKEN_REFRESH_SERIALIZER": "rest_framework_simplejwt.serializers.TokenRefreshSlidingSerializer",
+}
+
 # MARK: Image / Data Upload size limits
 IMAGE_UPLOAD_MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 DATA_UPLOAD_MAX_MEMORY_SIZE = 5 * 1024 * 1024  # 5MB
 
 # MARK: API Settings
+
+django.setup()
 
 from rest_framework import viewsets  # noqa: E402
 

--- a/backend/core/tests/unit/test_throttling.py
+++ b/backend/core/tests/unit/test_throttling.py
@@ -60,7 +60,7 @@ def test_auth_throttle():
         path="/v1/auth/sign_in",
         data={"username": test_username, "password": test_password},
     )
-    token = login_response.json()["token"]
+    token = login_response.json()["access"]
 
     settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user"] = "5/min"
     endpoint = "/v1/communities/organizations"

--- a/backend/events/admin.py
+++ b/backend/events/admin.py
@@ -29,12 +29,15 @@ admin.site.register(EventText)
 # MARK: Event Flag
 
 
-class EventFlagAdmin(admin.ModelAdmin[EventFlag]):
+class EventFlagAdmin(admin.ModelAdmin):
     """
     Admin interface for EventFlag model.
 
     Displays the Event, User and the date of the report filed.
     """
+
+    class Meta:
+        model = EventFlag
 
     list_display = ["event", "created_by", "creation_date"]
 

--- a/backend/events/tests/faq/test_event_faq_create.py
+++ b/backend/events/tests/faq/test_event_faq_create.py
@@ -56,7 +56,7 @@ def test_event_faq_create() -> None:
     # MARK: Update Success
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
 

--- a/backend/events/tests/faq/test_event_faq_update.py
+++ b/backend/events/tests/faq/test_event_faq_update.py
@@ -56,7 +56,7 @@ def test_event_faq_update(client: Client) -> None:
     # MARK: Update Success
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     response = client.put(
         path=f"/v1/events/event_faqs/{test_id}",

--- a/backend/events/tests/flag/test_event_flag_create.py
+++ b/backend/events/tests/flag/test_event_flag_create.py
@@ -27,7 +27,7 @@ def test_event_flag_create():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     event = EventFactory()
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(

--- a/backend/events/tests/flag/test_event_flag_delete.py
+++ b/backend/events/tests/flag/test_event_flag_delete.py
@@ -30,7 +30,7 @@ def test_event_flag_delete():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     flag = EventFlagFactory()
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(path=f"/v1/events/event_flag/{flag.id}")
@@ -59,7 +59,7 @@ def test_event_flag_delete_does_not_exist():
 
     bad_flagged_event_uuid = uuid4()
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(path=f"/v1/events/event_flag/{bad_flagged_event_uuid}")
     response_body = response.json()

--- a/backend/events/tests/flag/test_event_flag_list.py
+++ b/backend/events/tests/flag/test_event_flag_list.py
@@ -25,7 +25,7 @@ def test_event_flag_list():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path="/v1/events/event_flag")
 

--- a/backend/events/tests/flag/test_event_flag_retrieve.py
+++ b/backend/events/tests/flag/test_event_flag_retrieve.py
@@ -30,7 +30,7 @@ def test_event_flag_retrieve():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path=f"/v1/events/event_flag/{flag.id}")
 
@@ -57,7 +57,7 @@ def test_event_flag_retrieve_does_not_exist():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.get(path=f"/v1/events/event_flag/{flag}")
     response_body = response.json()

--- a/backend/events/tests/social_link/test_event_social_link_create.py
+++ b/backend/events/tests/social_link/test_event_social_link_create.py
@@ -29,7 +29,7 @@ def test_social_link_create():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(
@@ -66,7 +66,7 @@ def test_social_link_create_403():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.post(

--- a/backend/events/tests/social_link/test_event_social_link_delete.py
+++ b/backend/events/tests/social_link/test_event_social_link_delete.py
@@ -32,7 +32,7 @@ def test_social_link_delete():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(
@@ -62,7 +62,7 @@ def test_social_link_delete_404():
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.delete(

--- a/backend/events/tests/social_link/test_event_social_link_update.py
+++ b/backend/events/tests/social_link/test_event_social_link_update.py
@@ -54,7 +54,7 @@ def test_event_social_link_update(client: Client) -> None:
     # MARK: Update Success
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     response = client.put(
         path=f"/v1/events/event_social_links/{social_links.id}",
@@ -119,7 +119,7 @@ def test_event_social_link_not_creator_or_admin():
     # MARK: Access Failure
 
     login_body = login_response.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
     response = client.put(

--- a/backend/events/tests/test_event_api.py
+++ b/backend/events/tests/test_event_api.py
@@ -42,7 +42,7 @@ def login_user(user_data: UserDict) -> dict[Any, Any]:
         },
     )
     assert response.status_code == 200
-    return {"user": user_data["user"], "token": response.data["token"]}
+    return {"user": user_data["user"], "access": response.data["access"]}
 
 
 @pytest.fixture
@@ -105,7 +105,7 @@ def test_EventListAPIView(logged_in_user) -> None:
     org = OrganizationFactory.create(org_name="test_org", terms_checked=True)
     new_event = EventFactory.build(name="new_event", terms_checked=True)
     location = EntityLocationFactory.build()
-    token = logged_in_user["token"]
+    token = logged_in_user["access"]
 
     payload = {
         "name": new_event.name,
@@ -135,7 +135,7 @@ def test_EventListAPIView(logged_in_user) -> None:
 def test_EventDetailAPIView(logged_in_user) -> None:  # type: ignore[no-untyped-def]
     client = APIClient()
 
-    created_by_user, token = logged_in_user.values()
+    created_by_user, access = logged_in_user.values()
 
     new_event = EventFactory.create(created_by=created_by_user)
     assert Event.objects.filter(name=new_event.name).exists()
@@ -159,7 +159,7 @@ def test_EventDetailAPIView(logged_in_user) -> None:  # type: ignore[no-untyped-
 
     assert response.status_code == 401
 
-    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    client.credentials(HTTP_AUTHORIZATION=f"Token {access}")
     response = client.put(f"{EVENTS_URL}/{new_event.id}", data=payload, format="json")
 
     assert response.status_code == 200
@@ -171,7 +171,7 @@ def test_EventDetailAPIView(logged_in_user) -> None:  # type: ignore[no-untyped-
     response = client.delete(f"{EVENTS_URL}/{new_event.id}")
     assert response.status_code == 401
 
-    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    client.credentials(HTTP_AUTHORIZATION=f"Token {access}")
     response = client.delete(f"{EVENTS_URL}/{new_event.id}")
 
     assert response.status_code == 200

--- a/backend/events/tests/test_event_delete.py
+++ b/backend/events/tests/test_event_delete.py
@@ -28,7 +28,7 @@ def test_event_delete(client: Client) -> None:
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     event = EventFactory.create()
 

--- a/backend/events/tests/test_event_update.py
+++ b/backend/events/tests/test_event_update.py
@@ -32,7 +32,7 @@ def test_event_update(client: Client) -> None:
     assert login.status_code == 200
 
     login_body = login.json()
-    token = login_body["token"]
+    token = login_body["access"]
 
     event = EventFactory.create()
 

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -14,7 +14,6 @@ from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_sche
 from icalendar import Calendar  # type: ignore
 from icalendar import Event as ICalEvent
 from rest_framework import status, viewsets
-from rest_framework.authentication import TokenAuthentication
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import (
     AllowAny,
@@ -47,7 +46,6 @@ class EventAPIView(GenericAPIView[Event]):
     queryset = Event.objects.all().order_by("id")
     serializer_class = EventSerializer
     pagination_class = CustomPagination
-    authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticatedOrReadOnly]
 
     def get_permissions(self) -> Sequence[Any]:
@@ -264,7 +262,6 @@ class EventFlagAPIView(GenericAPIView[EventFlag]):
 class EventFlagDetailAPIView(GenericAPIView[EventFlag]):
     queryset = EventFlag.objects.all()
     serializer_class = EventFlagSerializers
-    authentication_classes = [TokenAuthentication]
     permission_classes = [IsAdminStaffCreatorOrReadOnly]
 
     @extend_schema(

--- a/backend/requirements-dev.in
+++ b/backend/requirements-dev.in
@@ -20,3 +20,4 @@ pytest-cov
 pytest-django
 ruff
 ts-backend-check
+djangorestframework-simplejwt

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -43,6 +43,7 @@ django==5.2.4
     #   django-stubs
     #   django-stubs-ext
     #   djangorestframework
+    #   djangorestframework-simplejwt
     #   drf-spectacular
 django-cors-headers==4.7.0
     # via -r requirements.txt
@@ -63,9 +64,12 @@ django-stubs-ext==5.2.2
 djangorestframework==3.16.0
     # via
     #   -r requirements.txt
+    #   djangorestframework-simplejwt
     #   drf-spectacular
 djangorestframework-camel-case==1.4.2
     # via -r requirements.txt
+djangorestframework-simplejwt==5.5.1
+    # via -r requirements-dev.in
 djangorestframework-stubs==3.16.1
     # via -r requirements.txt
 drf-spectacular==0.28.0
@@ -146,6 +150,8 @@ pygments==2.19.2
     #   i18n-check
     #   pytest
     #   rich
+pyjwt==2.10.1
+    # via djangorestframework-simplejwt
 pyproject-hooks==1.2.0
     # via
     #   build

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -18,3 +18,4 @@ icalendar
 pillow
 psycopg2-binary
 python-dotenv
+djangorestframework-simplejwt

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,6 +25,7 @@ django==5.2.4
     #   django-stubs
     #   django-stubs-ext
     #   djangorestframework
+    #   djangorestframework-simplejwt
     #   drf-spectacular
 django-cors-headers==4.7.0
     # via -r requirements.in
@@ -43,8 +44,11 @@ django-stubs-ext==5.2.2
 djangorestframework==3.16.0
     # via
     #   -r requirements.in
+    #   djangorestframework-simplejwt
     #   drf-spectacular
 djangorestframework-camel-case==1.4.2
+    # via -r requirements.in
+djangorestframework-simplejwt==5.5.1
     # via -r requirements.in
 djangorestframework-stubs==3.16.1
     # via -r requirements.in
@@ -70,6 +74,8 @@ pillow==11.3.0
     # via -r requirements.in
 psycopg2-binary==2.9.10
     # via -r requirements.in
+pyjwt==2.10.1
+    # via djangorestframework-simplejwt
 python-dateutil==2.9.0.post0
     # via
     #   django-recurrence


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR upgrades our current authentication system from `TokenAuthentication` to `JWTAuthentication` using `rest_framework_simpleJWT` module. I have set the `JWT_SETTINGS` mostly to defaults only changing a one of two here and there as the default seemed good enough.

Session GET View is working well but the same cannot be said for `POST` and `DELETE`. I will work on these in the coming days.

PS: A whole lot of files had to be changed because of the authentication getting changed, most of them being tests.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1375 
