### PR TITLE
feat: add alphabetical sorting to topics combobox

### DIFF
--- a/frontend/app/components/combobox/ComboboxTopics.vue
+++ b/frontend/app/components/combobox/ComboboxTopics.vue
@@ -102,9 +102,9 @@ const { data: topics } = useGetTopics();
 const options = ref<{ label: string; value: TopicEnum; id: string }[]>([]);
 options.value = topics.value
   .map((topic: Topic) => ({
-  label: t(GLOBAL_TOPICS.find((t) => t.topic === topic.type)?.label || ""),
-  value: topic.type as TopicEnum,
-  id: topic.id,
+    label: t(GLOBAL_TOPICS.find((t) => t.topic === topic.type)?.label || ""),
+    value: topic.type as TopicEnum,
+    id: topic.id,
   }))
   .sort((a, b) => a.label.localeCompare(b.label));
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description
This PR adds alphabetical sorting to the topics combobox found on `/events` and `/organizations` routes.

**Changes:**
- Updated the sorting logic in the `selectedTopics` watcher to sort topics alphabetically within their respective groups
- Selected topics now appear alphabetically sorted at the top
- Non-selected topics now appear alphabetically sorted below selected ones
- Implemented using `localeCompare()` for proper internationalization support

**Previous behavior:**
- Newly selected topics appeared at the bottom of the selected list (insertion order)
- Newly deselected topics appeared at the top of the non-selected list

**New behavior:**
- All selected topics are sorted alphabetically among themselves
- All non-selected topics are sorted alphabetically among themselves
- Easier for users to scan and find specific topics in the dropdown

**Testing:**
- Manually tested selecting/deselecting multiple topics
- Verified alphabetical ordering is maintained in both groups
- Confirmed filtering functionality still works as expected
- Tested with various topic names to ensure proper sorting

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- #1737 
