### PR TITLE
test(e2e): event create modal: handle create API 500 and assert error toast

### DIFF
--- a/frontend/test-e2e/specs/all/create-flows/event-create-modal.spec.ts
+++ b/frontend/test-e2e/specs/all/create-flows/event-create-modal.spec.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Page } from "@playwright/test";
+
 import { getEnglishText } from "#shared/utils/i18n";
 
 import { runAccessibilityTestScoped } from "~/test-e2e/accessibility/accessibilityTesting";
@@ -716,7 +717,9 @@ test.describe(
         const modal = newCreateEventModal(page);
 
         await modal.nameField.fill("E2E Error Path Event");
-        await modal.descriptionField.fill("Should not persist after failed create.");
+        await modal.descriptionField.fill(
+          "Should not persist after failed create."
+        );
         await selectFirstOrganization(modal);
         await modal.getNextStepButton().click({ force: true });
 


### PR DESCRIPTION
- Close org/topic comboboxes with Escape (Headless UI)
- Add create event API error route + toast assertion

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

### Summary
- Adds an E2E that mocks a **500** on event create (`POST **/api/auth/events/events`) and asserts the **error toast** (and end-of-flow behavior consistent with the app).


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- #2041
