### PR TITLE
test: improve Loading component unit test coverage

### DIFF
--- a/frontend/test/components/loading/Loading.spec.ts
+++ b/frontend/test/components/loading/Loading.spec.ts
@@ -61,12 +61,16 @@ describe("Loading Component", () => {
   describe("Color mode icon switching", () => {
     it("renders the light icon in light mode", () => {
       wrapper = createWrapper("light", true);
-      expect(wrapper.find("img").attributes("src")).toBe(ACTIVIST_ICON_LIGHT_URL);
+      expect(wrapper.find("img").attributes("src")).toBe(
+        ACTIVIST_ICON_LIGHT_URL
+      );
     });
 
     it("renders the dark icon in dark mode", () => {
       wrapper = createWrapper("dark", true);
-      expect(wrapper.find("img").attributes("src")).toBe(ACTIVIST_ICON_DARK_URL);
+      expect(wrapper.find("img").attributes("src")).toBe(
+        ACTIVIST_ICON_DARK_URL
+      );
     });
 
     it("does not render the dark icon in light mode", () => {
@@ -120,7 +124,9 @@ describe("Loading Component", () => {
       wrapper = createWrapper("light", false);
       await wrapper.setProps({ loading: true });
       await wrapper.vm.$nextTick();
-      const style = wrapper.find(".flex.items-center.justify-center").attributes("style") ?? "";
+      const style =
+        wrapper.find(".flex.items-center.justify-center").attributes("style") ??
+        "";
       expect(style).not.toContain("display: none");
     });
 
@@ -128,7 +134,9 @@ describe("Loading Component", () => {
       wrapper = createWrapper("light", true);
       await wrapper.setProps({ loading: false });
       await wrapper.vm.$nextTick();
-      expect(wrapper.find(".flex.items-center.justify-center").attributes("style")).toContain("display: none");
+      expect(
+        wrapper.find(".flex.items-center.justify-center").attributes("style")
+      ).toContain("display: none");
     });
   });
 
@@ -137,7 +145,9 @@ describe("Loading Component", () => {
   describe("Styling", () => {
     it("outer container has flex centering classes", () => {
       wrapper = createWrapper();
-      expect(wrapper.find(".flex.items-center.justify-center").exists()).toBe(true);
+      expect(wrapper.find(".flex.items-center.justify-center").exists()).toBe(
+        true
+      );
     });
 
     it("inner div has loading-pulse class", () => {


### PR DESCRIPTION
### Contributor checklist
- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description
Expanded unit tests for the `Loading` component, replacing the existing shallow spec with 18 tests covering:

- **Rendering** — component mounts, loading-pulse div present, correct number of images per color mode
- **Color mode switching** — light mode shows light icon URL, dark mode shows dark icon URL, no cross-contamination
- **Accessibility** — img alt attribute present and sourced from i18n key
- **Props** — default (no prop) hides content, toggling loading true/false reactively shows/hides
- **Styling** — flex centering classes, loading-pulse class, h-40 on img

Tests were run locally with `yarn vitest run test/components/loading/Loading.spec.ts` — 18/18 passing.

### Related issue
Closes #1805
