### PR TITLE
Remove hardcoded created_by UUID from create functions

### DIFF
--- a/frontend/pages/events/create.vue
+++ b/frontend/pages/events/create.vue
@@ -143,14 +143,13 @@
               />
             </div>
           </div>
-          <!-- TOOD: add events to CardTopicSelection -->
+          <!-- TODO: Add events to CardTopicSelection. -->
           <CardTopicSelection
             v-model="formData.topics"
             class="mt-5"
             pageType="event"
           />
           <div class="py-3"></div>
-          <!-- for spacing -->
           <div
             class="card-style mx-14 flex w-full justify-between gap-6 px-5 py-6"
           >
@@ -158,8 +157,7 @@
               <h3 for="roles" class="block font-medium">
                 {{ $t("i18n.pages.events.create.roles") }}*
               </h3>
-              <!-- TODO: replace this input with something that lets you make
-                roles and such -->
+              <!-- TODO: replace this input with something that lets you make roles. -->
               <input
                 v-model="formData.roles"
                 id="roles"
@@ -354,23 +352,21 @@ const eventTypeOptions = [
 
 const page = ref(0);
 
-// TODO: count the number of pages dynamically
-// or at least correct the hard coded value when needed
+// TODO: Count the number of pages dynamically.
 const pageCount = computed(() => 3);
 
 const hasNextPage = computed(() => page.value < pageCount.value - 1);
 const hasPreviousPage = computed(() => page.value > 0);
 
 function nextPage() {
-  // TODO: check validation before moving
+  // TODO: check validation before moving.
   if (hasNextPage.value) {
     page.value++;
   }
 }
 
 function previousPage() {
-  // TODO: check validation before moving
-  // may not be necessary for previous page move though
+  // TODO: Check validation before moving.
   if (hasPreviousPage.value) {
     page.value--;
   }
@@ -409,7 +405,5 @@ const submit = async () => {
       }),
     }
   );
-
-  // window.location.href = "/events";
 };
 </script>

--- a/frontend/pages/groups/create.vue
+++ b/frontend/pages/groups/create.vue
@@ -125,23 +125,24 @@ const formData = ref({
 });
 
 const submit = async () => {
+  // Note: created_by not included as the backend infers the user from the token.
   const payload: Record<string, unknown> = {
     name: formData.value.name,
     location: formData.value.location,
     tagline: formData.value.tagline,
     description: formData.value.description,
-    social_accounts: ["https://twitter.com/activist_hq"],
+    social_accounts: [],
     topics: formData.value.topics,
     high_risk: false,
     total_flags: 0,
   };
-  // Security: do not send created_by; backend should infer from authenticated request
+
   await useFetch(`${BASE_BACKEND_URL}/v1/communities/organizations`, {
     method: "POST",
     body: JSON.stringify(payload),
   });
 
-  //TODO: FEATURE - push notification with toast should be added here
+  //TODO: Push notification with toast should be added here
 
   window.location.href = "/organizations";
 };

--- a/frontend/pages/organizations/create.vue
+++ b/frontend/pages/organizations/create.vue
@@ -18,7 +18,6 @@
           {{ $t("i18n.pages.organizations.create.subtext") }}
         </p>
       </div>
-
       <Form
         @submit="submit"
         id="organization-create-form"
@@ -27,7 +26,7 @@
         class-button="mb-4"
         submit-label="i18n.pages.organizations.create.complete_application"
       >
-        <!-- First card: Name and Location -->
+        <!-- MARK: Name and Location -->
         <div class="card-style flex justify-between gap-6 px-5 py-6">
           <div class="w-1/2">
             <FormItem
@@ -50,7 +49,6 @@
               />
             </FormItem>
           </div>
-
           <div class="w-1/2">
             <FormItem
               v-slot="{ id, handleChange, handleBlur, errorMessage, value }"
@@ -71,8 +69,7 @@
             </FormItem>
           </div>
         </div>
-
-        <!-- Description card -->
+        <!-- MARK: Description -->
         <div class="card-style mt-5 px-5 py-6">
           <FormItem
             v-slot="{ id, handleChange, handleBlur, errorMessage }"
@@ -91,8 +88,7 @@
             />
           </FormItem>
         </div>
-
-        <!-- Tagline card -->
+        <!-- MARK: Tagline -->
         <div class="card-style mt-5 px-5 py-6">
           <FormItem
             v-slot="{ id, handleChange, handleBlur, errorMessage, value }"
@@ -109,8 +105,7 @@
             />
           </FormItem>
         </div>
-
-        <!-- Topics -->
+        <!-- MARK: Topics -->
         <div class="card-style mt-5 px-5 pb-6">
           <FormItem
             v-slot="{ id, handleChange, handleBlur, value }"
@@ -126,13 +121,11 @@
             />
           </FormItem>
         </div>
-
-        <!-- Connect organization -->
+        <!-- MARK: Connect -->
         <div class="mt-5">
           <CardConnectOrganization />
         </div>
-
-        <!-- Terms checkbox -->
+        <!-- MARK: Terms -->
         <div class="mt-5 flex flex-col">
           <div class="flex space-x-2">
             <FormCheckbox />

--- a/frontend/pages/resources/create.vue
+++ b/frontend/pages/resources/create.vue
@@ -126,23 +126,24 @@ const formData = ref({
 });
 
 const submit = async () => {
+  // Note: created_by not included as the backend infers the user from the token.
   const payload: Record<string, unknown> = {
     name: formData.value.name,
     location: formData.value.location,
     url: formData.value.link,
     description: formData.value.description,
-    social_accounts: ["https://twitter.com/activist_hq"],
+    social_accounts: [],
     topics: formData.value.topics,
     high_risk: false,
     total_flags: 0,
   };
-  // Security: do not send created_by; backend should infer from authenticated request
+
   await useFetch(`${BASE_BACKEND_URL}/v1/content/resources`, {
     method: "POST",
     body: JSON.stringify(payload),
   });
 
-  //TODO: FEATURE - push notification with toast should be added here
+  //TODO: Push notification with toast should be added here.
 
   window.location.href = "/resources";
 };

--- a/frontend/stores/event.ts
+++ b/frontend/stores/event.ts
@@ -74,6 +74,8 @@ export const useEventStore = defineStore("event", {
 
     async create(formData: EventCreateFormData) {
       this.loading = true;
+
+      // Note: created_by not included as the backend infers the user from the token.
       const payload: Record<string, unknown> = {
         name: formData.name,
         location: formData.location,
@@ -85,7 +87,6 @@ export const useEventStore = defineStore("event", {
         total_flags: 0,
         acceptance_date: new Date(),
       };
-      // Security: do not send created_by; backend should infer from authenticated request
 
       const responseEvent = await useFetch(
         `${BASE_BACKEND_URL}/events/events`,
@@ -473,6 +474,7 @@ export const useEventStore = defineStore("event", {
     async createResource(event: Event, formData: ResourceInput) {
       this.loading = true;
       const responses: boolean[] = [];
+
       const responseFaqEntries = await useFetch(
         `${BASE_BACKEND_URL}/events/event_resources`,
         {

--- a/frontend/stores/group.ts
+++ b/frontend/stores/group.ts
@@ -73,6 +73,8 @@ export const useGroupStore = defineStore("group", {
 
     async create(formData: GroupCreateFormData) {
       this.loading = true;
+
+      // Note: created_by not included as the backend infers the user from the token.
       const payload: Record<string, unknown> = {
         name: formData.name,
         location: formData.location,
@@ -84,7 +86,6 @@ export const useGroupStore = defineStore("group", {
         total_flags: 0,
         acceptance_date: new Date(),
       };
-      // Security: do not send created_by; backend should infer from authenticated request
 
       const responseGroup = await useFetch(
         `${BASE_BACKEND_URL}/communities/groups`,
@@ -271,6 +272,7 @@ export const useGroupStore = defineStore("group", {
     async createResource(group: Group, formData: ResourceInput) {
       this.loading = true;
       const responses: boolean[] = [];
+
       const responseFaqEntries = await useFetch(
         `${BASE_BACKEND_URL}/communities/group_resources`,
         {

--- a/frontend/stores/organization.ts
+++ b/frontend/stores/organization.ts
@@ -69,6 +69,8 @@ export const useOrganizationStore = defineStore("organization", {
 
     async create(formData: OrganizationCreateFormData) {
       this.loading = true;
+
+      // Note: created_by not included as the backend infers the user from the token.
       const payload: Record<string, unknown> = {
         name: formData.name,
         location: formData.location,
@@ -80,7 +82,6 @@ export const useOrganizationStore = defineStore("organization", {
         total_flags: 0,
         acceptance_date: new Date(),
       };
-      // Security: do not send created_by; backend should infer from authenticated request
 
       const responseOrg = await useFetch(
         `${BASE_BACKEND_URL}/communities/organizations`,
@@ -149,6 +150,7 @@ export const useOrganizationStore = defineStore("organization", {
     async createResource(organization: Organization, formData: ResourceInput) {
       this.loading = true;
       const responses: boolean[] = [];
+
       const responseFaqEntries = await useFetch(
         `${BASE_BACKEND_URL}/communities/organization_resources`,
         {


### PR DESCRIPTION
<!--- Thank you for your pull request! 🚀 -->
Contributor checklist
 This pull request is on a separate branch and not the main branch
 I have run the tests for the backend and frontend depending on what's needed for my changes as described in the testing section of the contributing guide
Description
Removes the hardcoded created_by UUID previously sent in entity create requests (events, groups, organizations, resources). The stores/pages now:

Derive the authenticated user id (if available) from auth/user state
Omit created_by when unauthenticated, allowing the backend to infer from the session/token
Prevent incorrect attribution and potential spoofing
Tested by:

Logging in and creating an event/group/org/resource: verified network payload includes my user id.
Logging out and attempting creation: request rejected (401) with no created_by in payload.
Confirmed created objects show correct creator in API/admin.
Related issue
#1500 