### PR TITLE
Fix/html lang attribute accessibility

### DIFF
--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -24,7 +24,6 @@ useHead({
   titleTemplate: (titleChunk: string | undefined) => {
     return titleChunk ? `${titleChunk} • activist` : "activist";
   },
-  // lang attribute is managed by i18n-head plugin
 });
 
 // Handle ctrl / meta keystrokes to open modal.

--- a/frontend/app.vue
+++ b/frontend/app.vue
@@ -24,10 +24,7 @@ useHead({
   titleTemplate: (titleChunk: string | undefined) => {
     return titleChunk ? `${titleChunk} • activist` : "activist";
   },
-  // Default to English, will be updated by i18n-head plugin.
-  htmlAttrs: {
-    lang: "en",
-  },
+  // lang attribute is managed by i18n-head plugin
 });
 
 // Handle ctrl / meta keystrokes to open modal.

--- a/frontend/components/dropdown/DropdownLanguage.vue
+++ b/frontend/components/dropdown/DropdownLanguage.vue
@@ -58,7 +58,7 @@ const availableLocales = computed(() => {
   return localesValues.filter((i) => getLocaleCode(i) !== locale.value);
 });
 
-// Function to update HTML lang attribute immediately
+// Function to update HTML lang attribute immediately.
 const updateLangAttribute = (newLocale: string) => {
   if (import.meta.client) {
     document.documentElement.setAttribute("lang", newLocale);

--- a/frontend/components/dropdown/DropdownLanguage.vue
+++ b/frontend/components/dropdown/DropdownLanguage.vue
@@ -60,8 +60,15 @@ const availableLocales = computed(() => {
 
 // Function to update HTML lang attribute immediately
 const updateLangAttribute = (newLocale: string) => {
+  // eslint-disable-next-line no-console
+  console.log("Dropdown: updateLangAttribute called with:", newLocale);
   if (import.meta.client) {
     document.documentElement.setAttribute("lang", newLocale);
+    // eslint-disable-next-line no-console
+    console.log(
+      "Dropdown: lang attribute set to:",
+      document.documentElement.getAttribute("lang")
+    );
   }
 };
 </script>

--- a/frontend/components/dropdown/DropdownLanguage.vue
+++ b/frontend/components/dropdown/DropdownLanguage.vue
@@ -11,6 +11,7 @@
     <ul class="px-2 py-2">
       <NuxtLink
         v-for="l in availableLocales"
+        @click="updateLangAttribute(getLocaleCode(l))"
         :key="getLocaleCode(l)"
         class="dropdown-language-list-items"
         :to="switchLocalePath(getLocaleCode(l))"
@@ -56,4 +57,11 @@ function getLocaleName(locale: LocaleObject) {
 const availableLocales = computed(() => {
   return localesValues.filter((i) => getLocaleCode(i) !== locale.value);
 });
+
+// Function to update HTML lang attribute immediately
+const updateLangAttribute = (newLocale: string) => {
+  if (import.meta.client) {
+    document.documentElement.setAttribute("lang", newLocale);
+  }
+};
 </script>

--- a/frontend/components/dropdown/DropdownLanguage.vue
+++ b/frontend/components/dropdown/DropdownLanguage.vue
@@ -60,15 +60,8 @@ const availableLocales = computed(() => {
 
 // Function to update HTML lang attribute immediately
 const updateLangAttribute = (newLocale: string) => {
-  // eslint-disable-next-line no-console
-  console.log("Dropdown: updateLangAttribute called with:", newLocale);
   if (import.meta.client) {
     document.documentElement.setAttribute("lang", newLocale);
-    // eslint-disable-next-line no-console
-    console.log(
-      "Dropdown: lang attribute set to:",
-      document.documentElement.getAttribute("lang")
-    );
   }
 };
 </script>

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,20 +1,24 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import prettier from "eslint-config-prettier";
 import perfectionist from "eslint-plugin-perfectionist";
+import vue from "eslint-plugin-vue";
 import vueA11y from "eslint-plugin-vuejs-accessibility";
 import withNuxt from "./.nuxt/eslint.config.mjs";
 
 // Note: flat/strongly-recommended and flat/recommended are also options.
-export default withNuxt({
+export default withNuxt(...vue.configs["flat/essential"], {
   files: ["**/*.js", "**/*.ts", "**/*.vue"],
 
   plugins: {
+    vue,
     "vuejs-accessibility": vueA11y,
     perfectionist,
     prettier,
   },
 
   rules: {
+    ...vue.configs.recommended.rules,
+
     "no-console": "error",
     "valid-v-for": "off",
     "vue/attribute-hyphenation": [

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -15,7 +15,6 @@ export default withNuxt({
   },
 
   rules: {
-
     "no-console": "error",
     "valid-v-for": "off",
     "vue/attribute-hyphenation": [

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,23 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import prettier from "eslint-config-prettier";
 import perfectionist from "eslint-plugin-perfectionist";
-import vue from "eslint-plugin-vue";
 import vueA11y from "eslint-plugin-vuejs-accessibility";
 import withNuxt from "./.nuxt/eslint.config.mjs";
 
 // Note: flat/strongly-recommended and flat/recommended are also options.
-export default withNuxt(...vue.configs["flat/essential"], {
+export default withNuxt({
   files: ["**/*.js", "**/*.ts", "**/*.vue"],
 
   plugins: {
-    vue,
     "vuejs-accessibility": vueA11y,
     perfectionist,
     prettier,
   },
 
   rules: {
-    ...vue.configs.recommended.rules,
 
     "no-console": "error",
     "valid-v-for": "off",

--- a/frontend/layouts/Auth.vue
+++ b/frontend/layouts/Auth.vue
@@ -5,7 +5,6 @@
   <div class="grid h-screen grid-cols-1 md:grid-cols-2">
     <Head>
       <Title>{{ $t(page.title) }}</Title>
-      <Html :lang="$i18n.locale || 'en'" />
     </Head>
     <div v-if="aboveMediumBP" class="relative">
       <div class="flex h-full w-full items-center justify-center">

--- a/frontend/plugins/i18n-head.ts
+++ b/frontend/plugins/i18n-head.ts
@@ -26,12 +26,19 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   // Update on i18n locale changes (for immediate updates when switching languages).
   if ($i18n) {
+    // eslint-disable-next-line no-console
+    console.log("Setting up i18n watcher, current locale:", $i18n.locale.value);
     watch(
       () => $i18n.locale.value,
       (newLocale) => {
+        // eslint-disable-next-line no-console
+        console.log("i18n locale changed to:", newLocale);
         setLangAttribute(newLocale);
       },
       { immediate: false }
     );
+  } else {
+    // eslint-disable-next-line no-console
+    console.log("$i18n not available in plugin");
   }
 });

--- a/frontend/plugins/i18n-head.ts
+++ b/frontend/plugins/i18n-head.ts
@@ -4,7 +4,7 @@ import type { Router } from "#vue-router";
 // Injects the lang attribute in all Nuxt <Head></Head> components.
 export default defineNuxtPlugin((nuxtApp) => {
   const router: Router = nuxtApp.vueApp.config.globalProperties.$router;
-  const { $i18n } = nuxtApp;
+  const $i18n = nuxtApp.$i18n as { locale: { value: string } };
 
   // Set initial lang attribute.
   const setLangAttribute = (locale: string) => {

--- a/frontend/plugins/i18n-head.ts
+++ b/frontend/plugins/i18n-head.ts
@@ -10,41 +10,8 @@ export default defineNuxtPlugin((nuxtApp) => {
   const setLangAttribute = (locale: string) => {
     if (import.meta.client) {
       document.documentElement.setAttribute("lang", locale);
-      // eslint-disable-next-line no-console
-      console.log(
-        "setLangAttribute: lang set to:",
-        document.documentElement.getAttribute("lang")
-      );
     }
   };
-
-  // Monitor for any changes to the lang attribute
-  if (import.meta.client) {
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((mutation) => {
-        if (
-          mutation.type === "attributes" &&
-          mutation.attributeName === "lang"
-        ) {
-          // eslint-disable-next-line no-console
-          console.log(
-            "Lang attribute changed by:",
-            mutation.target,
-            "New value:",
-            (mutation.target as Element).getAttribute("lang")
-          );
-          // Log stack trace to see what's changing it
-          // eslint-disable-next-line no-console
-          console.trace("Stack trace of lang attribute change");
-        }
-      });
-    });
-
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["lang"],
-    });
-  }
 
   // Set initial locale from i18n or default to 'en'.
   const initialLocale = $i18n?.locale?.value || "en";
@@ -54,26 +21,17 @@ export default defineNuxtPlugin((nuxtApp) => {
   router.afterEach((to) => {
     // Get the locale from the route params or from i18n instance.
     const locale = (to.params.locale as string) || $i18n?.locale?.value || "en";
-    // eslint-disable-next-line no-console
-    console.log("Route change: setting lang to:", locale);
     setLangAttribute(locale);
   });
 
   // Update on i18n locale changes (for immediate updates when switching languages).
   if ($i18n) {
-    // eslint-disable-next-line no-console
-    console.log("Setting up i18n watcher, current locale:", $i18n.locale.value);
     watch(
       () => $i18n.locale.value,
       (newLocale) => {
-        // eslint-disable-next-line no-console
-        console.log("i18n locale changed to:", newLocale);
         setLangAttribute(newLocale);
       },
       { immediate: false }
     );
-  } else {
-    // eslint-disable-next-line no-console
-    console.log("$i18n not available in plugin");
   }
 });

--- a/frontend/plugins/i18n-head.ts
+++ b/frontend/plugins/i18n-head.ts
@@ -24,8 +24,8 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   // Update on route changes.
   router.afterEach((to) => {
-    // Get the locale from the route params or default to 'en'.
-    const locale = (to.params.locale as string) || "en";
+    // Get the locale from the route params or from i18n instance.
+    const locale = (to.params.locale as string) || $i18n?.locale?.value || "en";
     // eslint-disable-next-line no-console
     console.log("Route change: setting lang to:", locale);
     setLangAttribute(locale);

--- a/frontend/plugins/i18n-head.ts
+++ b/frontend/plugins/i18n-head.ts
@@ -4,14 +4,18 @@ import type { Router } from "#vue-router";
 // Injects the lang attribute in all Nuxt <Head></Head> components.
 export default defineNuxtPlugin((nuxtApp) => {
   const router: Router = nuxtApp.vueApp.config.globalProperties.$router;
+  const { $i18n } = nuxtApp;
 
   // Set initial lang attribute.
   const setLangAttribute = (locale: string) => {
-    document.documentElement.setAttribute("lang", locale);
+    if (import.meta.client) {
+      document.documentElement.setAttribute("lang", locale);
+    }
   };
 
-  // Set initial locale - default to 'en' if i18n is not available.
-  setLangAttribute("en");
+  // Set initial locale from i18n or default to 'en'.
+  const initialLocale = $i18n?.locale?.value || "en";
+  setLangAttribute(initialLocale);
 
   // Update on route changes.
   router.afterEach((to) => {
@@ -19,4 +23,15 @@ export default defineNuxtPlugin((nuxtApp) => {
     const locale = (to.params.locale as string) || "en";
     setLangAttribute(locale);
   });
+
+  // Update on i18n locale changes (for immediate updates when switching languages).
+  if ($i18n) {
+    watch(
+      () => $i18n.locale.value,
+      (newLocale) => {
+        setLangAttribute(newLocale);
+      },
+      { immediate: false }
+    );
+  }
 });

--- a/frontend/plugins/i18n-head.ts
+++ b/frontend/plugins/i18n-head.ts
@@ -10,6 +10,11 @@ export default defineNuxtPlugin((nuxtApp) => {
   const setLangAttribute = (locale: string) => {
     if (import.meta.client) {
       document.documentElement.setAttribute("lang", locale);
+      // eslint-disable-next-line no-console
+      console.log(
+        "setLangAttribute: lang set to:",
+        document.documentElement.getAttribute("lang")
+      );
     }
   };
 
@@ -21,6 +26,8 @@ export default defineNuxtPlugin((nuxtApp) => {
   router.afterEach((to) => {
     // Get the locale from the route params or default to 'en'.
     const locale = (to.params.locale as string) || "en";
+    // eslint-disable-next-line no-console
+    console.log("Route change: setting lang to:", locale);
     setLangAttribute(locale);
   });
 

--- a/frontend/plugins/i18n-head.ts
+++ b/frontend/plugins/i18n-head.ts
@@ -18,6 +18,34 @@ export default defineNuxtPlugin((nuxtApp) => {
     }
   };
 
+  // Monitor for any changes to the lang attribute
+  if (import.meta.client) {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (
+          mutation.type === "attributes" &&
+          mutation.attributeName === "lang"
+        ) {
+          // eslint-disable-next-line no-console
+          console.log(
+            "Lang attribute changed by:",
+            mutation.target,
+            "New value:",
+            (mutation.target as Element).getAttribute("lang")
+          );
+          // Log stack trace to see what's changing it
+          // eslint-disable-next-line no-console
+          console.trace("Stack trace of lang attribute change");
+        }
+      });
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["lang"],
+    });
+  }
+
   // Set initial locale from i18n or default to 'en'.
   const initialLocale = $i18n?.locale?.value || "en";
   setLangAttribute(initialLocale);


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description
This fixes the 'lang' attribute accessibility error and also udpates the lang value based on the user switching languages from the dropdown.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- 
