### PR TITLE
Prioritize Activist organization first on  /organizations  in development mode

### DIFF
--- a/backend/communities/organizations/views.py
+++ b/backend/communities/organizations/views.py
@@ -72,7 +72,7 @@ class OrganizationAPIView(GenericAPIView[Organization]):
         if os.environ.get("ENVIRONMENT") != "development":
             return queryset
 
-        activist_match = Q(name__iexact="activist") | Q(name__iexact="the activist")
+        activist_match = Q(name__iexact="activist")
 
         return queryset.annotate(
             _priority=Case(

--- a/backend/core/management/commands/entity_data_to_assign.yaml
+++ b/backend/core/management/commands/entity_data_to_assign.yaml
@@ -98,7 +98,7 @@ organizations:
       url: https://github.com/activist-org/activist/blob/main/FRONTEND_TESTING.md
 
     events:
-    - name: Dev Sync
+    - name: activist dev sync
       tagline: Community triage, Q&A and hacking session
       type: action
       texts:

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -4,11 +4,13 @@ API views for event management.
 """
 
 import logging
+import os
 import re
 from typing import Any, Sequence, Type
 from uuid import UUID
 
 from django.core.exceptions import ValidationError
+from django.db.models import Case, IntegerField, Q, QuerySet, Value, When
 from django.db.utils import IntegrityError, OperationalError
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
@@ -53,12 +55,28 @@ logger = logging.getLogger("django")
 
 
 class EventAPIView(GenericAPIView[Event]):
-    queryset = Event.objects.all().order_by("id")
+    queryset = Event.objects.all()
     serializer_class = EventSerializer
     pagination_class = CustomPagination
     filterset_class = EventFilters
     filter_backends = [DjangoFilterBackend]
     permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def get_queryset(self) -> QuerySet[Event]:
+        queryset = super().get_queryset().order_by("id")
+
+        if os.environ.get("ENVIRONMENT") != "development":
+            return queryset
+
+        dev_sync_match = Q(name__iexact="activist dev sync")
+
+        return queryset.annotate(
+            _priority=Case(
+                When(dev_sync_match, then=Value(0)),
+                default=Value(1),
+                output_field=IntegerField(),
+            )
+        ).order_by("_priority", "id")
 
     def get_permissions(self) -> Sequence[Any]:
         if self.request.method == "POST":
@@ -560,7 +578,7 @@ class EventSocialLinkViewSet(viewsets.ModelViewSet[EventSocialLink]):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        serializer = self.get_serializer(social_link, request.data, partial=True)
+        serializer = self.get_serializer(social_link, data=request.data, partial=True)
         if serializer.is_valid():
             serializer.save(event=event)
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This pull request updates organization list ordering in development mode so the Activist organization is shown first on initial load of `/organizations`.

Main file changed:
- `backend/communities/organizations/views.py`
  - Added dev-only queryset prioritization in `OrganizationAPIView.get_queryset()`.
  - Kept default ordering by `id` for non-development environments.
  - Added a priority annotation so organizations named `activist` or `the activist` are sorted first when `ENVIRONMENT=development`.
  - Updated non-paginated serialization to use the computed `queryset` for consistent ordering/filter behavior.



### Related issue

- Closes #2015
