### PR TITLE
fix: group modal images upload

### DIFF
--- a/frontend/app/components/modal/upload-image/ModalUploadImageGroup.vue
+++ b/frontend/app/components/modal/upload-image/ModalUploadImageGroup.vue
@@ -45,9 +45,8 @@ const props = withDefaults(defineProps<Props>(), {
   uploadLimit: 10,
 });
 
-const groupStore = useGroupStore();
+const { data: groupImages } = useGetGroupImages(props.groupId);
 const groupId = computed(() => props.groupId);
-const { images: groupImages } = groupStore;
 const { updateImage, uploadImages } = useGroupImageMutations(groupId);
 const files = ref<FileUploadMix[]>([]);
 
@@ -95,7 +94,7 @@ const handleUpload = async () => {
         uploadFiles.map((file) => file.sequence)
       );
     }
-    files.value = (groupImages || []).map(
+    files.value = (groupImages.value || []).map(
       (image: ContentImage, index: number) => ({
         type: "file",
         data: image,


### PR DESCRIPTION
…mages from group

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->
The issue was caused because when you reopen the modal they don't show the images from the group. I have added to use the composable and not the store to get images. Which checks first if its in the store and then if not gets it from the backend. 
### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes  #1791 
