### PR TITLE
organization form fix

### DIFF
--- a/frontend/app/pages/organizations/create.vue
+++ b/frontend/app/pages/organizations/create.vue
@@ -23,6 +23,7 @@
         @submit="submit"
         class="flex w-full flex-col items-center justify-center pt-4"
         class-button="mb-4"
+        :is-loading="loading"
         :schema="schema"
         submit-label="i18n.pages.organizations.create.complete_application"
       >
@@ -152,7 +153,7 @@
 </template>
 
 <script setup lang="ts">
-import { Toaster, toast } from "vue-sonner";
+import { Toaster } from "vue-sonner";
 import { z } from "zod";
 
 const schema = z.object({
@@ -164,16 +165,20 @@ const schema = z.object({
 });
 
 const localePath = useLocalePath();
+const { create, loading } = useOrganizationMutations();
 
-const submit = async () => {
-  // const responseId = await organizationStore.create(
-  //   values as OrganizationCreateFormData
-  // );
-  const responseId = "test-id"; // TODO: Replace with actual response from store
-  if (responseId) {
-    navigateTo(localePath(`/organizations/${responseId}`));
-  } else {
-    toast.error("Something went wrong. Please try again later.");
+const submit = async (values: Record<string, unknown>) => {
+  const organization = await create({
+    name: values.name as string,
+    tagline: values.tagline as string | undefined,
+    city: values.location as string,
+    country_code: "en",
+    description: values.description as string,
+    topics: values.topics as TopicEnum[] | undefined,
+  });
+
+  if (organization) {
+    navigateTo(localePath(`/organizations/${organization.id}`));
   }
 };
 </script>


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x]  I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
 
frontend/app/pages/organizations/create.vue
 
- A description of how you tested that your change actually works

The organization create form was non-functional — submitting it never called the API. The submit handler had the real implementation commented out and replaced with a hardcoded "test-id" stub, which caused the form to always navigate to /organizations/test-id (a non-existent page) regardless of user input.

- Pictures or a video of your change (if possible)
 
- Any risks that should be accounted for in your change
 
The country_code field is hardcoded to "en" as the form does not currently collect it. This matches the backend's existing default. A follow-up issue could split the location field into city + country.
 
- A disclosure of which parts of the contribution include AI generated code

This fix was identified with AI assistance (Claude Code).

Description of the proposed change...

Wired submit to useOrganizationMutations().create(), which was already fully implemented but unused here. It POSTs the form data to /communities/organizations, handles loading state, and shows a toast on error.
Added values parameter to submit so the validated form fields (name, tagline, location, description, topics) are passed through to the API call. The location field is mapped to city to match the backend's OrganizationPOSTSerializer, with country_code defaulting to "en" as the backend already does.
On success, navigates to the newly created organization's page using the real organization.id returned from the API.
Added :is-loading="loading" to the Form component so the submit button shows a spinner and prevents double-submits while the request is in flight. Removed the unused toast import since error toasting is handled inside useOrganizationMutations.

### Related issue

No related issue — this bug was discovered during a code review of the create form. A follow-up issue could be opened to track splitting the location field into city + country_code.

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- #ISSUE_NUMBER
