### PR TITLE
fix: pass label prop to BtnAction in dropdown

### DIFF
--- a/frontend/app/components/btn/action/BtnActionDropdown.vue
+++ b/frontend/app/components/btn/action/BtnActionDropdown.vue
@@ -47,9 +47,8 @@
             ]"
             :cta="true"
             fontSize="base"
-          >
-            {{ option }}
-          </BtnAction>
+            :label="option"
+          />
         </MenuItem>
       </MenuItems>
     </Menu>


### PR DESCRIPTION
Fixes #2052

The dropdown options in BtnActionDropdown were invisible because the option text was passed as slot content (`{{ option }}`) but BtnAction doesn't render a slot — it renders BtnIconsLabel which needs the `label` prop. Switched to passing `:label="option"` directly.

— saschabuehrle