### PR TITLE
bugfix: fixed the button highlight based on url-route

### DIFF
--- a/frontend/app/composables/useMenuEntriesState.ts
+++ b/frontend/app/composables/useMenuEntriesState.ts
@@ -25,7 +25,7 @@ const createMenuEntry = (label: string, basePath: string, iconUrl: string) => {
 
 const useMenuEntriesState = () => {
   const router = useRouter();
-  const { locale } = useI18n(); // Move useI18n to top level
+  const { locale } = useI18n(); // move useI18n to top level
   const currentPath = ref(router.currentRoute.value.fullPath);
   let removeGuard: (() => void) | null = null;
 
@@ -118,33 +118,20 @@ const useMenuEntriesState = () => {
           button.selected = false;
         }
       } else {
-        // Extract the last segment from the current route path
-        const currentRoutePath = router.currentRoute.value.path;
-        const pathSegments = currentRoutePath
-          .split("/")
-          .filter((seg) => seg.length > 0);
-        const currentPageName = pathSegments[pathSegments.length - 1];
-
-        // Extract the page name from the button label
-        const buttonPageName = button.label.split(".").pop()!.toLowerCase();
-
-        // Match by comparing the page names
-        button.selected = currentPageName === buttonPageName;
+        button.selected = currentPath.value.endsWith(
+          button.routeUrl.split("/").pop()!
+        );
       }
     }
   };
 
-  // Call updateCurrentPath immediately to set initial selected state.
-  // This ensures selectedMenuItem is set before components try to access it.
-  updateCurrentPath();
-
-  // Watch for route changes to update menu selection
+  // Watch for route changes to update menu selection and set initial state.
   watch(
     () => router.currentRoute.value.path,
     () => {
       updateCurrentPath();
     },
-    { immediate: false }
+    { immediate: true }
   );
 
   onMounted(() => {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
- Fixed the `updateCurrentPath` function so that the correct button is highlighted in the side bar of an organisation's page
- Added a watcher to make sure that we don't have to reload the page to update the highlight to another button if we've changed the we are in section

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1620 
