### PR TITLE
test(e2e): stabilize event FAQ CRUD delete assertion

### DIFF
--- a/frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts
+++ b/frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts
@@ -186,28 +186,37 @@ test.describe("Event FAQ Page", { tag: ["@desktop"] }, () => {
     const confirmationModal = page.locator("#modal").first();
     await expect(confirmationModal).toBeVisible({ timeout: 15000 });
 
-    // Confirm deletion.
+    // Confirm deletion. ModalAlert does not await the parent's async delete handler, so the
+    // dialog can close before DELETE + refetch finish — wait on the API response, then poll UI.
     const confirmButton = confirmationModal.getByRole("button", {
       name: /confirm|yes|delete/i,
     });
+    const deleteFaqResponse = page.waitForResponse(
+      (res) =>
+        res.request().method() === "DELETE" &&
+        /\/events\/event_faqs\//i.test(new URL(res.url()).pathname),
+      { timeout: 20000 }
+    );
     await confirmButton.click();
+    const deleteRes = await deleteFaqResponse;
+    expect(
+      [200, 204].includes(deleteRes.status()),
+      `DELETE event FAQ expected 200 or 204, got ${deleteRes.status()}`
+    ).toBe(true);
 
-    // Wait for modal to close.
     await expect(confirmationModal).not.toBeVisible();
     await page.waitForLoadState("domcontentloaded");
-    await page.waitForTimeout(1000);
 
-    // Verify the FAQ is no longer visible.
     await expect(
       faqPage.faqCards.filter({ hasText: updatedQuestion })
-    ).not.toBeVisible();
+    ).not.toBeVisible({ timeout: 15000 });
 
-    // Verify FAQ count decreased once the list has updated (poll to avoid race with DOM update).
     await expect
-      .poll(async () => await faqPage.getFAQCount(), {
-        timeout: 10000,
+      .poll(async () => faqPage.getFAQCount(), {
+        timeout: 20000,
+        intervals: [100, 200, 500],
       })
-      .toBeLessThanOrEqual(afterCreateCount - 1);
+      .toBe(initialFaqCount);
   });
 
   // MARK: View and Interact


### PR DESCRIPTION
Wait for DELETE /events/event_faqs/ after confirm; assert 200/204. Poll FAQ count to initialFaqCount with longer timeout and intervals — ModalAlert does not await async parent delete + refetch.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

## Summary
Stabilizes the **Event FAQ Page** E2E that exercises **CREATE → UPDATE → DELETE** by waiting for the **DELETE** request to finish before asserting on the list, then polling until the FAQ count matches the pre-test baseline.
## Problem
After confirming delete in `ModalAlert`, the UI can close before the parent finishes **`deleteFAQ()`** (HTTP DELETE + `refreshNuxtData`), because the alert’s `onConfirmation` path does not await the async work. The test then asserted FAQ count too early; under load the count could stay at **1** until the poll timed out (e.g. `Expected: <= 0`, `Received: 1` when the event started with no FAQs).
## Changes
**`frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts`**
- Register **`page.waitForResponse`** before clicking confirm, matching **`DELETE`** to **`/events/event_faqs/`**, timeout **20s**.
- Assert response status **200** or **204**.
- Remove the fixed **1s** sleep after delete in favor of that network wait.
- **`not.toBeVisible`** on the deleted FAQ’s card: **15s** timeout.
- **`expect.poll`** on **`getFAQCount()`** until it equals **`initialFaqCount`** (we add exactly one FAQ and remove it), **20s** timeout, **`intervals: [100, 200, 500]`**.


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- #ISSUE_NUMBER
