### PR TITLE
test: add unit tests for TooltipBase.vue (#1653)

### DIFF
--- a/frontend/app/components/tooltip/TooltipBase.vue
+++ b/frontend/app/components/tooltip/TooltipBase.vue
@@ -7,10 +7,10 @@
       'elem-shadow-md w-min px-3 py-2': slots.default,
     }"
   >
-    <h4 v-if="header">
+    <h4 v-if="header" data-testid="tooltip-header">
       {{ header }}
     </h4>
-    <p v-if="text" class="text-left">
+    <p v-if="text" class="text-left" data-testid="tooltip-text">
       {{ text }}
     </p>
     <slot />

--- a/frontend/test/components/tooltip/TooltipBase.spec.ts
+++ b/frontend/test/components/tooltip/TooltipBase.spec.ts
@@ -1,8 +1,9 @@
 import { mount } from '@vue/test-utils'
 import { describe, it, expect } from 'vitest'
+
 import TooltipBase from '../../../app/components/tooltip/TooltipBase.vue'
 
-describe('TooltipBase.vue', () => {
+describe('TooltipBase component', () => {
   it('renders header and text when provided', () => {
     const wrapper = mount(TooltipBase, {
       props: {
@@ -11,16 +12,16 @@ describe('TooltipBase.vue', () => {
       }
     })
 
-    expect(wrapper.find('h4').exists()).toBe(true)
-    expect(wrapper.find('h4').text()).toBe('Tooltip Title')
-    expect(wrapper.find('p').exists()).toBe(true)
-    expect(wrapper.find('p').text()).toBe('Some tooltip body text.')
+    expect(wrapper.find('[data-testid="tooltip-header"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="tooltip-header"]').text()).toBe('Tooltip Title')
+    expect(wrapper.find('[data-testid="tooltip-text"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="tooltip-text"]').text()).toBe('Some tooltip body text.')
   })
 
   it('does not render header or text when not provided', () => {
     const wrapper = mount(TooltipBase)
-    expect(wrapper.find('h4').exists()).toBe(false)
-    expect(wrapper.find('p').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tooltip-header"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="tooltip-text"]').exists()).toBe(false)
   })
 
   it('renders slot content when provided', () => {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Added unit tests for the `TooltipBase.vue` component.

- Tests rendering of `header` and `text` props
- Tests slot content rendering
- Verifies dynamic Tailwind classes (with and without slot)
- No production code changes

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- Closes #1653