### PR TITLE
fixed issue

### DIFF
--- a/frontend/app/components/menu/mobile/MenuMobileNavigationDropdown.vue
+++ b/frontend/app/components/menu/mobile/MenuMobileNavigationDropdown.vue
@@ -149,10 +149,13 @@ const handleItemClick = (menuEntry: MenuEntry) => {
 };
 
 watchEffect(() => {
-  selectedMenuItem.value = useRouter().currentRoute.value.fullPath.includes(
-    "/organizations/"
-  )
-    ? menuEntryState.organizationEntry.value.find((e) => e.selected)
-    : menuEntryState.eventEntry.value.find((e) => e.selected);
+  const currentPath = useRouter().currentRoute.value.fullPath;
+  if (currentPath.includes("/organizations/")) {
+    selectedMenuItem.value = menuEntryState.organizationEntry.value.find((e) => e.selected);
+  } else if (currentPath.includes("/events/")) {
+    selectedMenuItem.value = menuEntryState.eventEntry.value.find((e) => e.selected);
+  } else {
+    selectedMenuItem.value = undefined;
+  }
 });
 </script>

--- a/frontend/app/composables/useMenuEntriesState.ts
+++ b/frontend/app/composables/useMenuEntriesState.ts
@@ -95,7 +95,9 @@ const useMenuEntriesState = () => {
 
     const buttons = currentPath.value.includes("/organizations/")
       ? organizationEntries
-      : eventEntries;
+      : currentPath.value.includes("/events/")
+      ? eventEntries
+      : organizationEntries; // fallback to organization entries
 
     // Update the id and routeUrl for each button based on current route params.
     const currentId = (router.currentRoute.value.params.groupId ||


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)


### Description

This PR fixes the missing mobile navigation dropdown on event pages. Currently, when users view event subpages (e.g., /events/[eventId]/about) on mobile devices, they have no way to navigate between different event sections (About, Team, Resources, FAQ, Tasks, Discussion, Settings) because the navigation dropdown is completely missing.
Changes Made
MenuMobileNavigationDropdown.vue - Updated the watchEffect to properly detect event pages and show the appropriate menu entries
useMenuEntriesState.ts - Updated the updateCurrentPath function to handle event paths when determining which menu entries to use



- #1626
