### PR TITLE
fix(test): add useLocalePath and useAuth mocks to fix 23 failing tests

### DIFF
--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -6,6 +6,10 @@ import { createI18n } from "vue-i18n";
 
 import en from "../i18n/locales/en-US.json" assert { type: "json" };
 import { setupAutoImportMocks } from "./auto-imports";
+import {
+  createUseAuthMock,
+  createUseLocalePathMock,
+} from "./mocks/composableMocks";
 
 // Set up Pinia.
 setActivePinia(createPinia());
@@ -42,8 +46,18 @@ globalThis.useAuthStateMock = vi.fn(() => ({
   data: globalThis.data, // read from globalThis.data to allow tests to override
 }));
 globalThis.useAuthState = () => globalThis.useAuthStateMock();
+
+// useLocalePath returns a function (path) => string. Must be set before setupAutoImportMocks
+// so the default {} mock doesn't overwrite it. Components like sign-up.vue call localePath() in template.
+globalThis.useLocalePath = createUseLocalePathMock();
+
+// useAuth: MenuItemLabel and other components need signOut. Must be set before setupAutoImportMocks.
+// vi.mock for @sidebase/nuxt-auth only mocks useAuthState; useAuth must be provided globally.
+globalThis.useAuth = createUseAuthMock();
+
 vi.mock("@sidebase/nuxt-auth", () => ({
   useAuthState: globalThis.useAuthState,
+  useAuth: globalThis.useAuth,
 }));
 
 // Auto-import default mocks for composables not manually mocked above.


### PR DESCRIPTION
Root cause: Missing global mocks for Nuxt auto-imported composables.

- useLocalePath: setupAutoImportMocks returned {} instead of a function. sign-up.vue calls localePath() in template; {} is not callable. Fix: Set useLocalePath via createUseLocalePathMock() in setup.ts.

- useAuth: vi.mock for @sidebase/nuxt-auth only mocked useAuthState. MenuItemLabel.vue destructures { signOut } from useAuth(); useAuth was undefined. Fix: Add useAuth via createUseAuthMock() to setup.ts and vi.mock export.

Uses factories from composableMocks.ts per FRONTEND_TESTING.md patterns.

All 1299 tests now pass.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- closes #1870 
