### PR TITLE
fix(frontend): org image upload modal shows empty file list after upload

### DIFF
--- a/frontend/app/components/image/ImageMultipleFileDropZone.vue
+++ b/frontend/app/components/image/ImageMultipleFileDropZone.vue
@@ -50,9 +50,13 @@
       ghost-class="opacity-0"
       tag="div"
     >
-      <template #item="{ element: file }">
+      <template #item="{ element: file, index }">
         <span class="pb-4">
-          <button @click="handleRemoveFile(file)" class="text-action-red">
+          <button
+            @click="handleRemoveFile(file)"
+            class="text-action-red"
+            :data-testid="`upload-image-remove-${index}`"
+          >
             <Icon :name="IconMap.X_SM" size="1.5em" />
           </button>
           <img
@@ -97,7 +101,7 @@ function emitFiles() {
 }
 
 watch(
-  props.modelValue,
+  () => props.modelValue,
   (newValue) => {
     localFiles.value = newValue;
   },

--- a/frontend/app/components/modal/upload-image/ModalUploadImageGroup.vue
+++ b/frontend/app/components/modal/upload-image/ModalUploadImageGroup.vue
@@ -69,7 +69,8 @@ watch(
       data: image,
       sequence: index,
     })) as FileUploadMix[];
-    files.value = images.concat(files.value);
+    const pendingUploads = files.value.filter((f) => f.type === "upload");
+    files.value = images.concat(pendingUploads);
     return;
   },
   { immediate: true, deep: true }

--- a/frontend/app/components/modal/upload-image/ModalUploadImageOrganization.vue
+++ b/frontend/app/components/modal/upload-image/ModalUploadImageOrganization.vue
@@ -22,6 +22,7 @@
           @click="handleUpload"
           ariaLabel="i18n.components._global.upvote_application_aria_label"
           :cta="true"
+          data-testid="upload-image-upload-button"
           :disabled="files.length === 0 || files.length > uploadLimit"
           fontSize="sm"
           iconSize="1.25em"
@@ -68,7 +69,8 @@ watch(
       data: image,
       sequence: index,
     })) as FileUploadMix[];
-    files.value = images.concat(files.value);
+    const pendingUploads = files.value.filter((f) => f.type === "upload");
+    files.value = images.concat(pendingUploads);
     return;
   },
   { immediate: true, deep: true }

--- a/frontend/app/layouts/group/GroupPage.vue
+++ b/frontend/app/layouts/group/GroupPage.vue
@@ -4,7 +4,7 @@
     <ModalUploadImageGroup
       @closeModal="handleCloseModalUploadImage"
       @upload-complete="handleUploadComplete"
-      :groupId="group?.id || ''"
+      :groupId="groupId || ''"
       :images="images || []"
     />
     <ModalUploadImageIcon

--- a/frontend/app/layouts/organization/OrganizationPage.vue
+++ b/frontend/app/layouts/organization/OrganizationPage.vue
@@ -8,7 +8,7 @@
     />
     <ModalUploadImageIcon
       @closeModal="handleCloseModalUploadImageIcon"
-      :entityId="organization?.id || ''"
+      :entityId="orgId || ''"
       :entityType="EntityType.ORGANIZATION"
     />
     <ModalQRCode />

--- a/frontend/app/layouts/organization/OrganizationPage.vue
+++ b/frontend/app/layouts/organization/OrganizationPage.vue
@@ -4,7 +4,7 @@
     <ModalUploadImageOrganization
       @closeModal="handleCloseModalUploadImage"
       :images="images || []"
-      :orgId="organization?.id || ''"
+      :orgId="orgId || ''"
     />
     <ModalUploadImageIcon
       @closeModal="handleCloseModalUploadImageIcon"

--- a/frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts
+++ b/frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts
@@ -211,16 +211,11 @@ test.describe("Event FAQ Page", { tag: ["@desktop"] }, () => {
     await expect(confirmationModal).not.toBeVisible();
     await page.waitForLoadState("domcontentloaded");
 
+    // Assert on our specific FAQ only — total count is unreliable under fullyParallel
+    // because the "view and interact" test runs concurrently and may add FAQ cards.
     await expect(
       faqPage.faqCards.filter({ hasText: updatedQuestion })
-    ).not.toBeVisible({ timeout: 15000 });
-
-    await expect
-      .poll(async () => faqPage.getFAQCount(), {
-        timeout: 20000,
-        intervals: [100, 200, 500],
-      })
-      .toBe(initialFaqCount);
+    ).toHaveCount(0, { timeout: 20000 });
   });
 
   // MARK: View and Interact


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

- [x] This pull request is on a separate branch and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the testing section of the contributing guide

---

### Description

Fixes the org image upload modal showing "Number of files: 0" after an upload. The upload itself succeeds and the carousel updates, but reopening the modal shows nothing. Related to #1791, the delete path was fixed in #2109 but this upload path was not fixed.

Found three issues while tracing through the E2E tests in #1665:

- **`OrganizationPage.vue`** — the layout was passing `organization?.id` to the modal as `orgId`, but that value is `null` on first render before the org data loads. This meant the modal's data fetcher registered under the wrong cache key, so the post-upload cache refresh never reached it. Fixed by passing the route param instead, which is always correct.

- **`ImageMultipleFileDropZone.vue`** — `watch(props.modelValue)` was missing a getter function, so Vue never detected when the parent replaced the file array. Changed to `watch(() => props.modelValue)`.

- **`ModalUploadImageOrganization.vue`** — the watch that populates the file list was appending new results on top of existing ones instead of replacing them, causing duplicates to accumulate across refreshes.

Tested manually and via the E2E tests in #1665.

### Related issue

- Closes #2117 
