### PR TITLE
ci(e2e): start filescan service in E2E workflows and wait for it to be ready

### DIFF
--- a/.github/workflows/ci_e2e_playwright_desktop.yaml
+++ b/.github/workflows/ci_e2e_playwright_desktop.yaml
@@ -54,7 +54,7 @@ jobs:
           ! nc -z localhost 5432
 
       - name: Run Docker Compose
-        run: docker compose --env-file .env.dev up --build -d backend db
+        run: docker compose --env-file .env.dev up --build -d backend db filescan
 
       - name: Wait for Database
         run: |
@@ -63,6 +63,10 @@ jobs:
       - name: Wait for Backend
         run: |
           timeout 180 bash -c 'until curl -s http://localhost:8000/v1/auth/sign_in -o /dev/null -w "%{http_code}" | grep -qE "^(200|405)"; do sleep 3; done'
+
+      - name: Wait for Filescan
+        run: |
+          timeout 180 bash -c 'until curl -s -o /dev/null http://localhost:9101/health; do sleep 3; done'
 
       - name: Setup Node Environment
         uses: actions/setup-node@v5

--- a/.github/workflows/ci_e2e_playwright_mobile.yaml
+++ b/.github/workflows/ci_e2e_playwright_mobile.yaml
@@ -54,7 +54,7 @@ jobs:
           ! nc -z localhost 5432
 
       - name: Run Docker Compose
-        run: docker compose --env-file .env.dev up --build -d backend db
+        run: docker compose --env-file .env.dev up --build -d backend db filescan
 
       - name: Wait for Database
         run: |
@@ -63,6 +63,10 @@ jobs:
       - name: Wait for Backend
         run: |
           timeout 180 bash -c 'until curl -s http://localhost:8000/v1/auth/sign_in -o /dev/null -w "%{http_code}" | grep -qE "^(200|405)"; do sleep 3; done'
+
+      - name: Wait for Filescan
+        run: |
+          timeout 180 bash -c 'until curl -s -o /dev/null http://localhost:9101/health; do sleep 3; done'
 
       - name: Setup Node Environment
         uses: actions/setup-node@v5

--- a/frontend/test-e2e/specs/all/events/event-about/event-about-permissions.spec.ts
+++ b/frontend/test-e2e/specs/all/events/event-about/event-about-permissions.spec.ts
@@ -231,7 +231,18 @@ test.describe(
             .getInvolvedField(editModal.modal)
             .fill(updatedGetInvolved);
           await editModal.joinUrlField(editModal.modal).fill(updatedJoinUrl);
+
+          // Register before click so the response is captured even if it
+          // resolves before the await below.
+          const updateResponse = page.waitForResponse(
+            (res) =>
+              res.request().method() === "PUT" &&
+              /\/events\/event_texts\//i.test(new URL(res.url()).pathname),
+            { timeout: 20000 }
+          );
           await editModal.submitButton(editModal.modal).click();
+          await updateResponse;
+
           await expect(editModal.modal).not.toBeVisible();
         }
       );

--- a/frontend/test-e2e/specs/all/events/event-about/event-about-permissions.spec.ts
+++ b/frontend/test-e2e/specs/all/events/event-about/event-about-permissions.spec.ts
@@ -195,7 +195,18 @@ test.describe(
           await expect(editModal.modal).toBeVisible();
           const descriptionField = editModal.descriptionField(editModal.modal);
           await descriptionField.fill(updatedDescription);
+
+          // Register before click so the response is captured even if it
+          // resolves before the await below.
+          const updateResponse = page.waitForResponse(
+            (res) =>
+              res.request().method() === "PUT" &&
+              /\/events\/event_texts\//i.test(new URL(res.url()).pathname),
+            { timeout: 20000 }
+          );
           await editModal.submitButton(editModal.modal).click();
+          await updateResponse;
+
           await expect(editModal.modal).not.toBeVisible();
         }
       );

--- a/frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts
+++ b/frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts
@@ -103,7 +103,7 @@ test.describe("Event FAQ Page", { tag: ["@desktop"] }, () => {
     const createFaqResponse = page.waitForResponse(
       (res) =>
         res.request().method() === "POST" &&
-        /\/events\/event_faqs\//i.test(new URL(res.url()).pathname),
+        /\/events\/event_faqs/i.test(new URL(res.url()).pathname),
       { timeout: 20000 }
     );
 

--- a/frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts
+++ b/frontend/test-e2e/specs/all/events/event-faq/event-faq-page.spec.ts
@@ -98,13 +98,26 @@ test.describe("Event FAQ Page", { tag: ["@desktop"] }, () => {
     await expect(questionInput).toHaveValue(newQuestion);
     await expect(answerInput).toHaveValue(newAnswer);
 
+    // Register listener before click so it captures the response even if
+    // the request resolves before the await below.
+    const createFaqResponse = page.waitForResponse(
+      (res) =>
+        res.request().method() === "POST" &&
+        /\/events\/event_faqs\//i.test(new URL(res.url()).pathname),
+      { timeout: 20000 }
+    );
+
     // Submit the form.
     await submitButton.click();
 
+    const createRes = await createFaqResponse;
+    expect(
+      [200, 201].includes(createRes.status()),
+      `POST event FAQ expected 200 or 201, got ${createRes.status()}`
+    ).toBe(true);
+
     // Wait for modal to close.
     await expect(faqPage.faqModal).not.toBeVisible();
-    await page.waitForLoadState("domcontentloaded");
-    await page.waitForTimeout(1000);
 
     // Verify the new FAQ appears on the page (don't check exact count as there may be existing FAQs).
     const newFaqCard = faqPage.faqCards.filter({ hasText: newQuestion });
@@ -146,13 +159,28 @@ test.describe("Event FAQ Page", { tag: ["@desktop"] }, () => {
     await expect(editQuestionInput).toHaveValue(updatedQuestion);
     await expect(editAnswerInput).toHaveValue(updatedAnswer);
 
+    // Register listener before click so it captures the response even if
+    // the request resolves before the await below.
+    const updateFaqResponse = page.waitForResponse(
+      (res) =>
+        (res.request().method() === "PATCH" ||
+          res.request().method() === "PUT") &&
+        /\/events\/event_faqs\//i.test(new URL(res.url()).pathname),
+      { timeout: 20000 }
+    );
+
     // Submit the edit.
     await editSubmitButton.click();
+
+    const updateRes = await updateFaqResponse;
+    expect(
+      [200, 204].includes(updateRes.status()),
+      `PATCH event FAQ expected 200 or 204, got ${updateRes.status()}`
+    ).toBe(true);
 
     // Wait for modal to close.
     await expect(faqPage.editFAQModal).not.toBeVisible();
     await page.waitForLoadState("domcontentloaded");
-    await page.waitForTimeout(1000);
 
     // Verify the updated FAQ appears on the page.
     const updatedFaqCard = faqPage.faqCards.filter({
@@ -184,6 +212,7 @@ test.describe("Event FAQ Page", { tag: ["@desktop"] }, () => {
 
     // Delete the FAQ we created and edited.
     const deleteButton = updatedFaqCard.getByTestId("faq-delete-button");
+    await expect(deleteButton).toBeVisible({ timeout: 10000 });
     await deleteButton.click();
 
     // Verify confirmation modal opens.


### PR DESCRIPTION
The filescan service was not included in the docker compose startup for either E2E workflow. Django's image upload view calls scan_uploads_and_rewind before saving any file, which POSTs to http://filescan:9101/scan. With the service absent, httpx throws a RequestError that Django wraps as HTTP 400 ("The file could not be scanned."), causing every image upload test to fail in CI regardless of whether the app and test code are correct.

Add `filescan` to the compose command and poll http://localhost:9101/health until uvicorn responds before running Playwright tests. The wait uses curl without -f because the /health endpoint permanently returns 503 (the ClamAV instream protocol rejects the empty-byte probe used by the health check) even when real file scans work correctly. A plain HTTP response is sufficient since the entrypoint only starts uvicorn after confirming the ClamAV socket exists, so any response means actual uploads will succeed.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->
## Summary

Both `ci_e2e_playwright_desktop.yaml` and `ci_e2e_playwright_mobile.yaml` only started `backend` and `db` in their Docker Compose step. The `filescan` service was never started.

Django's image upload view calls `scan_uploads_and_rewind` before saving any uploaded file, which POSTs to `http://filescan:9101/scan`. With the service absent, `httpx` throws a `RequestError` that Django wraps as HTTP 400:

```json
{"nonFieldErrors": ["The file could not be scanned. Please try again later."]}
```

This caused every E2E test that uploads an image to fail in CI regardless of whether the app and test code were correct. The failure was not obvious because the frontend's `uploadImages()` catches errors internally and closes the modal anyway, so tests failed at a downstream assertion (`data-slide-count` staying at the placeholder value) rather than at the upload step itself.

## Changes

- Add `filescan` to the `docker compose up` command in both workflows
- Add a "Wait for Filescan" step that polls `http://localhost:9101/health` until uvicorn responds before Playwright runs

The wait uses `curl` without `-f` intentionally. The `/health` endpoint returns 503 even when the service can scan real files. Using `-f` would block indefinitely. A plain HTTP response (any status) is sufficient: the service entrypoint only starts uvicorn after confirming the ClamAV socket exists, so if the server responds at all, real file scans will succeed.

Tested on my fork and it passes CI

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Discovered while debugging #1665.
- Closes #2123 
