### PR TITLE
E2E: org + event create modals (coverage, helpers, WebKit auth tweak)

### DIFF
--- a/frontend/test-e2e/component-objects/CreateOrganizationModal.ts
+++ b/frontend/test-e2e/component-objects/CreateOrganizationModal.ts
@@ -11,8 +11,8 @@ export const newCreateOrganizationModal = (page: Page) => {
     root,
     closeButton: root.getByTestId("modal-close-button"),
 
-    // MARK: Details
-    detailsForm: root.locator("#event-details"),
+    // MARK: Details (`MachineStepsCreateOrganizationDetails` form id).
+    detailsForm: root.locator("#organization-details"),
     nameField: root.locator("#form-item-name"),
     taglineField: root.locator("#form-item-tagline"),
     descriptionField: root.locator("#form-item-description"),
@@ -22,10 +22,16 @@ export const newCreateOrganizationModal = (page: Page) => {
     countryField: root.locator("#form-item-country"),
     cityField: root.locator("#form-item-city"),
 
+    /** Location step primary submit (`MachineStepsCreateOrganizationsLocation` form id `event-location`). */
+    submitLocationButton: root.locator("#event-location-submit"),
+
     // MARK: Step Buttons
     getNextStepButton(): Locator {
       return root.getByRole("button", {
-        name: new RegExp(getEnglishText("i18n._global.next_step"), "i"),
+        name: new RegExp(
+          getEnglishText("i18n.components.submit_aria_label"),
+          "i"
+        ),
       });
     },
 

--- a/frontend/test-e2e/component-objects/CreateOrganizationModal.ts
+++ b/frontend/test-e2e/component-objects/CreateOrganizationModal.ts
@@ -11,7 +11,7 @@ export const newCreateOrganizationModal = (page: Page) => {
     root,
     closeButton: root.getByTestId("modal-close-button"),
 
-    // MARK: Details (`MachineStepsCreateOrganizationDetails` form id).
+    // MARK: Organization Details
     detailsForm: root.locator("#organization-details"),
     nameField: root.locator("#form-item-name"),
     taglineField: root.locator("#form-item-tagline"),
@@ -21,8 +21,6 @@ export const newCreateOrganizationModal = (page: Page) => {
     locationForm: root.locator("#event-location"),
     countryField: root.locator("#form-item-country"),
     cityField: root.locator("#form-item-city"),
-
-    /** Location step primary submit (`MachineStepsCreateOrganizationsLocation` form id `event-location`). */
     submitLocationButton: root.locator("#event-location-submit"),
 
     // MARK: Step Buttons

--- a/frontend/test-e2e/global-fixtures.ts
+++ b/frontend/test-e2e/global-fixtures.ts
@@ -10,6 +10,7 @@ import {
   ADMIN_AUTH_STATE_PATH,
   MEMBER_AUTH_STATE_PATH,
 } from "~/test-e2e/constants/authPaths";
+import { normalizeAuthStorageLoopbackSecureCookies } from "~/test-e2e/utils/normalize-auth-storage-for-webkit-http";
 
 export { MEMBER_AUTH_STATE_PATH };
 
@@ -75,12 +76,14 @@ export const test = base.extend<{ page: Page }>({
           await page.goto("/auth/sign-in", { waitUntil: "load" });
           await signIn(page, "activist_0", "password", "**/home");
           await page.context().storageState({ path: MEMBER_AUTH_STATE_PATH });
+          normalizeAuthStorageLoopbackSecureCookies(MEMBER_AUTH_STATE_PATH);
           lastRenewalTime = Date.now();
         }
       } else if (needsRenewal) {
         await page.goto("/auth/sign-in", { waitUntil: "load" });
         await signInAsAdmin(page, "admin", "admin", true);
         await page.context().storageState({ path: ADMIN_AUTH_STATE_PATH });
+        normalizeAuthStorageLoopbackSecureCookies(ADMIN_AUTH_STATE_PATH);
         lastRenewalTime = Date.now();
       }
     }

--- a/frontend/test-e2e/global-setup.ts
+++ b/frontend/test-e2e/global-setup.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import path from "path";
 
 import { signInAsAdmin } from "~/test-e2e/actions/authentication";
+import { normalizeAuthStorageLoopbackSecureCookies } from "~/test-e2e/utils/normalize-auth-storage-for-webkit-http";
 import {
   quickServerHealthCheck,
   waitForServerReady,
@@ -133,6 +134,14 @@ async function globalSetup(config: FullConfig) {
     throw new Error("baseURL is not configured in playwright.config.ts");
   }
 
+  /** Same paths as playwright.config / authPaths `.auth/` directory. */
+  const normalizeAuthFilesLoopbackCookies = (): void => {
+    const authDir = path.join(__dirname, ".auth");
+    for (const name of ["admin.json", "member.json"]) {
+      normalizeAuthStorageLoopbackSecureCookies(path.join(authDir, name));
+    }
+  };
+
   const accounts: AuthAccount[] = [
     {
       username: "admin",
@@ -149,6 +158,7 @@ async function globalSetup(config: FullConfig) {
   ];
 
   if (accounts.every((a) => isAuthStateValid(a.authFile))) {
+    normalizeAuthFilesLoopbackCookies();
     return;
   }
 
@@ -181,6 +191,8 @@ async function globalSetup(config: FullConfig) {
     if (isAuthStateValid(account.authFile)) continue;
     await createAuthState(baseURL, account);
   }
+
+  normalizeAuthFilesLoopbackCookies();
 }
 
 export default globalSetup;

--- a/frontend/test-e2e/specs/all/create-flows/event-create-modal.spec.ts
+++ b/frontend/test-e2e/specs/all/create-flows/event-create-modal.spec.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import type { Page } from "@playwright/test";
+import type { Page, Response } from "@playwright/test";
 
 import { getEnglishText } from "#shared/utils/i18n";
 
@@ -9,31 +9,18 @@ import { newCreateEventModal } from "~/test-e2e/component-objects/CreateEventMod
 import { newSidebarLeft } from "~/test-e2e/component-objects/SidebarLeft";
 import { newSidebarRight } from "~/test-e2e/component-objects/SidebarRight";
 import { expect, test } from "~/test-e2e/global-fixtures";
+import {
+  E2E_GEO_REFERENCE_COUNTRY,
+  selectCountryComboboxOption,
+} from "~/test-e2e/utils/modal-helpers";
 import { logTestPath } from "~/test-e2e/utils/test-traceability";
 
-test.beforeEach(async ({ page }) => {
-  await page.goto("/home");
-  await page.waitForURL("**/home**");
-
-  const viewportSize = page.viewportSize();
-  const isMobileLayout = viewportSize ? viewportSize.width < 768 : false;
-
-  if (isMobileLayout) {
-    const sidebarRight = newSidebarRight(page);
-    await sidebarRight.openButton.click();
-    await expect(sidebarRight.closeButton).toBeVisible();
-    const createDropdown = newCreateDropdown(page, {
-      root: page.locator("#drawer-navigation"),
-    });
-    await createDropdown.clickNewEvent();
-  } else {
-    await expect(page.locator("#sidebar-left")).toBeVisible({ timeout: 15000 });
-    const sidebarLeft = newSidebarLeft(page);
-    await sidebarLeft.open();
-    const createDropdown = newCreateDropdown(page);
-    await createDropdown.clickNewEvent();
-  }
-});
+/** POST create-event (`services/event/event.ts`: `POST /events/events`). */
+function isPostCreateEventResponse(res: Response): boolean {
+  if (res.request().method() !== "POST") return false;
+  const path = new URL(res.url()).pathname.replace(/\/$/, "");
+  return path.endsWith("/events/events");
+}
 
 const orgsLabel = getEnglishText("i18n._global.organizations");
 const topicsLabel = getEnglishText("i18n.components._global.topics");
@@ -164,6 +151,32 @@ test.describe(
   "Event Create Modal",
   { tag: ["@desktop", "@mobile", "@all"] },
   () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+
+      const viewportSize = page.viewportSize();
+      const isMobileLayout = viewportSize ? viewportSize.width < 768 : false;
+
+      if (isMobileLayout) {
+        const sidebarRight = newSidebarRight(page);
+        await sidebarRight.openButton.click();
+        await expect(sidebarRight.closeButton).toBeVisible();
+        const createDropdown = newCreateDropdown(page, {
+          root: page.locator("#drawer-navigation"),
+        });
+        await createDropdown.clickNewEvent();
+      } else {
+        await expect(page.locator("#sidebar-left")).toBeVisible({
+          timeout: 15000,
+        });
+        const sidebarLeft = newSidebarLeft(page);
+        await sidebarLeft.open();
+        const createDropdown = newCreateDropdown(page);
+        await createDropdown.clickNewEvent();
+      }
+    });
+
     // MARK: Modal opens
 
     test("modal opens with correct heading", async ({ page }) => {
@@ -195,7 +208,7 @@ test.describe(
           const modal = newCreateEventModal(page);
           await expect(modal.eventDetailsForm).toBeVisible();
 
-          await test.step("axe modal — step 1 details", async () => {
+          await test.step("axe modal - step 1 details", async () => {
             const violations = await runAccessibilityTestScoped(
               "Event Create Modal step 1 event details",
               page,
@@ -217,7 +230,7 @@ test.describe(
           const modal = newCreateEventModal(page);
           await goToEventTypeStep(modal);
 
-          await test.step("axe modal — step 2 event type", async () => {
+          await test.step("axe modal - step 2 event type", async () => {
             const violations = await runAccessibilityTestScoped(
               "Event Create Modal step 2 event type",
               page,
@@ -239,7 +252,7 @@ test.describe(
           const modal = newCreateEventModal(page);
           await goToLinkOnlineStep(modal);
 
-          await test.step("axe modal — step 3 link online", async () => {
+          await test.step("axe modal - step 3 link online", async () => {
             const violations = await runAccessibilityTestScoped(
               "Event Create Modal step 3 link online",
               page,
@@ -261,7 +274,7 @@ test.describe(
           const modal = newCreateEventModal(page);
           await goToPhysicalLocationStep(modal);
 
-          await test.step("axe modal — step 3 physical location", async () => {
+          await test.step("axe modal - step 3 physical location", async () => {
             const violations = await runAccessibilityTestScoped(
               "Event Create Modal step 3 physical location",
               page,
@@ -289,7 +302,7 @@ test.describe(
           await dayButtons.nth(1).click();
           await setFirstDayEndTimeToFuture(modal, page);
 
-          await test.step("axe modal — step 4 time", async () => {
+          await test.step("axe modal - step 4 time", async () => {
             const violations = await runAccessibilityTestScoped(
               "Event Create Modal step 4 date and time",
               page,
@@ -491,7 +504,17 @@ test.describe(
       await dayButtons.first().click();
       await dayButtons.nth(1).click();
       await setFirstDayEndTimeToFuture(modal, page);
+
+      const createResponse = page.waitForResponse(isPostCreateEventResponse, {
+        timeout: 30000,
+      });
       await modal.getNextStepButton().click();
+
+      const createRes = await createResponse;
+      expect(
+        [200, 201].includes(createRes.status()),
+        `POST event create expected 200 or 201, got ${createRes.status()}`
+      ).toBe(true);
 
       await expect(modal.root).not.toBeVisible({ timeout: 15000 });
       await expect(page).toHaveURL(/\/events\/[^/]+\/about/, {
@@ -538,7 +561,17 @@ test.describe(
       await allDayCheckbox.check();
       // Second day (times.1) is not all-day; backend requires start_time < end_time for it.
       await setFirstDayEndTimeToFuture(modal, page);
+
+      const createResponse = page.waitForResponse(isPostCreateEventResponse, {
+        timeout: 30000,
+      });
       await modal.getNextStepButton().click();
+
+      const createRes = await createResponse;
+      expect(
+        [200, 201].includes(createRes.status()),
+        `POST event create expected 200 or 201, got ${createRes.status()}`
+      ).toBe(true);
 
       await expect(modal.root).not.toBeVisible({ timeout: 15000 });
       await expect(page).toHaveURL(/\/events\/[^/]+\/about/, {
@@ -596,7 +629,17 @@ test.describe(
       await createAnotherCheckbox.check();
       const submitBtn = modal.getNextStepButton();
       await submitBtn.scrollIntoViewIfNeeded();
+
+      const createResponse = page.waitForResponse(isPostCreateEventResponse, {
+        timeout: 30000,
+      });
       await submitBtn.click();
+
+      const createRes = await createResponse;
+      expect(
+        [200, 201].includes(createRes.status()),
+        `POST event create expected 200 or 201, got ${createRes.status()}`
+      ).toBe(true);
 
       await expect(modal.root).toBeVisible({ timeout: 15000 });
       await expect(modal.eventDetailsForm).toBeVisible();
@@ -628,15 +671,14 @@ test.describe(
       await expect(modal.locationForm).toBeVisible();
       const searchLocationForm = modal.root.locator("#search-location");
       const countryLabel = getEnglishText("i18n.components._global.country");
-      const countryButton = searchLocationForm
+      const countryTrigger = searchLocationForm
         .locator("#form-item-country")
         .getByRole("button", { name: new RegExp(countryLabel, "i") });
-      await countryButton.click();
-      const germanyOption = modal.root.getByRole("option", {
-        name: /Germany/i,
-      });
-      await expect(germanyOption).toBeVisible({ timeout: 5000 });
-      await germanyOption.click();
+      await selectCountryComboboxOption(
+        modal.root,
+        countryTrigger,
+        E2E_GEO_REFERENCE_COUNTRY
+      );
       const cityField = searchLocationForm.locator("#form-item-city");
       await cityField.click();
       await expect(modal.root.getByRole("option").first()).toBeHidden({
@@ -682,7 +724,17 @@ test.describe(
         el.scrollTop = el.scrollHeight;
       });
       const submitBtn = modal.getNextStepButton();
+
+      const createResponse = page.waitForResponse(isPostCreateEventResponse, {
+        timeout: 30000,
+      });
       await submitBtn.click();
+
+      const createRes = await createResponse;
+      expect(
+        [200, 201].includes(createRes.status()),
+        `POST event create expected 200 or 201, got ${createRes.status()}`
+      ).toBe(true);
 
       await expect(modal.root).not.toBeVisible({ timeout: 15000 });
       await expect(page).toHaveURL(/\/events\/[^/]+\/about/, {
@@ -744,7 +796,17 @@ test.describe(
         await dayButtons.first().click();
         await dayButtons.nth(1).click();
         await setFirstDayEndTimeToFuture(modal, page);
+
+        const createResponse = page.waitForResponse(isPostCreateEventResponse, {
+          timeout: 30000,
+        });
         await modal.getNextStepButton().click({ force: true });
+
+        const createRes = await createResponse;
+        expect(
+          createRes.status(),
+          `POST event create expected 500 error path, got ${createRes.status()}`
+        ).toBe(500);
 
         await expect(errorToast(page)).toBeVisible({ timeout: 15000 });
         await expect(errorToast(page)).toContainText(
@@ -753,6 +815,54 @@ test.describe(
         // Flow may close the modal after the failed create attempt; toast is the stable signal.
         await expect(modal.root).not.toBeVisible({ timeout: 15000 });
       });
+    });
+  }
+);
+
+test.describe(
+  "Event create modal — unauthenticated user",
+  { tag: ["@desktop", "@unauth"] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+    });
+
+    test("Create control is not shown in left sidebar footer", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await expect(page.locator("#sidebar-left")).toBeVisible({
+        timeout: 15000,
+      });
+      const sidebarLeft = newSidebarLeft(page);
+      await sidebarLeft.open();
+      await expect(page.locator("#sidebar-left #create")).toHaveCount(0);
+    });
+  }
+);
+
+test.describe(
+  "Event create modal — unauthenticated user (mobile drawer)",
+  { tag: ["@mobile", "@all", "@unauth"] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+    });
+
+    test("Create control is not shown in header drawer menu", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const sidebarRight = newSidebarRight(page);
+      await sidebarRight.openButton.click();
+      await expect(sidebarRight.closeButton).toBeVisible();
+      await expect(page.locator("#drawer-navigation #create")).toHaveCount(0);
     });
   }
 );

--- a/frontend/test-e2e/specs/all/create-flows/organization-create-modal.spec.ts
+++ b/frontend/test-e2e/specs/all/create-flows/organization-create-modal.spec.ts
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { Page, Response } from "@playwright/test";
+
+import { getEnglishText } from "#shared/utils/i18n";
+
+import { runAccessibilityTestScoped } from "~/test-e2e/accessibility/accessibilityTesting";
+import { newCreateOrganizationModal } from "~/test-e2e/component-objects/CreateOrganizationModal";
+import { newCreateDropdown } from "~/test-e2e/component-objects/CreateDropdown";
+import { newSidebarLeft } from "~/test-e2e/component-objects/SidebarLeft";
+import { newSidebarRight } from "~/test-e2e/component-objects/SidebarRight";
+import { expect, test } from "~/test-e2e/global-fixtures";
+import {
+  E2E_GEO_REFERENCE_COUNTRY,
+  selectCountryComboboxOption,
+} from "~/test-e2e/utils/modal-helpers";
+import { logTestPath } from "~/test-e2e/utils/test-traceability";
+
+/** Renders localized "step X of Y" copy from `Machine.vue`. */
+function machineStepLabel(currentStep: number, totalSteps: number): string {
+  return getEnglishText("i18n.components.machine._global.machine")
+    .replace("{current_step}", String(currentStep))
+    .replace("{total_steps}", String(totalSteps));
+}
+
+/** POST create-organization (`organization.ts`: `POST /communities/organizations`). */
+function isPostCreateOrganizationResponse(res: Response): boolean {
+  if (res.request().method() !== "POST") return false;
+  const url = res.url();
+  return (
+    url.includes("/communities/organizations") &&
+    !url.includes("organizations_by_user")
+  );
+}
+
+const errorToast = (page: Page) =>
+  page.locator(
+    '[data-sonner-toast][data-type="error"][data-rich-colors="true"]'
+  );
+
+async function selectCountryInOrganizationModal(
+  modal: ReturnType<typeof newCreateOrganizationModal>,
+  optionNameMatch: RegExp | string
+) {
+  const countryLabel = getEnglishText("i18n.components._global.country");
+  const countryTrigger = modal.countryField.getByRole("button", {
+    name: new RegExp(countryLabel, "i"),
+  });
+  await selectCountryComboboxOption(
+    modal.root,
+    countryTrigger,
+    optionNameMatch
+  );
+}
+
+/** Axe scope: open create-organization dialog (`ModalCreateOrganization` root). */
+const MODAL_A11Y_ROOT = '[data-testid="modal-ModalCreateOrganization"]';
+
+test.describe(
+  "Organization Create Modal",
+  { tag: ["@desktop", "@mobile", "@all"] },
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+
+      const viewportSize = page.viewportSize();
+      const isMobileLayout = viewportSize ? viewportSize.width < 768 : false;
+
+      if (isMobileLayout) {
+        const sidebarRight = newSidebarRight(page);
+        await sidebarRight.openButton.click();
+        await expect(sidebarRight.closeButton).toBeVisible();
+        const createDropdown = newCreateDropdown(page, {
+          root: page.locator("#drawer-navigation"),
+        });
+        await createDropdown.clickNewOrganization();
+      } else {
+        await expect(page.locator("#sidebar-left")).toBeVisible({ timeout: 15000 });
+        const sidebarLeft = newSidebarLeft(page);
+        await sidebarLeft.open();
+        const createDropdown = newCreateDropdown(page);
+        await createDropdown.clickNewOrganization();
+      }
+    });
+
+    test("modal opens with correct heading", async ({ page }) => {
+      const modal = newCreateOrganizationModal(page);
+      await expect(modal.root).toBeVisible();
+      await expect(
+        modal.root.getByRole("heading", {
+          level: 2,
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.modal_create_organization.create_new_organization"
+            ),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+    });
+
+    // MARK: Accessibility by wizard step (modal subtree only)
+
+    test.describe("Organization Create Modal accessibility by step", () => {
+      test.setTimeout(120000);
+
+      test(
+        "step 1 organization details has no detectable accessibility issues in modal",
+        { tag: "@accessibility" },
+        async ({ page }, testInfo) => {
+          logTestPath(testInfo);
+          const modal = newCreateOrganizationModal(page);
+          await expect(modal.detailsForm).toBeVisible();
+
+          await test.step("axe modal - step 1 details", async () => {
+            const violations = await runAccessibilityTestScoped(
+              "Organization Create Modal step 1 details",
+              page,
+              testInfo,
+              MODAL_A11Y_ROOT
+            );
+            expect
+              .soft(violations, "Accessibility violations (step 1):")
+              .toHaveLength(0);
+          });
+        }
+      );
+
+      test(
+        "step 2 location has no detectable accessibility issues in modal",
+        { tag: "@accessibility" },
+        async ({ page }, testInfo) => {
+          logTestPath(testInfo);
+          const modal = newCreateOrganizationModal(page);
+          await modal.nameField.fill("A11y Organization");
+          await modal.descriptionField.fill("Accessibility scan step 2.");
+          await modal.getNextStepButton().click({ force: true });
+          await expect(modal.locationForm).toBeVisible();
+
+          await test.step("axe modal - step 2 location", async () => {
+            const violations = await runAccessibilityTestScoped(
+              "Organization Create Modal step 2 location",
+              page,
+              testInfo,
+              MODAL_A11Y_ROOT
+            );
+            expect
+              .soft(violations, "Accessibility violations (step 2):")
+              .toHaveLength(0);
+          });
+        }
+      );
+    });
+
+    // MARK: Step 1 validation
+
+    test("step 1 shows validation when required fields are empty", async ({
+      page,
+    }) => {
+      const modal = newCreateOrganizationModal(page);
+      await expect(modal.root).toBeVisible();
+      await expect(modal.detailsForm).toBeVisible();
+
+      await modal.getNextStepButton().click();
+
+      await expect(modal.detailsForm).toBeVisible();
+      await expect(modal.root).toBeVisible();
+    });
+
+    // MARK: Step 1 → 2
+
+    test("step 1 to 2: filled details advance to location step", async ({
+      page,
+    }) => {
+      const modal = newCreateOrganizationModal(page);
+      await expect(modal.detailsForm).toBeVisible();
+
+      await modal.nameField.fill("E2E Org");
+      await modal.taglineField.fill("E2E tagline.");
+      await modal.descriptionField.fill("Description for organization E2E.");
+
+      await modal.getNextStepButton().click({ force: true });
+
+      await expect(modal.locationForm).toBeVisible();
+    });
+
+    // MARK: Step indicator + previous
+
+    test("step indicator shows current step; back returns without losing detail data", async ({
+      page,
+    }) => {
+      const modal = newCreateOrganizationModal(page);
+      await expect(modal.root).toContainText(machineStepLabel(1, 2));
+
+      const orgName = "Step indicator org";
+      const description = "Data must survive Prev.";
+      await modal.nameField.fill(orgName);
+      await modal.descriptionField.fill(description);
+
+      await modal.getNextStepButton().click({ force: true });
+      await expect(modal.locationForm).toBeVisible();
+      await expect(modal.root).toContainText(machineStepLabel(2, 2));
+
+      await modal.getPreviousStepButton().click();
+      await expect(modal.detailsForm).toBeVisible();
+      await expect(modal.root).toContainText(machineStepLabel(1, 2));
+
+      await expect(modal.nameField).toHaveValue(orgName);
+      await expect(modal.descriptionField).toHaveValue(description);
+    });
+
+    // MARK: Modal close
+
+    test("modal close button hides modal", async ({ page }) => {
+      const modal = newCreateOrganizationModal(page);
+      await expect(modal.root).toBeVisible();
+
+      await modal.closeButton.click();
+
+      await expect(modal.root).not.toBeVisible();
+    });
+
+    // MARK: Full flow
+
+    test("full flow closes modal and navigates to new organization about page", async ({
+      page,
+    }) => {
+      const modal = newCreateOrganizationModal(page);
+      const timestamp = Date.now();
+      const orgName = `E2E New Org ${timestamp}`;
+
+      await modal.nameField.fill(orgName);
+      await modal.taglineField.fill("Created by Playwright.");
+      await modal.descriptionField.fill("Full flow organization create test.");
+
+      await modal.getNextStepButton().click({ force: true });
+      await expect(modal.locationForm).toBeVisible();
+
+      await selectCountryInOrganizationModal(
+        modal,
+        E2E_GEO_REFERENCE_COUNTRY
+      );
+      await modal.cityField.fill("Berlin");
+
+      const createResponse = page.waitForResponse(
+        isPostCreateOrganizationResponse,
+        { timeout: 30000 }
+      );
+
+      await modal.submitLocationButton.click();
+
+      const createRes = await createResponse;
+      expect(
+        [200, 201].includes(createRes.status()),
+        `POST organization expected 200 or 201, got ${createRes.status()}`
+      ).toBe(true);
+
+      await expect(modal.root).not.toBeVisible({ timeout: 20000 });
+      await expect(page).toHaveURL(/\/organizations\/[^/]+\/about/, {
+        timeout: 15000,
+      });
+    });
+
+    // MARK: Create API errors
+
+    test.describe("Create organization API error handling", () => {
+      test.afterEach(async ({ page }) => {
+        await page.unrouteAll();
+      });
+
+      test("shows error toast when create organization returns 500", async ({
+        page,
+      }, testInfo) => {
+        logTestPath(testInfo);
+
+        await page.route("**/api/auth/communities/organizations", async (route) => {
+          if (route.request().method() !== "POST") {
+            await route.continue();
+            return;
+          }
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({
+              detail: "E2E: organization create failed.",
+            }),
+          });
+        });
+
+        const modal = newCreateOrganizationModal(page);
+
+        await modal.nameField.fill("E2E Org Error Path");
+        await modal.descriptionField.fill(
+          "Should not persist after failed create."
+        );
+        await modal.getNextStepButton().click({ force: true });
+        await expect(modal.locationForm).toBeVisible();
+
+        await selectCountryInOrganizationModal(
+        modal,
+        E2E_GEO_REFERENCE_COUNTRY
+      );
+        await modal.cityField.fill("Berlin");
+
+        const createResponse = page.waitForResponse(
+          isPostCreateOrganizationResponse,
+          { timeout: 30000 }
+        );
+        await modal.submitLocationButton.click();
+
+        const createRes = await createResponse;
+        expect(
+          createRes.status(),
+          `POST organization expected 500 error path, got ${createRes.status()}`
+        ).toBe(500);
+
+        await expect(errorToast(page)).toBeVisible({ timeout: 15000 });
+        await expect(errorToast(page)).toContainText(
+          /E2E: organization create failed/i
+        );
+
+        await expect(modal.root).toBeVisible({ timeout: 15000 });
+        await expect(page).not.toHaveURL(/\/organizations\/[^/]+\/about/);
+      });
+    });
+  }
+);
+
+test.describe(
+  "Organization create modal — unauthenticated user",
+  { tag: ["@desktop", "@unauth"] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+    });
+
+    test("Create control is not shown in left sidebar footer", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await expect(page.locator("#sidebar-left")).toBeVisible({
+        timeout: 15000,
+      });
+      const sidebarLeft = newSidebarLeft(page);
+      await sidebarLeft.open();
+      await expect(page.locator("#sidebar-left #create")).toHaveCount(0);
+    });
+  }
+);
+
+test.describe(
+  "Organization create modal — unauthenticated user (mobile drawer)",
+  { tag: ["@mobile", "@all", "@unauth"] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+    });
+
+    test("Create control is not shown in header drawer menu", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const sidebarRight = newSidebarRight(page);
+      await sidebarRight.openButton.click();
+      await expect(sidebarRight.closeButton).toBeVisible();
+      await expect(page.locator("#drawer-navigation #create")).toHaveCount(0);
+    });
+  }
+);

--- a/frontend/test-e2e/specs/all/create-flows/organization-create-modal.spec.ts
+++ b/frontend/test-e2e/specs/all/create-flows/organization-create-modal.spec.ts
@@ -4,8 +4,8 @@ import type { Page, Response } from "@playwright/test";
 import { getEnglishText } from "#shared/utils/i18n";
 
 import { runAccessibilityTestScoped } from "~/test-e2e/accessibility/accessibilityTesting";
-import { newCreateOrganizationModal } from "~/test-e2e/component-objects/CreateOrganizationModal";
 import { newCreateDropdown } from "~/test-e2e/component-objects/CreateDropdown";
+import { newCreateOrganizationModal } from "~/test-e2e/component-objects/CreateOrganizationModal";
 import { newSidebarLeft } from "~/test-e2e/component-objects/SidebarLeft";
 import { newSidebarRight } from "~/test-e2e/component-objects/SidebarRight";
 import { expect, test } from "~/test-e2e/global-fixtures";
@@ -75,7 +75,9 @@ test.describe(
         });
         await createDropdown.clickNewOrganization();
       } else {
-        await expect(page.locator("#sidebar-left")).toBeVisible({ timeout: 15000 });
+        await expect(page.locator("#sidebar-left")).toBeVisible({
+          timeout: 15000,
+        });
         const sidebarLeft = newSidebarLeft(page);
         await sidebarLeft.open();
         const createDropdown = newCreateDropdown(page);
@@ -236,10 +238,7 @@ test.describe(
       await modal.getNextStepButton().click({ force: true });
       await expect(modal.locationForm).toBeVisible();
 
-      await selectCountryInOrganizationModal(
-        modal,
-        E2E_GEO_REFERENCE_COUNTRY
-      );
+      await selectCountryInOrganizationModal(modal, E2E_GEO_REFERENCE_COUNTRY);
       await modal.cityField.fill("Berlin");
 
       const createResponse = page.waitForResponse(
@@ -273,19 +272,22 @@ test.describe(
       }, testInfo) => {
         logTestPath(testInfo);
 
-        await page.route("**/api/auth/communities/organizations", async (route) => {
-          if (route.request().method() !== "POST") {
-            await route.continue();
-            return;
+        await page.route(
+          "**/api/auth/communities/organizations",
+          async (route) => {
+            if (route.request().method() !== "POST") {
+              await route.continue();
+              return;
+            }
+            await route.fulfill({
+              status: 500,
+              contentType: "application/json",
+              body: JSON.stringify({
+                detail: "E2E: organization create failed.",
+              }),
+            });
           }
-          await route.fulfill({
-            status: 500,
-            contentType: "application/json",
-            body: JSON.stringify({
-              detail: "E2E: organization create failed.",
-            }),
-          });
-        });
+        );
 
         const modal = newCreateOrganizationModal(page);
 
@@ -297,9 +299,9 @@ test.describe(
         await expect(modal.locationForm).toBeVisible();
 
         await selectCountryInOrganizationModal(
-        modal,
-        E2E_GEO_REFERENCE_COUNTRY
-      );
+          modal,
+          E2E_GEO_REFERENCE_COUNTRY
+        );
         await modal.cityField.fill("Berlin");
 
         const createResponse = page.waitForResponse(

--- a/frontend/test-e2e/utils/modal-helpers.ts
+++ b/frontend/test-e2e/utils/modal-helpers.ts
@@ -4,6 +4,35 @@ import type { Locator, Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 /**
+ * Row label regexp for country comboboxes when tests use a fixed address (e.g. Berlin) and
+ * need consistent geocoding / search API behavior in English locale.
+ */
+export const E2E_GEO_REFERENCE_COUNTRY = /Germany/i;
+
+/**
+ * Opens a localized country combobox, then selects a listbox option by accessible name.
+ *
+ * Used for org create (location step) and event create (physical search form); callers supply
+ * the trigger that matches their DOM (e.g. `#form-item-country` + localized label).
+ *
+ * @param optionListRoot - Locator that contains the option elements (usually the modal root).
+ * @param countryTrigger - Combobox button that opens the country list.
+ * @param optionNameMatch - `RegExp` or substring passed to `getByRole("option", { name })`.
+ * @param visibilityTimeoutMs - Max wait for the option to become visible (default 5000).
+ */
+export async function selectCountryComboboxOption(
+  optionListRoot: Locator,
+  countryTrigger: Locator,
+  optionNameMatch: RegExp | string,
+  visibilityTimeoutMs: number = 5000
+) {
+  await countryTrigger.click();
+  const option = optionListRoot.getByRole("option", { name: optionNameMatch });
+  await expect(option).toBeVisible({ timeout: visibilityTimeoutMs });
+  await option.click();
+}
+
+/**
  * Submit a modal form with robust retry logic to handle timing/hydration issues
  * @param page - Playwright page object
  * @param modal - The modal locator

--- a/frontend/test-e2e/utils/normalize-auth-storage-for-webkit-http.ts
+++ b/frontend/test-e2e/utils/normalize-auth-storage-for-webkit-http.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import fs from "fs";
+
+/** Host-only or registrable-ish forms seen in Playwright exports. */
+function isLoopbackCookieDomain(domainRaw: unknown): boolean {
+  if (typeof domainRaw !== "string" || domainRaw.length === 0) return false;
+
+  const host = domainRaw.replace(/^\./, "").toLowerCase();
+  return (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".127.0.0.1")
+  );
+}
+
+/**
+ * WebKit omits RFC `Secure` cookies on plain HTTP (`http://localhost`) while
+ * Chromium tends to forward them anyway. Clearing `Secure` only for loopback
+ * hosts keeps Chromium behavior correct and aligns Safari/WebKit/iPad/Mobile Safari
+ * with the same `.auth/*.json`, without weakening production-bound cookies when
+ * the domain is a real HTTPS host such as activist.org.
+ */
+export function normalizeAuthStorageLoopbackSecureCookies(
+  authFilePath: string
+): void {
+  if (!fs.existsSync(authFilePath)) return;
+
+  let rawJson: unknown;
+  try {
+    rawJson = JSON.parse(fs.readFileSync(authFilePath, "utf-8"));
+  } catch {
+    return;
+  }
+
+  if (
+    typeof rawJson !== "object" ||
+    rawJson === null ||
+    !Array.isArray((rawJson as { cookies?: unknown }).cookies)
+  ) {
+    return;
+  }
+
+  const payload = rawJson as {
+    cookies: Array<Record<string, unknown>>;
+  };
+
+  let changed = false;
+  payload.cookies = payload.cookies.map((c) => {
+    if (!isLoopbackCookieDomain(c.domain) || c.secure !== true) {
+      return c;
+    }
+    changed = true;
+    return { ...c, secure: false };
+  });
+
+  if (changed) {
+    fs.writeFileSync(
+      authFilePath,
+      `${JSON.stringify(rawJson, null, 2)}\n`,
+      "utf-8"
+    );
+  }
+}

--- a/frontend/test-e2e/utils/normalize-auth-storage-for-webkit-http.ts
+++ b/frontend/test-e2e/utils/normalize-auth-storage-for-webkit-http.ts
@@ -15,13 +15,6 @@ function isLoopbackCookieDomain(domainRaw: unknown): boolean {
   );
 }
 
-/**
- * WebKit omits RFC `Secure` cookies on plain HTTP (`http://localhost`) while
- * Chromium tends to forward them anyway. Clearing `Secure` only for loopback
- * hosts keeps Chromium behavior correct and aligns Safari/WebKit/iPad/Mobile Safari
- * with the same `.auth/*.json`, without weakening production-bound cookies when
- * the domain is a real HTTPS host such as activist.org.
- */
 export function normalizeAuthStorageLoopbackSecureCookies(
   authFilePath: string
 ): void {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

This PR **primarily tackles #1964** (organization create modal E2E) as part of the larger Epic on Playwright coverage for modal create journeys.

A few small follow-ons: event create-modal tests covering signed-out users and smoother happy paths; organization modal test selectors updated to match what users see; one shared picker helper for repeated location flows; and a tweak so Safari and Chrome can lean on the same saved login snapshots when developing against local HTTP.

**How this is split:**

1. **Local auth / WebKit**: Playwright saves logged-in state in `admin.json` / `member.json`. Chromium tends to be fine reusing those on `http://localhost`; Safari/WebKit can silently drop `Secure` cookies there, so Safari runs looked logged out compared to Chrome. After we write or refresh those files (global setup and fixture renewal), we clear `Secure` only on cookies whose domain looks like loopback (`localhost`, `127.0.0.1`, etc.). Cookies for real-looking hostnames stay as-is.

2. **Country combobox helper**: one shared "open picker + pick option" plus a regexp constant so we are not copying the same flow in every physical-address test.

3. **`CreateOrganizationModal`**: update the page object so its locators match the organization create wizard (correct details form id, next-step button label from the modal submit aria text, and a dedicated locator for the location step submit control).

4. **Organization create modal spec**: open/close, axe per step, validation, happy path create, error toast on 500, plus unauth checks on desktop sidebar and mobile drawer. Meant as a baseline, not every edge case.

5. **`event-create-modal.spec`**: move the authenticated "home + New Event" hook inside the authenticated `describe`; add parallel unauth tests; wire physical-location country through the helper; add POST assertions on success paths beside existing UI assertions; tiny helper for matching the event-create POST URL; axe step labels use ASCII hyphens.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- closes #1964
