### PR TITLE
fix: use correct route parameter for groupId in FAQ page

### DIFF
--- a/frontend/app/pages/organizations/[orgId]/groups/[groupId]/faq.vue
+++ b/frontend/app/pages/organizations/[orgId]/groups/[groupId]/faq.vue
@@ -67,7 +67,7 @@ const groupTabs = useGetGroupTabs();
 
 const { openModal } = useModalHandlers("ModalFaqEntryGroup");
 
-const paramsGroupId = useRoute().params.eventId;
+const paramsGroupId = useRoute().params.groupId;
 const groupId = typeof paramsGroupId === "string" ? paramsGroupId : "";
 
 const { data: group } = useGetGroup(groupId);


### PR DESCRIPTION
Fixes FAQ creation by using params.groupId instead of params.eventId. This was causing groupId to be empty, preventing FAQ creation from working.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- closes #1747
