### PR TITLE
fix: improve color contrast for distinct-text to meet WCAG AA requirements

### DIFF
--- a/frontend/app/assets/css/tailwind.css
+++ b/frontend/app/assets/css/tailwind.css
@@ -21,7 +21,7 @@ MARK: Colors
   --section-div: 216, 222, 228;
   --primary-text: 0, 0, 0;
   --primary-text-over-layer-2: 36, 36, 35;
-  --distinct-text: 90, 90, 90;
+  --distinct-text: 70, 70, 70;
   --distinct-text-over-layer-2: 105, 105, 105;
   --link-text: 0, 92, 184;
   --link-text-hover: 0, 59, 119;


### PR DESCRIPTION
- Changed --distinct-text from RGB(90, 90, 90) to RGB(70, 70, 70)
- Fixes accessibility violation: insufficient contrast (3.92) for keyboard shortcut indicators
- Now meets WCAG 2 AA minimum contrast ratio of 4.5:1

tested with: ```yarn test:local:grep --grep "@accessibility"```

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- #ISSUE_NUMBER: N/A
