### PR TITLE
test: add unit tests for 5 Modal components

### DIFF
--- a/frontend/test/components/modal/ModalCommandPalette.spec.ts
+++ b/frontend/test/components/modal/ModalCommandPalette.spec.ts
@@ -27,7 +27,8 @@ const ModalBaseStub = {
   name: "ModalBase",
   props: ["modalName"],
   emits: ["closeModal"],
-  template: '<div data-testid="modal-base" :data-modal-name="modalName"><slot /></div>',
+  template:
+    '<div data-testid="modal-base" :data-modal-name="modalName"><slot /></div>',
 };
 
 const ComboboxStub = {
@@ -70,16 +71,32 @@ interface Command {
 }
 
 const testCommands: Command[] = [
-  { id: 1, path: "organizations", iconName: "SEARCH", displayName: "Organizations", action: vi.fn() },
-  { id: 2, path: "events", iconName: "SEARCH", displayName: "Events", action: vi.fn() },
-  { id: 3, path: "resources", iconName: "SEARCH", displayName: "Resources", action: vi.fn() },
+  {
+    id: 1,
+    path: "organizations",
+    iconName: "SEARCH",
+    displayName: "Organizations",
+    action: vi.fn(),
+  },
+  {
+    id: 2,
+    path: "events",
+    iconName: "SEARCH",
+    displayName: "Events",
+    action: vi.fn(),
+  },
+  {
+    id: 3,
+    path: "resources",
+    iconName: "SEARCH",
+    displayName: "Resources",
+    action: vi.fn(),
+  },
 ];
 
 // MARK: Helper
 
-const createWrapper = (
-  props: { paletteData?: Command[] } = {}
-): VueWrapper =>
+const createWrapper = (props: { paletteData?: Command[] } = {}): VueWrapper =>
   mount(ModalCommandPalette, {
     props: {
       paletteData: testCommands,
@@ -117,7 +134,9 @@ describe("ModalCommandPalette component", () => {
       const wrapper = createWrapper();
       const modalBase = wrapper.find('[data-testid="modal-base"]');
       expect(modalBase.exists()).toBe(true);
-      expect(modalBase.attributes("data-modal-name")).toBe("ModalCommandPalette");
+      expect(modalBase.attributes("data-modal-name")).toBe(
+        "ModalCommandPalette"
+      );
     });
 
     it("renders the search input", () => {

--- a/frontend/test/components/modal/ModalMediaImageCarousel.spec.ts
+++ b/frontend/test/components/modal/ModalMediaImageCarousel.spec.ts
@@ -12,7 +12,8 @@ import { EntityType } from "../../../shared/types/entity";
 const ModalBaseStub = {
   name: "ModalBase",
   props: ["modalName"],
-  template: '<div data-testid="modal-base" :data-modal-name="modalName"><slot /></div>',
+  template:
+    '<div data-testid="modal-base" :data-modal-name="modalName"><slot /></div>',
 };
 
 const MediaImageCarouselStub = {
@@ -29,7 +30,10 @@ const createWrapper = (
 ): VueWrapper =>
   mount(ModalMediaImageCarousel, {
     props: {
-      imageUrls: ["https://example.com/img1.jpg", "https://example.com/img2.jpg"],
+      imageUrls: [
+        "https://example.com/img1.jpg",
+        "https://example.com/img2.jpg",
+      ],
       entityType: EntityType.ORGANIZATION,
       ...props,
     },

--- a/frontend/test/components/modal/ModalOrganizationOverview.spec.ts
+++ b/frontend/test/components/modal/ModalOrganizationOverview.spec.ts
@@ -11,7 +11,8 @@ import ModalOrganizationOverview from "../../../app/components/modal/ModalOrgani
 const ModalBaseStub = {
   name: "ModalBase",
   props: ["modalName"],
-  template: '<div data-testid="modal-base" :data-modal-name="modalName"><slot /></div>',
+  template:
+    '<div data-testid="modal-base" :data-modal-name="modalName"><slot /></div>',
 };
 
 const DialogTitleStub = {
@@ -50,9 +51,7 @@ const testEvent = {
 
 // MARK: Helper
 
-const createWrapper = (
-  props: { event?: CommunityEvent } = {}
-): VueWrapper =>
+const createWrapper = (props: { event?: CommunityEvent } = {}): VueWrapper =>
   mount(ModalOrganizationOverview, {
     props: { ...props },
     global: {
@@ -75,7 +74,9 @@ describe("ModalOrganizationOverview component", () => {
       const wrapper = createWrapper({ event: testEvent });
       const modalBase = wrapper.find('[data-testid="modal-base"]');
       expect(modalBase.exists()).toBe(true);
-      expect(modalBase.attributes("data-modal-name")).toBe("ModalOrganizationOverview");
+      expect(modalBase.attributes("data-modal-name")).toBe(
+        "ModalOrganizationOverview"
+      );
     });
 
     it("renders the organizations heading", () => {

--- a/frontend/test/components/modal/ModalOrganizationStatus.spec.ts
+++ b/frontend/test/components/modal/ModalOrganizationStatus.spec.ts
@@ -50,7 +50,13 @@ const testOrganization = {
 
 const testModalData = {
   discussionEntries: [
-    { id: 1, author: "Alice", content: "Looks good", votes: 3, date: new Date() },
+    {
+      id: 1,
+      author: "Alice",
+      content: "Looks good",
+      votes: 3,
+      date: new Date(),
+    },
   ],
   organizationsInFavor: [testOrganization],
   upVotes: 5,
@@ -71,15 +77,17 @@ const createWrapper = (
     },
     global: {
       plugins: [createPinia()],
-      mocks: { $t: (key: string, params?: Record<string, string>) => {
-        if (params) {
-          return Object.entries(params).reduce(
-            (str, [k, v]) => str.replace(`{${k}}`, v),
-            key
-          );
-        }
-        return key;
-      }},
+      mocks: {
+        $t: (key: string, params?: Record<string, string>) => {
+          if (params) {
+            return Object.entries(params).reduce(
+              (str, [k, v]) => str.replace(`{${k}}`, v),
+              key
+            );
+          }
+          return key;
+        },
+      },
       stubs: {
         ModalBase: ModalBaseStub,
         DialogTitle: DialogTitleStub,
@@ -107,7 +115,9 @@ describe("ModalOrganizationStatus component", () => {
       const wrapper = createWrapper();
       const modalBase = wrapper.find('[data-testid="modal-base"]');
       expect(modalBase.exists()).toBe(true);
-      expect(modalBase.attributes("data-modal-name")).toBe("ModalOrganizationStatus");
+      expect(modalBase.attributes("data-modal-name")).toBe(
+        "ModalOrganizationStatus"
+      );
     });
 
     it("displays organization application heading", () => {
@@ -142,7 +152,9 @@ describe("ModalOrganizationStatus component", () => {
   describe("Injected Data", () => {
     it("renders CardOrgApplicationVote with injected data", () => {
       const wrapper = createWrapper();
-      const voteCard = wrapper.findComponent({ name: "CardOrgApplicationVote" });
+      const voteCard = wrapper.findComponent({
+        name: "CardOrgApplicationVote",
+      });
       expect(voteCard.exists()).toBe(true);
       expect(voteCard.props("upVotes")).toBe(5);
       expect(voteCard.props("downVotes")).toBe(2);

--- a/frontend/test/components/modal/ModalSharePage.spec.ts
+++ b/frontend/test/components/modal/ModalSharePage.spec.ts
@@ -11,7 +11,8 @@ import ModalSharePage from "../../../app/components/modal/ModalSharePage.vue";
 const ModalBaseStub = {
   name: "ModalBase",
   props: ["modalName"],
-  template: '<div data-testid="modal-base" :data-modal-name="modalName"><slot /></div>',
+  template:
+    '<div data-testid="modal-base" :data-modal-name="modalName"><slot /></div>',
 };
 
 const DialogTitleStub = {
@@ -21,17 +22,34 @@ const DialogTitleStub = {
 const BtnShareIconStub = {
   name: "BtnShareIcon",
   props: [
-    "iconName", "iconSize", "name", "nativeBehaviorOptions",
-    "reasonForSuggesting", "redirectLink", "shareOptions",
-    "socialComponent", "text", "type", "urlLink",
-    "useNativeBehavior", "windowFeatures",
+    "iconName",
+    "iconSize",
+    "name",
+    "nativeBehaviorOptions",
+    "reasonForSuggesting",
+    "redirectLink",
+    "shareOptions",
+    "socialComponent",
+    "text",
+    "type",
+    "urlLink",
+    "useNativeBehavior",
+    "windowFeatures",
   ],
   template: '<div data-testid="share-btn" :data-text="text"></div>',
 };
 
 const ModalQRCodeBtnStub = {
   name: "ModalQRCodeBtn",
-  props: ["organization", "group", "event", "resource", "user", "reasonForSuggesting", "type"],
+  props: [
+    "organization",
+    "group",
+    "event",
+    "resource",
+    "user",
+    "reasonForSuggesting",
+    "type",
+  ],
   template: '<div data-testid="qr-code-btn"></div>',
 };
 
@@ -151,17 +169,23 @@ describe("ModalSharePage component", () => {
 
     it("renders the share heading", () => {
       const wrapper = createWrapper({ organization: testOrganization });
-      expect(wrapper.text()).toContain("i18n.components.modal_share_page.header");
+      expect(wrapper.text()).toContain(
+        "i18n.components.modal_share_page.header"
+      );
     });
 
     it("renders suggested section heading", () => {
       const wrapper = createWrapper({ organization: testOrganization });
-      expect(wrapper.text()).toContain("i18n.components.modal_share_page.suggested");
+      expect(wrapper.text()).toContain(
+        "i18n.components.modal_share_page.suggested"
+      );
     });
 
     it("renders other section heading", () => {
       const wrapper = createWrapper({ organization: testOrganization });
-      expect(wrapper.text()).toContain("i18n.components.modal_share_page.other");
+      expect(wrapper.text()).toContain(
+        "i18n.components.modal_share_page.other"
+      );
     });
 
     it("renders Toaster component", () => {


### PR DESCRIPTION
## Summary
- Add Vitest unit tests for 5 previously untested Modal components: `ModalMediaImageCarousel`, `ModalOrganizationOverview`, `ModalOrganizationStatus`, `ModalCommandPalette`, and `ModalSharePage`
- 50 new tests total (1683 passing, 0 failures, no regressions)
- Follows existing test conventions from `ModalBase.spec.ts` and `ModalAlert.spec.ts`

Closes #1986

## Test plan
- [x] All 50 new tests pass locally
- [x] Full test suite (1683 tests) passes with 0 failures
- [x] No regressions in existing modal tests (ModalBase, ModalAlert)
- [ ] CI passes on PR