### PR TITLE
Update changelog for to remove an impossible release date

### DIFF
--- a/docs/product/about/changelog.md
+++ b/docs/product/about/changelog.md
@@ -8,6 +8,6 @@ description: What's new
 
 ## Upcoming release: MVP (0.1.0)
 
-We are currently en route for a launch in November 2024.&#x20;
+We are currently developing the MVP (0.1.0).
 
-Those interested can [Request access](https://forms.activist.org/s/cm30ujrcj0003107fqc75yke8) to the platform and we'll reach out to you once we're live.
+Those interested can [Request access](https://forms.activist.org/s/cm30ujrcj0003107fqc75yke8) to the platform and we'll reach out to you as soon as we're live.


### PR DESCRIPTION
If there is a new planned release date, it would be great to add it, but if not / until then I wanted to remove the old 2024 release date.

### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

The [changelog](https://docs.activist.org/activist/product/about/changelog) in the docs said there would be an upcoming release of the MVP in November 2024.

The changelog was updated to remove the release date that was in the past. 

