### PR TITLE
Fix typos in documentation and urls.py

### DIFF
--- a/BACKEND_TESTING.md
+++ b/BACKEND_TESTING.md
@@ -6,7 +6,7 @@ This documentation details standards for writing pytest based backend testing fi
 
 ## **Contents**
 
-- [Standards](#standatds-)
+- [Standards](#standards-)
 
 <a id="standards-"></a>
 

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -73,7 +73,7 @@ urlpatterns = [
         name="swagger-ui-content",
     ),
     path(
-        "v1/schema/swagger-ui/enticommunitiesties/",
+        "v1/schema/swagger-ui/communities/",
         SpectacularSwaggerView.as_view(url_name="schema-communities"),
         name="swagger-ui-communities",
     ),


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

1. Fixed typo in `BACKEND_TESTING.md:9`: “Standards” was misspelled as “standatds” in the table of contents link.
2. Fixed typo in `backend/core/urls.py:76`: There was a typo in "v1/schema/swagger-ui/communities/".

### Related issue

None
