### PR TITLE
fix(frontend): refresh image cache after delete in org/group upload modals

### DIFF
--- a/frontend/app/components/media/image-carousel/MediaImageCarousel.vue
+++ b/frontend/app/components/media/image-carousel/MediaImageCarousel.vue
@@ -3,10 +3,11 @@
   <div class="relative">
     <swiper-container
       ref="swiperRef"
+      class="swiper card-style h-full w-full cursor-pointer overflow-clip"
+      :data-slide-count="imageUrls?.length ?? 0"
       :data-testid="
         props.fullscreen ? 'image-carousel-fullscreen' : 'image-carousel-main'
       "
-      class="swiper card-style h-full w-full cursor-pointer overflow-clip"
       :keyboard="true"
       :loop="true"
       :pagination="{ clickable: true }"

--- a/frontend/app/components/media/image-carousel/MediaImageCarousel.vue
+++ b/frontend/app/components/media/image-carousel/MediaImageCarousel.vue
@@ -3,6 +3,9 @@
   <div class="relative">
     <swiper-container
       ref="swiperRef"
+      :data-testid="
+        props.fullscreen ? 'image-carousel-fullscreen' : 'image-carousel-main'
+      "
       class="swiper card-style h-full w-full cursor-pointer overflow-clip"
       :keyboard="true"
       :loop="true"

--- a/frontend/app/components/modal/upload-image/ModalUploadImageGroup.vue
+++ b/frontend/app/components/modal/upload-image/ModalUploadImageGroup.vue
@@ -12,8 +12,8 @@
       </DialogTitle>
       <div class="mt-4">
         <ImageMultipleFileDropZone
-          @update:modelValue="(newFiles) => (files = newFiles)"
           @file-deleted="handleFileDeleted"
+          @update:modelValue="(newFiles) => (files = newFiles)"
           :model-value="files"
           :uploadLimit="uploadLimit"
         />

--- a/frontend/app/components/modal/upload-image/ModalUploadImageGroup.vue
+++ b/frontend/app/components/modal/upload-image/ModalUploadImageGroup.vue
@@ -13,6 +13,7 @@
       <div class="mt-4">
         <ImageMultipleFileDropZone
           @update:modelValue="(newFiles) => (files = newFiles)"
+          @file-deleted="handleFileDeleted"
           :model-value="files"
           :uploadLimit="uploadLimit"
         />
@@ -47,8 +48,18 @@ const props = withDefaults(defineProps<Props>(), {
 
 const groupId = computed(() => props.groupId);
 const { data: groupImages } = useGetGroupImages(groupId);
-const { updateImage, uploadImages } = useGroupImageMutations(groupId);
+const { updateImage, uploadImages, refreshGroupData } =
+  useGroupImageMutations(groupId);
 const files = ref<FileUploadMix[]>([]);
+
+// useFileManager.removeFile() deletes on the server but doesn't invalidate
+// the groupImages cache, so the carousel stays stale until reload (same
+// class of bug as #1791). Only server-side images need a refresh.
+const handleFileDeleted = async (file: FileUploadMix) => {
+  if (file?.type === "file") {
+    await refreshGroupData();
+  }
+};
 
 watch(
   groupImages,

--- a/frontend/app/components/modal/upload-image/ModalUploadImageOrganization.vue
+++ b/frontend/app/components/modal/upload-image/ModalUploadImageOrganization.vue
@@ -12,8 +12,8 @@
       </DialogTitle>
       <div class="mt-4">
         <ImageMultipleFileDropZone
-          @update:modelValue="(newFiles) => (files = newFiles)"
           @file-deleted="handleFileDeleted"
+          @update:modelValue="(newFiles) => (files = newFiles)"
           :model-value="files"
           :uploadLimit="uploadLimit"
         />

--- a/frontend/app/components/modal/upload-image/ModalUploadImageOrganization.vue
+++ b/frontend/app/components/modal/upload-image/ModalUploadImageOrganization.vue
@@ -13,6 +13,7 @@
       <div class="mt-4">
         <ImageMultipleFileDropZone
           @update:modelValue="(newFiles) => (files = newFiles)"
+          @file-deleted="handleFileDeleted"
           :model-value="files"
           :uploadLimit="uploadLimit"
         />
@@ -46,8 +47,18 @@ const props = withDefaults(defineProps<Props>(), {
 });
 const orgId = computed(() => props.orgId);
 const { data: organizationImages } = useGetOrganizationImages(orgId);
-const { updateImage, uploadImages } = useOrganizationImageMutations(orgId);
+const { updateImage, uploadImages, refreshOrganizationImagesData } =
+  useOrganizationImageMutations(orgId);
 const files = ref<FileUploadMix[]>([]);
+
+// useFileManager.removeFile() deletes on the server but doesn't invalidate
+// the organizationImages cache, so the carousel stays stale until reload
+// (issue #1791). Only server-side images (`type === "file"`) need a refresh.
+const handleFileDeleted = async (file: FileUploadMix) => {
+  if (file?.type === "file") {
+    await refreshOrganizationImagesData();
+  }
+};
 
 watch(
   organizationImages,


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

Deleting an image from the upload modal left the carousel stale until a full page reload.
**Cause:** `useFileManager.removeFile()` deletes on the server but can't invalidate the `useAsyncData` cache behind `useGetOrganizationImages` / `useGetGroupImages`. The drop zone already emits `file-deleted` for this case — no parent was listening.
**Fix:** wire `@file-deleted` in both upload modals to the existing `refreshOrganizationImagesData` / `refreshGroupData` helpers (same helpers `uploadImages`/`updateImage` already use). Only refreshes for server-side images (`type === "file"`).
**Files:**
- `ModalUploadImageOrganization.vue`, `ModalUploadImageGroup.vue` — wire the event.
- `MediaImageCarousel.vue` — add `data-testid` (`image-carousel-main` / `-fullscreen`) for reliable E2E selectors.
**Tested:** manual upload → delete round-trip on Desktop and Mobile Chrome, both org and group carousels update without reload. Prettier clean.


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #2108
- Closes #1791
