### PR TITLE
fix: remove duplicate organization-faq-list test ID from draggable component

### DIFF
--- a/frontend/app/pages/organizations/[orgId]/faq.vue
+++ b/frontend/app/pages/organizations/[orgId]/faq.vue
@@ -29,7 +29,6 @@
         :animation="150"
         chosen-class="sortable-chosen"
         class="space-y-4"
-        data-testid="organization-faq-list"
         :delay="0"
         :delay-on-touch-start="false"
         direction="vertical"


### PR DESCRIPTION

Removes duplicate data-testid attribute from draggable component in organization FAQ page to fix Playwright strict mode violation in E2E tests.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes https://github.com/activist-org/activist/issues/1742
