### PR TITLE
ci(playwright): run desktop and mobile E2E in parallel via separate workflows

### DIFF
--- a/.github/workflows/ci_playwright_e2e_desktop.yaml
+++ b/.github/workflows/ci_playwright_e2e_desktop.yaml
@@ -10,13 +10,21 @@ on:
       - synchronize
     paths:
       - "backend/**"
+      - "!backend/**/tests/**/*.py"
       - "frontend/**"
+      - "!frontend/test/**"
+      - ".github/workflows/ci_playwright_e2e_desktop.yaml"
+      - ".github/workflows/ci_playwright_e2e_mobile.yaml"
   push:
     branches:
       - main
     paths:
       - "backend/**"
+      - "!backend/**/tests/**/*.py"
       - "frontend/**"
+      - "!frontend/test/**"
+      - ".github/workflows/ci_playwright_e2e_desktop.yaml"
+      - ".github/workflows/ci_playwright_e2e_mobile.yaml"
 
 jobs:
   frontend-e2e-desktop:
@@ -64,7 +72,7 @@ jobs:
       - name: Install Dependencies and Build
         working-directory: ./frontend
         env:
-          USE_PREVIEW: "true"
+          USE_PREVIEW: true
           VITE_FRONTEND_URL: http://localhost:3000
           VITE_BACKEND_URL: http://localhost:8000
           VITE_API_URL: http://localhost:8000/v1
@@ -127,8 +135,8 @@ jobs:
       - name: Run Playwright Tests (Desktop Chrome)
         working-directory: ./frontend
         env:
-          FAST_TESTS: "true"
-          SKIP_WEBSERVER: "true"
+          FAST_TESTS: true
+          SKIP_WEBSERVER: true
           PLAYWRIGHT_BROWSERS_PATH: /opt/playwright-browsers
           NUXT_SESSION_PASSWORD: "password-with-at-least-32-characters"
           VITE_BACKEND_URL: http://localhost:8000

--- a/.github/workflows/ci_playwright_e2e_mobile.yaml
+++ b/.github/workflows/ci_playwright_e2e_mobile.yaml
@@ -9,14 +9,24 @@ on:
       - reopened
       - synchronize
     paths:
-      - "backend/**"
+      # Note: We only run e2e tests for desktop on backend changes.
+      # - "backend/**"
+      # - "!backend/**/tests/**/*.py"
       - "frontend/**"
+      - "!frontend/test/**"
+      - ".github/workflows/ci_playwright_e2e_desktop.yaml"
+      - ".github/workflows/ci_playwright_e2e_mobile.yaml"
   push:
     branches:
       - main
     paths:
-      - "backend/**"
+      # Note: We only run e2e tests for desktop on backend changes.
+      # - "backend/**"
+      # - "!backend/**/tests/**/*.py"
       - "frontend/**"
+      - "!frontend/test/**"
+      - ".github/workflows/ci_playwright_e2e_desktop.yaml"
+      - ".github/workflows/ci_playwright_e2e_mobile.yaml"
 
 jobs:
   frontend-e2e-mobile:
@@ -64,7 +74,7 @@ jobs:
       - name: Install Dependencies and Build
         working-directory: ./frontend
         env:
-          USE_PREVIEW: "true"
+          USE_PREVIEW: true
           VITE_FRONTEND_URL: http://localhost:3000
           VITE_BACKEND_URL: http://localhost:8000
           VITE_API_URL: http://localhost:8000/v1
@@ -127,8 +137,8 @@ jobs:
       - name: Run Playwright Tests (Mobile Chrome)
         working-directory: ./frontend
         env:
-          FAST_TESTS: "true"
-          SKIP_WEBSERVER: "true"
+          FAST_TESTS: true
+          SKIP_WEBSERVER: true
           PLAYWRIGHT_BROWSERS_PATH: /opt/playwright-browsers
           NUXT_SESSION_PASSWORD: "password-with-at-least-32-characters"
           VITE_BACKEND_URL: http://localhost:8000


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

## Summary
Splits the Playwright E2E CI into two workflow files so desktop and mobile tests run in parallel instead of sequentially in one job.

## Changes
- **ci_playwright_e2e_desktop.yaml** – Runs E2E with `--project="Desktop Chrome"`. Same triggers and setup as before (Docker, build, preview server, etc.).
- **ci_playwright_e2e_mobile.yaml** – Runs E2E with `--project="Mobile Chrome"`. Same setup; only the Playwright project differs.
- **Removed** `ci_playwright_e2e.yaml` (previously used a matrix with both projects in one workflow).

## Result
- On PR/push (with backend/frontend path filters), both workflows are triggered and can run at the same time on separate runners.
- In the Actions tab: **ci_playwright_e2e_desktop** and **ci_playwright_e2e_mobile** appear as two workflow runs.
- Artifacts: `playwright-report-desktop` and `playwright-report-mobile` for each run.

### Related issue

closes #2002 

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->


