### PR TITLE
fix: resolve search bar focus and input field conflicts with '/' key

### DIFF
--- a/frontend/components/SearchBar.vue
+++ b/frontend/components/SearchBar.vue
@@ -24,6 +24,7 @@
             @focus="onFocus"
             @blur="onFocusLost"
             @input="handleChange"
+            ref="input"
             id="input-search"
             :value="localValue"
             class="h-5 w-16 bg-transparent outline-none"
@@ -135,7 +136,10 @@ const activeElement = useActiveElement();
 const hotkeyIndicators = ref();
 const isInputFocused = ref(false);
 const notUsingEditor = computed(
-  () => !activeElement.value?.classList?.contains("tiptap")
+  () =>
+    !activeElement.value?.classList?.contains("tiptap") &&
+    activeElement.value?.tagName !== "INPUT" &&
+    activeElement.value?.tagName !== "TEXTAREA"
 );
 
 const { slash } = useMagicKeys({
@@ -144,7 +148,9 @@ const { slash } = useMagicKeys({
     if (
       e.key === "/" &&
       e.type === "keydown" &&
-      !activeElement.value?.classList?.contains("tiptap")
+      !activeElement.value?.classList?.contains("tiptap") &&
+      activeElement.value?.tagName !== "INPUT" &&
+      activeElement.value?.tagName !== "TEXTAREA"
     )
       e.preventDefault();
   },


### PR DESCRIPTION
I tested this fix and it seems to work. Needs to be double-checked and reviewed.

- Add missing ref=input to search input element to enable focus functionality
- Prevent '/' key interception when typing in INPUT and TEXTAREA elements
- Update notUsingEditor logic to exclude form fields from search shortcuts
- Fixes issue where '/' could not be typed in form fields and search bar wouldn't focus

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER: https://github.com/activist-org/activist/issues/1529
