### PR TITLE
chore(frontend): drop i18n.test.* placeholders from button specs

### DIFF
--- a/frontend/test/components/btn/BtnTag.spec.ts
+++ b/frontend/test/components/btn/BtnTag.spec.ts
@@ -9,7 +9,7 @@ describe("BtnTag", () => {
   const defaultProps = {
     cta: true,
     fontSize: "base" as const,
-    ariaLabel: "i18n.test.button",
+    ariaLabel: "tag button aria",
   };
 
   it("renders button with aria-label", async () => {

--- a/frontend/test/components/btn/action/BtnAction.spec.ts
+++ b/frontend/test/components/btn/action/BtnAction.spec.ts
@@ -9,7 +9,7 @@ describe("BtnAction", () => {
   const defaultProps = {
     cta: true,
     fontSize: "base" as const,
-    ariaLabel: "i18n.test.button",
+    ariaLabel: "action button aria",
   };
 
   it("renders button with aria-label", async () => {

--- a/frontend/test/components/btn/action/BtnActionDropdown.spec.ts
+++ b/frontend/test/components/btn/action/BtnActionDropdown.spec.ts
@@ -30,12 +30,12 @@ describe("BtnActionDropdown", () => {
   const defaultProps = {
     cta: true,
     fontSize: "base" as const,
-    ariaLabel: "i18n.test.main",
-    ariaLabelDropdown: "i18n.test.dropdown",
+    ariaLabel: "dropdown main aria",
+    ariaLabelDropdown: "dropdown toggle aria",
     dropdownIcon: "bi:chevron-down",
     dropdownOptions: ["Option 1", "Option 2"],
     dropdownOptionsCallback: mockCallback,
-    label: "i18n.test.label",
+    label: "dropdown label",
     leftIcon: "bi:filter",
     iconSize: "1em",
   };

--- a/frontend/test/components/btn/route/BtnRouteExternal.spec.ts
+++ b/frontend/test/components/btn/route/BtnRouteExternal.spec.ts
@@ -9,7 +9,7 @@ describe("BtnRouteExternal", () => {
   const defaultProps = {
     cta: true,
     fontSize: "base" as const,
-    ariaLabel: "i18n.test.external",
+    ariaLabel: "external route aria",
     linkTo: "https://example.com",
   };
 

--- a/frontend/test/components/btn/route/BtnRouteInternal.spec.ts
+++ b/frontend/test/components/btn/route/BtnRouteInternal.spec.ts
@@ -25,7 +25,7 @@ describe("BtnRouteInternal", () => {
   const defaultProps = {
     cta: true,
     fontSize: "base" as const,
-    ariaLabel: "i18n.test.link",
+    ariaLabel: "internal route aria",
     linkTo: "/test-page",
   };
 

--- a/frontend/test/setup.ts
+++ b/frontend/test/setup.ts
@@ -57,8 +57,9 @@ const i18n = createI18n({
   locale: "en",
   fallbackLocale: "en",
   messages: Object.assign({ en }),
-  // Suppress missing key warnings in test environment.
-  // Test keys like "i18n.test.button" don't exist in locale files.
+  // Tests often pass plain placeholder strings into props that are translated
+  // at runtime (e.g. ariaLabel). Suppress the resulting missing-key noise so
+  // it does not drown out genuine warnings in test output.
   missingWarn: false,
   fallbackWarn: false,
 });


### PR DESCRIPTION
Replace i18n.test.* placeholder strings in the 5 button spec files with plain descriptive strings, and update the comment in test/setup.ts since the example it cited no longer exists.

The runtime missingWarn/fallbackWarn suppression in setup.ts has to stay: button components call t(ariaLabel) at runtime, so vue-i18n warns for any unresolved string regardless of shape. The static-check fix and the runtime suppression are separate concerns.

Prep work for activist-org/activist#2114 so enabling nonexistent-keys: search-dirs in i18n-check no longer flags these 6 keys.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

## What

Renames the 6 `i18n.test.*` placeholder strings in the 5 button spec files to plain descriptive strings (e.g. `"tag button aria"`), and updates the comment in `test/setup.ts` since the example it cited won't exist anymore.

## Why

Prep work for #2114. Once `nonexistent-keys: search-dirs` gets enabled in `i18n-check`, those 6 keys would get flagged. They're not real translations though — the button templates do `:aria-label="$t(ariaLabel)"`, and the tests just assert prop pass-through (class names, `aria-label` is set, etc.) without caring about the rendered string. Plain strings serve the same purpose and drop off the static checker since `i18n-check` only flags `i18n.*`-shaped strings.

## On the runtime suppression

Tried dropping `missingWarn: false` / `fallbackWarn: false` from `test/setup.ts` first and it doesnt work — `$t("tag button aria")` still misses at runtime and warns, and at least one unrelated test (`DropdownTheme`) relies on the same suppression. Static-check fix and runtime suppression are separate concerns, so this PR only handles the first.

## Validation

- `yarn test` — 1855 passed, no regressions
- `yarn prettier --check` on chang

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- #2114 
