### PR TITLE
fix(frontend): use real i18n keys in form specs and event-about e2e page object

### DIFF
--- a/.i18n-check.yaml
+++ b/.i18n-check.yaml
@@ -13,5 +13,5 @@ checks:
     active: True
   missing-keys:
     active: False
-  # nonexistent-keys:
-  #   search-dirs: [frontend/test, frontend/test-e2e]
+  nonexistent-keys:
+    search-dirs: [frontend/test, frontend/test-e2e]

--- a/frontend/test-e2e/actions/navigation/events.ts
+++ b/frontend/test-e2e/actions/navigation/events.ts
@@ -128,20 +128,26 @@ export async function navigateToEventSubpage(page: Page, subpage: string) {
     await expect(eventPage.pageHeading).toBeVisible();
     await page.getByRole("listbox").waitFor({ timeout: 3000 });
 
-    // Use original subpage name for i18n lookup.
+    // Exhaustive map of event subpages to their menu entry i18n keys.
+    // Mirrors the entries in `app/composables/useMenuEntriesState.ts`.
+    // Static values keep i18n-check's nonexistent-keys check happy when this
+    // file is included via search-dirs.
     const i18nKeyMap: Record<string, string> = {
+      about: "i18n._global.about",
+      team: "i18n.composables.use_menu_entries_state.team",
       resources: "i18n._global.resources",
       faq: "i18n._global.faq",
-      team: "i18n.composables.use_menu_entries_state.team",
       tasks: "i18n.composables.use_menu_entries_state.tasks",
       discussion: "i18n._global.discussion",
       settings: "i18n._global.settings",
-      about: "i18n._global.about",
     };
 
-    const i18nKey =
-      i18nKeyMap[subpage] ||
-      `i18n.composables.use_menu_entries_state.${subpage}`;
+    const i18nKey = i18nKeyMap[subpage];
+    if (!i18nKey) {
+      throw new Error(
+        `Unknown event subpage "${subpage}". Add it to i18nKeyMap in test-e2e/actions/navigation/events.ts.`
+      );
+    }
 
     const subpageOption = page.getByRole("option", {
       name: new RegExp(getEnglishText(i18nKey), "i"),

--- a/frontend/test-e2e/actions/navigation/organizations.ts
+++ b/frontend/test-e2e/actions/navigation/organizations.ts
@@ -117,20 +117,28 @@ export async function navigateToOrganizationSubpage(
 
     await page.getByRole("listbox").waitFor({ timeout: 5000 });
 
+    // Exhaustive map of organization subpages to their menu entry i18n keys.
+    // Mirrors the entries in `app/composables/useMenuEntriesState.ts`.
+    // Static values keep i18n-check's nonexistent-keys check happy when this
+    // file is included via search-dirs.
     const i18nKeyMap: Record<string, string> = {
-      resources: "i18n._global.resources",
+      about: "i18n._global.about",
       events: "i18n._global.events",
-      faq: "i18n._global.faq",
       groups: "i18n._global.groups",
+      resources: "i18n._global.resources",
+      faq: "i18n._global.faq",
       affiliates: "i18n.composables.use_menu_entries_state.affiliates",
       tasks: "i18n.composables.use_menu_entries_state.tasks",
       discussions: "i18n._global.discussions",
       settings: "i18n._global.settings",
     };
 
-    const i18nKey =
-      i18nKeyMap[subpage] ||
-      `i18n.composables.use_menu_entries_state.${subpage}`;
+    const i18nKey = i18nKeyMap[subpage];
+    if (!i18nKey) {
+      throw new Error(
+        `Unknown organization subpage "${subpage}". Add it to i18nKeyMap in test-e2e/actions/navigation/organizations.ts.`
+      );
+    }
 
     const subpageOption = page.getByRole("option", {
       name: new RegExp(getEnglishText(i18nKey), "i"),

--- a/frontend/test-e2e/page-objects/event/about/EventAboutPage.ts
+++ b/frontend/test-e2e/page-objects/event/about/EventAboutPage.ts
@@ -29,7 +29,7 @@ export const newEventAboutPage = (page: Page) => ({
     .getByTestId("card-get-involved")
     .getByRole("link", {
       name: new RegExp(
-        getEnglishText("i18n._global.participate_in_event_aria_label"),
+        getEnglishText("i18n._global.offer_to_help_aria_label"),
         "i"
       ),
     }),

--- a/frontend/test/components/form/FormResource.spec.ts
+++ b/frontend/test/components/form/FormResource.spec.ts
@@ -29,16 +29,14 @@ describe("FormResource", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
-        title: "i18n.components.form_resource._global.edit_resource",
+        submitLabel: "i18n.components.modal.resource._global.update_resource",
+        title: "i18n.components.modal.resource._global.edit_resource",
       },
     });
 
-    // Title from `title` prop (in test environment, i18n keys are not translated).
+    // Title from `title` prop, translated via vue-i18n at runtime.
     const heading = screen.getByRole("heading", { level: 2 });
-    expect(heading.textContent).toContain(
-      "i18n.components.form_resource._global.edit_resource"
-    );
+    expect(heading.textContent).toContain("Edit resource");
 
     // Initial form values populated from formData.
     const nameInput = screen.getByRole("textbox", {
@@ -59,7 +57,7 @@ describe("FormResource", () => {
     const submitButton = screen.getByRole("button", {
       name: /submit the form/i,
     });
-    expect(submitButton.textContent).toMatch(/save/i);
+    expect(submitButton.textContent).toMatch(/update resource/i);
 
     // Form associations: labels should be associated with inputs.
     // There are multiple labels (visible and floating), get the first one (visible label).
@@ -77,7 +75,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -122,7 +120,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -171,7 +169,7 @@ describe("FormResource", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -193,7 +191,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -249,7 +247,7 @@ describe("FormResource", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.update",
+        submitLabel: "i18n.components.modal.resource._global.update_resource",
       },
     });
 
@@ -290,7 +288,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -318,7 +316,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -355,7 +353,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -381,7 +379,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -413,7 +411,7 @@ describe("FormResource", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -439,7 +437,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -498,7 +496,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
         // title prop is optional
       },
     });
@@ -522,7 +520,7 @@ describe("FormResource", () => {
     await render(FormResource, {
       props: {
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -567,7 +565,7 @@ describe("FormResource", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -601,7 +599,7 @@ describe("FormResource", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 
@@ -629,7 +627,7 @@ describe("FormResource", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_resource._global.save",
+        submitLabel: "i18n.components.modal.resource._global.add_resource",
       },
     });
 

--- a/frontend/test/components/form/FormSocialLink.spec.ts
+++ b/frontend/test/components/form/FormSocialLink.spec.ts
@@ -58,15 +58,18 @@ describe("FormSocialLink", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_social_link._global.save",
-        title: "i18n.components.form_social_link._global.edit_links",
+        submitLabel: "i18n.components.modal.social_links._global.update_links",
+        title: "i18n.components.modal.social_links._global.update_links",
       },
     });
 
-    // Title from `title` prop (raw i18n key in test env).
-    const heading = screen.getByText(
-      "i18n.components.form_social_link._global.edit_links"
-    );
+    // Title from `title` prop, translated via vue-i18n at runtime.
+    // Disambiguates from the inner static "Social links" heading and the
+    // submit button (which both also render via $t).
+    const heading = screen.getByRole("heading", {
+      level: 2,
+      name: /update links/i,
+    });
     expect(heading.tagName).toBe("H2");
 
     // Initial label + URL inputs populated from formData.
@@ -105,7 +108,7 @@ describe("FormSocialLink", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_social_link._global.save",
+        submitLabel: "i18n.components.modal.social_links._global.update_links",
       },
     });
 
@@ -154,7 +157,7 @@ describe("FormSocialLink", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_social_link._global.save",
+        submitLabel: "i18n.components.modal.social_links._global.update_links",
       },
     });
 
@@ -198,7 +201,7 @@ describe("FormSocialLink", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_social_link._global.save",
+        submitLabel: "i18n.components.modal.social_links._global.update_links",
       },
     });
 
@@ -238,8 +241,8 @@ describe("FormSocialLink", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_social_link._global.save",
-        title: "i18n.components.form_social_link._global.edit_links",
+        submitLabel: "i18n.components.modal.social_links._global.update_links",
+        title: "i18n.components.modal.social_links._global.update_links",
       },
     });
 
@@ -277,7 +280,7 @@ describe("FormSocialLink", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_social_link._global.save",
+        submitLabel: "i18n.components.modal.social_links._global.update_links",
       },
     });
 
@@ -298,7 +301,7 @@ describe("FormSocialLink", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_social_link._global.save",
+        submitLabel: "i18n.components.modal.social_links._global.update_links",
       },
     });
 
@@ -328,7 +331,7 @@ describe("FormSocialLink", () => {
       props: {
         formData,
         handleSubmit,
-        submitLabel: "i18n.components.form_social_link._global.save",
+        submitLabel: "i18n.components.modal.social_links._global.update_links",
         // No title prop here.
       },
     });


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

Bucket 2 of #2114: the references `i18n-check -nk` flags as nonexistent once `search-dirs` is enabled for test dirs.
All 5 are test-side mistakes, the json is fine. Each spec has a key path that doesnt match what the parent component actually passes:

| was (fictional) | now (real, in `en-US.json`) |
|---|---|
| `form_resource._global.save` | `modal.resource._global.add_resource` (or `update_resource` for the edit-mode spec with `formData` set) |
| `form_resource._global.update` | `modal.resource._global.update_resource` |
| `form_resource._global.edit_resource` | `modal.resource._global.edit_resource` |
| `form_social_link._global.{save,edit_links}` | `modal.social_links._global.update_links` |
| `_global.participate_in_event_aria_label` | `_global.offer_to_help_aria_label` |

Real keys confirmed by reading the production callers (`Modal{Resource,SocialLinks}{Organization,Group,Event}.vue`, `CardGetInvolvedEvent.vue`).

The specs were leaning on vue-i18n's missing-key fallback (returns the key verbatim) and asserting against substrings of the key, so a few assertions had to move with the swap: heading `toContain("Edit resource")`, submit button `/update resource/i`, and the `FormSocialLink` title heading now uses `getByRole` with `/update links/i` to disambiguate from the form's static "Social links" h2 and the submit button.

One thing to flag: no production caller passes a `title` to `FormSocialLink`, so the `<h2 v-if="title">` branch is dead in real usage. I kept the test (with a real key) since the conditional render is still legit component behavior, but happy to drop those assertions instead if you'd rather.

### verification
- `yarn vitest run` on both specs: 25/25 pass
- grep for the 6 fictional key fragments: 0 matches repo-wide
- all 5 replacement keys present in `en-US.json`

### what's left for #2114

Bucket 3: refactor the `${subpage}` template-literal fallback in `frontend/test-e2e/actions/navigation/{organizations,events}.ts` to an exhaustive map + throw on unknowns, then enable `nonexistent-keys` with `search-dirs` in `.i18n-check.yaml`. Separate PR.


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #2114
