### PR TITLE
fix/test: Fix bugs and add MC/DC test coverage to EventResourceViewSet.update

### DIFF
--- a/backend/events/tests/resource/test_resource_viewset.py
+++ b/backend/events/tests/resource/test_resource_viewset.py
@@ -1,0 +1,65 @@
+from uuid import uuid4
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from authentication.factories import UserFactory
+from events.factories import EventFactory, EventResourceFactory
+
+
+class TestEventResourceUpdate(APITestCase):
+    def setUp(self) -> None:
+        self.event_creator = UserFactory(is_staff=False)
+
+        self.staff_user = UserFactory(is_staff=True)
+
+        self.other_user = UserFactory(is_staff=False)
+
+        self.event = EventFactory(created_by=self.event_creator)
+        self.resource = EventResourceFactory(event=self.event, name="Origin Resource")
+
+        self.update_url = f"/v1/events/event_resources/{self.resource.id}"
+
+        self.valid_data = {"name": "New Resource Name"}
+
+    def test_update_resource_not_found(self):
+        invalid_uuid = uuid4()
+
+        url = f"/v1/events/event_resources/{invalid_uuid}"
+
+        self.client.force_authenticate(user=self.staff_user)
+
+        response = self.client.patch(url, self.valid_data)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_resource_by_creator_is_allowed(self):
+        self.client.force_authenticate(user=self.event_creator)
+
+        response = self.client.patch(self.update_url, self.valid_data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.resource.refresh_from_db()
+        self.assertEqual(self.resource.name, "New Resource Name")
+
+    def test_update_resource_by_staff_is_allowed(self):
+        self.client.force_authenticate(user=self.staff_user)
+
+        response = self.client.patch(self.update_url, self.valid_data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.resource.refresh_from_db()
+
+        self.assertEqual(self.resource.name, "New Resource Name")
+
+    def test_update_resource_by_other_user_is_forbidden(self):
+        self.client.force_authenticate(user=self.other_user)
+
+        response = self.client.patch(self.update_url, self.valid_data)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.resource.refresh_from_db()
+        self.assertEqual(self.resource.name, "Origin Resource")

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -414,7 +414,9 @@ class EventResourceViewSet(viewsets.ModelViewSet[EventResource]):
             status=status.HTTP_201_CREATED,
         )
 
-    def update(self, request: Request, pk: UUID | str) -> Response:
+    def update(
+        self, request: Request, pk: UUID | str, *args: Any, **kwargs: Any
+    ) -> Response:
         try:
             faq = EventResource.objects.get(id=pk)
 
@@ -430,7 +432,9 @@ class EventResourceViewSet(viewsets.ModelViewSet[EventResource]):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        serializer = self.get_serializer(faq, data=request.data, partial=True)
+        serializer = self.get_serializer(
+            faq, data=request.data, partial=kwargs.get("partial", False)
+        )
         serializer.is_valid(raise_exception=True)
         serializer.save()
 


### PR DESCRIPTION
- Create test_resource_viewset.py file
- Modify the view to include new filters

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

Hello!

This PR addresses an issue where the `EventResourceViewSet.update` method had 0% test coverage. While writing tests for issue #1639, I also discovered and fixed two critical bugs that prevented the method from working.

This work was done as part of a university assignment on software testing, focusing on applying MC/DC (Modified Condition/Decision Coverage).

### The Problem

1.  **Missing Coverage:** The coverage report showed that the entire `update` method in `EventResourceViewSet` was untested (`Missing: 396-412`).
2.  **`TypeError` Bug:** The method was missing `*args, **kwargs` in its signature. This caused it to crash with a `TypeError` on all `PATCH` requests, as it could not accept the `partial=True` argument sent by DRF.
of `resource`, which would have caused an `AttributeError` after fixing the first bug.

### The Solution

1.  **Bug Fixes (in `events/views.py`):**
    * Corrected the `update` method's signature to `update(self, request: Request, pk: UUID | str, *args: Any, **kwargs: Any) -> Response:`.
    * Ensured the serializer call correctly uses `partial=kwargs.get("partial", False)`.

2.  **New Tests (in `events/tests/resource/test_resource_viewset.py`):**
    * Added a new test class `TestEventResourceUpdate` with 4 new tests to provide full MC/DC coverage for the method's logic:
        * `test_update_resource_not_found` (CT1: 404 Not Found)
        * `test_update_resource_by_other_user_is_forbidden` (CT4: 403 Forbidden - non-creator, non-staff)
        * `test_update_resource_by_creator_is_allowed` (CT2: 200 OK - creator, non-staff)
        * `test_update_resource_by_staff_is_allowed` (CT3: 200 OK - staff, non-creator)

All new and existing tests are now passing, along with all `mypy` and `ruff` checks.

Thank you for your review!

---

### Related issue

- Fixes #1639