### PR TITLE
"bugfix: added logic to convert active_on back to day value "

### DIFF
--- a/frontend/app/components/sidebar/left/filter/SidebarLeftFilterEvents.vue
+++ b/frontend/app/components/sidebar/left/filter/SidebarLeftFilterEvents.vue
@@ -268,9 +268,11 @@ watch(
   (form) => {
     const queryData = { ...(form.query as Record<string, unknown>) };
     const { view, ...rest } = queryData;
-    
-    if (typeof view === "string" &&
-        Object.values(ViewType).includes(view as ViewType)) {
+
+    if (
+      typeof view === "string" &&
+      Object.values(ViewType).includes(view as ViewType)
+    ) {
       viewType.value = view as ViewType;
     } else {
       viewType.value = ViewType.MAP;


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
- the `days ahead` value was being received as `active_on` in the url
- but then it wasn't being read back as `day` when refreshed
- added logic to do the reverse conversion

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #1623 
