### PR TITLE
Add `skip_postgeneration_save = True` to factory Meta classes.

### DIFF
--- a/backend/authentication/factories.py
+++ b/backend/authentication/factories.py
@@ -87,6 +87,7 @@ class UserFactory(factory.django.DjangoModelFactory):
         model = UserModel
         exclude = ("plaintext_password",)
         django_get_or_create = ("username",)
+        skip_postgeneration_save = True
 
     username = factory.Faker("user_name")
     name = factory.Faker("name")

--- a/backend/content/factories.py
+++ b/backend/content/factories.py
@@ -38,6 +38,7 @@ class EntityLocationFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Location
+        skip_postgeneration_save = True
 
     @factory.post_generation
     def location(self, create, extracted, **kwargs):
@@ -119,6 +120,7 @@ class EventLocationFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Location
+        skip_postgeneration_save = True
 
     @factory.post_generation
     def location(self, create, extracted, **kwargs):

--- a/backend/events/factories.py
+++ b/backend/events/factories.py
@@ -36,6 +36,7 @@ class EventFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Event
+        skip_postgeneration_save = True
 
     created_by = factory.SubFactory("authentication.factories.UserFactory")
     name = factory.Faker("word")


### PR DESCRIPTION
closes #1933

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

This PR addresses deprecation warnings from factory_boy regarding `_after_postgeneration` automatic saves.

Applied `skip_postgeneration_save = True` to the following factories:
- UserFactory
- EventFactory
- EntityLocationFactory
- EventLocationFactory

> [!IMPORTANT]
> The deprecation warnings are resolved, but some tests are now failing.

The failures appear to be related to authentication and resource tests.
With the new behavior, these changes are no longer persisted unless explicitly saved.

@andrewtavis could be discuss this further about the failing tests after the proposed changes? Should I add explicit `self.save()` calls in relevant `post_generation` hooks?

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

