### PR TITLE
Test populate DB entities and content

### DIFF
--- a/backend/core/tests/test_populate_db_command.py
+++ b/backend/core/tests/test_populate_db_command.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Test to check the numbers of entities (groups, organizations and events) and content (faqs, resources and social links)
+created by the Command entity in the populate_db.py script.
+"""
+
+import pytest
+from django.core.management import call_command
+
+from authentication.models import UserModel
+from communities.groups.models import Group
+from communities.organizations.models import Organization
+from events.models import Event
+
+
+@pytest.mark.django_db
+def test_populate_db_command_basic():
+    """Test that the populate_db command creates the expected number of entities."""
+    call_command(
+        "populate_db", users=2, orgs_per_user=1, groups_per_org=1, events_per_org=1
+    )
+    assert UserModel.objects.count() == 2
+    assert Organization.objects.count() == 2
+    assert Group.objects.count() == 2
+    assert Event.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_populate_db_command_zero_users():
+    """Test that the populate_db command handles zero users correctly."""
+    call_command("populate_db", users=0)
+    assert UserModel.objects.count() == 0
+    assert Organization.objects.count() == 0
+    assert Group.objects.count() == 0
+    assert Event.objects.count() == 0

--- a/backend/core/tests/test_populate_db_command.py
+++ b/backend/core/tests/test_populate_db_command.py
@@ -8,28 +8,60 @@ import pytest
 from django.core.management import call_command
 
 from authentication.models import UserModel
-from communities.groups.models import Group
-from communities.organizations.models import Organization
-from events.models import Event
+from communities.groups.models import Group, GroupFaq, GroupResource, GroupSocialLink
+from communities.organizations.models import (
+    Organization,
+    OrganizationFaq,
+    OrganizationResource,
+    OrganizationSocialLink,
+)
+from events.models import Event, EventFaq, EventResource, EventSocialLink
 
 
 @pytest.mark.django_db
 def test_populate_db_command_basic():
-    """Test that the populate_db command creates the expected number of entities."""
+    """Test that the populate_db command creates the expected number of entities and content."""
     call_command(
-        "populate_db", users=2, orgs_per_user=1, groups_per_org=1, events_per_org=1
+        "populate_db", users=2, orgs_per_user=1, groups_per_org=1, events_per_org=1, resources_per_entity=1, faq_entries_per_entity=1
     )
     assert UserModel.objects.count() == 2
+    # check number of entities
     assert Organization.objects.count() == 2
     assert Group.objects.count() == 2
     assert Event.objects.count() == 2
-
+    # check number of contents
+    # resources
+    assert OrganizationResource.objects.count() == 6
+    assert EventResource.objects.count() == 6
+    assert GroupResource.objects.count() == 6
+    # FAQ
+    assert OrganizationFaq.objects.count() == 6
+    assert EventFaq.objects.count() == 6
+    assert GroupFaq.objects.count() == 6
+    # social links
+    assert OrganizationSocialLink.objects.count() == 6
+    assert GroupSocialLink.objects.count() == 6
+    assert EventSocialLink.objects.count() == 6
 
 @pytest.mark.django_db
 def test_populate_db_command_zero_users():
     """Test that the populate_db command handles zero users correctly."""
     call_command("populate_db", users=0)
     assert UserModel.objects.count() == 0
+    # check number of entities
     assert Organization.objects.count() == 0
     assert Group.objects.count() == 0
     assert Event.objects.count() == 0
+    # check number of contents
+    # resources
+    assert OrganizationResource.objects.count() == 0
+    assert EventResource.objects.count() == 0
+    assert GroupResource.objects.count() == 0
+    # FAQ
+    assert OrganizationFaq.objects.count() == 0
+    assert EventFaq.objects.count() == 0
+    assert GroupFaq.objects.count() == 0
+    # social links
+    assert OrganizationSocialLink.objects.count() == 0
+    assert GroupSocialLink.objects.count() == 0
+    assert EventSocialLink.objects.count() == 0


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [test-populate-db-entities-content](https://github.com/alessandromontanari/activist/tree/test-populate-db-entities-content) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

I created the test for the open issue [#1484](https://github.com/activist-org/activist/issues/1484).  The test uses the django call_command to run the factories to generate test data for working on activist with the `backend/core/management/commands/populate_db.py` file. Then it verifies the number of entities (groups, organisations and events) and content (FAQs, resources and social links) that are created. I could not run tests for the backend because it seems I have problem with my local installation of activities when running the docker containers.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1484
