### PR TITLE
fix: Add page validation to stores to ensure pages are always >= 1

### DIFF
--- a/frontend/app/stores/event.ts
+++ b/frontend/app/stores/event.ts
@@ -13,7 +13,7 @@ export const useEventStore = defineStore("event", {
     event: null as unknown as CommunityEvent,
     events: [],
     filters: {} as EventFilters,
-    page: 0,
+    page: 1,
   }),
   actions: {
     setEvent(event: CommunityEvent) {
@@ -24,7 +24,8 @@ export const useEventStore = defineStore("event", {
       return this.page;
     },
     setPage(page: number) {
-      this.page = page;
+      // Ensure page is always >= 1. Invalid values are clamped to 1.
+      this.page = Math.max(1, page);
     },
 
     getEvent(): CommunityEvent {

--- a/frontend/app/stores/organization.ts
+++ b/frontend/app/stores/organization.ts
@@ -13,7 +13,7 @@ export const useOrganizationStore = defineStore("organization", {
     images: [] as ContentImage[],
     organizations: [],
     filters: {} as OrganizationFilters,
-    page: 0,
+    page: 1,
   }),
   actions: {
     // MARK: Set Organizations
@@ -21,7 +21,8 @@ export const useOrganizationStore = defineStore("organization", {
       return this.page;
     },
     setPage(page: number) {
-      this.page = page;
+      // Ensure page is always >= 1. Invalid values are clamped to 1.
+      this.page = Math.max(1, page);
     },
     setOrganizations(organizations: Organization[]) {
       this.organizations = organizations;

--- a/frontend/test/stores/event.spec.ts
+++ b/frontend/test/stores/event.spec.ts
@@ -31,9 +31,9 @@ describe("useEventStore", () => {
       expect(store.filters).toEqual({});
     });
 
-    it("initializes with page 0", () => {
+    it("initializes with page 1", () => {
       const store = useEventStore();
-      expect(store.page).toBe(0);
+      expect(store.page).toBe(1);
     });
   });
 
@@ -213,19 +213,19 @@ describe("useEventStore", () => {
       expect(store.filters).toEqual({});
     });
 
-    it("can set page to 0", () => {
+    it("clamps page to 1 when setting to 0", () => {
       const store = useEventStore();
       store.setPage(5);
       store.setPage(0);
-      expect(store.page).toBe(0);
-      expect(store.getPage()).toBe(0);
+      expect(store.page).toBe(1);
+      expect(store.getPage()).toBe(1);
     });
 
-    it("can set page to negative number", () => {
+    it("clamps page to 1 when setting to negative number", () => {
       const store = useEventStore();
       store.setPage(-1);
-      expect(store.page).toBe(-1);
-      expect(store.getPage()).toBe(-1);
+      expect(store.page).toBe(1);
+      expect(store.getPage()).toBe(1);
     });
     it("can set page to large number", () => {
       const store = useEventStore();

--- a/frontend/test/stores/organization.spec.ts
+++ b/frontend/test/stores/organization.spec.ts
@@ -40,9 +40,9 @@ describe("useOrganizationStore", () => {
       expect(store.filters).toEqual({});
     });
 
-    it("initializes with page 0", () => {
+    it("initializes with page 1", () => {
       const store = useOrganizationStore();
-      expect(store.page).toBe(0);
+      expect(store.page).toBe(1);
     });
   });
 
@@ -262,12 +262,19 @@ describe("useOrganizationStore", () => {
       expect(store.images).toEqual([]);
       expect(store.getImages()).toHaveLength(0);
     });
-    it("can set page to 0", () => {
+    it("clamps page to 1 when setting to 0", () => {
       const store = useOrganizationStore();
       store.setPage(5);
       store.setPage(0);
-      expect(store.page).toBe(0);
-      expect(store.getPage()).toBe(0);
+      expect(store.page).toBe(1);
+      expect(store.getPage()).toBe(1);
+    });
+
+    it("clamps page to 1 when setting to negative number", () => {
+      const store = useOrganizationStore();
+      store.setPage(-1);
+      expect(store.page).toBe(1);
+      expect(store.getPage()).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Description

This PR adds validation to the `setPage()` method in both event and organization stores to ensure page numbers are always >= 1. Invalid page numbers (0 or negative) are automatically clamped to 1 instead of being accepted as-is.

This addresses an edge case identified in PR #1754 where tests were documenting that invalid page numbers (like -1 or 0) could be set on stores.

## Why 1-indexed instead of 0-indexed?

The stores originally initialized with `page: 0`, but I've changed this to `page: 1` for the following reasons:

1. **Backend API is 1-indexed**: Django REST Framework's `PageNumberPagination` uses 1-indexed pagination (pages start at 1, not 0)
2. **Frontend services default to page 1**: Both `listEvents()` and `listOrganizations()` have default parameters of `{ page: 1, page_size: 10 }`
3. **Composables always use page 1**: The `useGetEvents` and `useGetOrganizations` composables initialize with `page = ref(1)` and always set the store page to 1
4. **No code checks for page === 0**: There's no logic that treats `page: 0` as a special "unloaded" state - it was just an inconsistent initial value

By making the store 1-indexed from initialization, we stay consistent with the API, services, and composables throughout the application.

## Changes

### Store Updates
- **Event Store** (`frontend/app/stores/event.ts`):
  - Added validation to `setPage()` using `Math.max(1, page)` to clamp invalid values
  - Changed initial page state from `0` to `1` (1-indexed pagination)
  
- **Organization Store** (`frontend/app/stores/organization.ts`):
  - Added validation to `setPage()` using `Math.max(1, page)` to clamp invalid values
  - Changed initial page state from `0` to `1` (1-indexed pagination)

### Test Updates
- **Event Store Tests** (`frontend/test/stores/event.spec.ts`):
  - Updated initial state test to expect page `1` instead of `0`
  - Changed "can set page to 0" test to expect clamping to `1`
  - Changed "can set page to negative number" test to expect clamping to `1`
  
- **Organization Store Tests** (`frontend/test/stores/organization.spec.ts`):
  - Updated initial state test to expect page `1` instead of `0`
  - Changed "can set page to 0" test to expect clamping to `1`
  - Added new test for negative number clamping to `1`

## Behavior

- Invalid page numbers (< 1) are automatically clamped to 1
- No errors are thrown - invalid values are silently corrected for better UX
- Pages are consistently 1-indexed throughout the application
- Existing code using relative comparisons (`page.value > pageCached`) continues to work correctly

## Related

- Addresses edge case mentioned in PR #1754: https://github.com/activist-org/activist/pull/1754#discussion_r2571242428

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- closes https://github.com/activist-org/activist/issues/1768
