### PR TITLE
fix(accessibility): use :aria-label attribute for native HTML buttons

### DIFF
--- a/frontend/components/sidebar/left/content/SidebarLeftContentEvent.vue
+++ b/frontend/components/sidebar/left/content/SidebarLeftContentEvent.vue
@@ -31,7 +31,9 @@
         "
         @click="openModal()"
         class="focus-brand absolute bottom-1 right-1 z-10 flex rounded-md border border-black/80 bg-white/80 p-1 text-black/80 dark:border-white/80 dark:bg-black/80 dark:text-white/80"
-        ariaLabel="i18n.components.sidebar_left_content_event.edit_aria_label"
+        :aria-label="
+          $t('i18n.components.sidebar_left_content_event.edit_aria_label')
+        "
       >
         <Icon :name="IconMap.EDIT" size="1em" />
       </button>

--- a/frontend/components/sidebar/left/content/SidebarLeftContentGroupPage.vue
+++ b/frontend/components/sidebar/left/content/SidebarLeftContentGroupPage.vue
@@ -26,7 +26,9 @@
         "
         @click="openModalUploadImage()"
         class="focus-brand absolute bottom-1 right-1 z-10 flex rounded-md border border-black/80 bg-white/80 p-1 text-black/80 dark:border-white/80 dark:bg-black/80 dark:text-white/80"
-        ariaLabel="i18n.components.sidebar_left_content_group_page.edit_aria_label"
+        :aria-label="
+          $t('i18n.components.sidebar_left_content_group_page.edit_aria_label')
+        "
       >
         <Icon :name="IconMap.EDIT" size="1em" />
       </button>

--- a/frontend/components/sidebar/left/content/SidebarLeftContentOrganization.vue
+++ b/frontend/components/sidebar/left/content/SidebarLeftContentOrganization.vue
@@ -31,7 +31,11 @@
         "
         @click="openModal()"
         class="focus-brand absolute bottom-1 right-1 z-10 flex rounded-md border border-black/80 bg-white/80 p-1 text-black/80 dark:border-white/80 dark:bg-black/80 dark:text-white/80"
-        ariaLabel="i18n.components.sidebar_left_content_organization.edit_aria_label"
+        :aria-label="
+          $t(
+            'i18n.components.sidebar_left_content_organization.edit_aria_label'
+          )
+        "
       >
         <Icon :name="IconMap.EDIT" size="1em" />
       </button>


### PR DESCRIPTION
- Replace ariaLabel prop with :aria-label attribute on native <button> elements
- Use $t() function to translate i18n keys for proper screen reader support
- Fix 3 sidebar components: Organization, GroupPage, and Event
- Ensures screen readers receive translated text instead of literal i18n keys

Components fixed:
- SidebarLeftContentOrganization.vue
- SidebarLeftContentGroupPage.vue
- SidebarLeftContentEvent.vue

Example of change:

```vue
      <button
        v-if="
          showButton &&
          (sidebar.collapsed == false || sidebar.collapsedSwitch == false)
        "
        @click="openModal()"
        class="focus-brand absolute bottom-1 right-1 z-10 flex rounded-md border border-black/80 bg-white/80 p-1 text-black/80 dark:border-white/80 dark:bg-black/80 dark:text-white/80"
        ariaLabel="i18n.components.sidebar_left_content_organization.edit_aria_label"
      >
```

to 

```vue
      <button
        v-if="
          showButton &&
          (sidebar.collapsed == false || sidebar.collapsedSwitch == false)
        "
        @click="openModal()"
        class="focus-brand absolute bottom-1 right-1 z-10 flex rounded-md border border-black/80 bg-white/80 p-1 text-black/80 dark:border-white/80 dark:bg-black/80 dark:text-white/80"
        :aria-label="
          $t(
            'i18n.components.sidebar_left_content_organization.edit_aria_label'
          )
        "
      >
        <Icon :name="IconMap.EDIT" size="1em" />
      </button>
```

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

The HTML was displaying the literal key in the aria-label value, e.g.

```html
<button class="focus-brand absolute bottom-1 right-1 z-10 flex rounded-md border border-black/80 bg-white/80 p-1 text-black/80 dark:border-white/80 dark:bg-black/80 dark:text-white/80" aria-label="i18n.components.sidebar_left_content_organization.edit_aria_label">...</button>
```

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- https://github.com/activist-org/activist/issues/1537
