### PR TITLE
fix: move coverage directory to frontend root

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,1 +1,2 @@
 tsconfig.playwright.tsbuildinfo
+coverage/

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -1,5 +1,10 @@
 // https://nuxt.com/docs/getting-started/testing
 import { defineVitestConfig } from "@nuxt/test-utils/config";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export default defineVitestConfig({
   test: {
@@ -19,7 +24,7 @@ export default defineVitestConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],
-      reportsDirectory: "./app/coverage",
+      reportsDirectory: resolve(__dirname, "coverage"),
       thresholds: {
         statements: 5,
         branches: 5,


### PR DESCRIPTION
- Update vitest.config.mts to use absolute path for coverage reports
- Add coverage/ to .gitignore
- Prevents coverage from being generated in app/coverage nested directory
- Coverage now generates at frontend/coverage/ as expected

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- N/A
