### PR TITLE
fix: correct bugs, typos, and misconfigurations across backend and docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,9 +74,9 @@ The following are the current and planned technologies for [activist.org](https:
 
 - [Docker](https://www.docker.com) • [Netlify](https://www.netlify.com)
 
-### Deployment
+### Testing
 
-[pytest](https://docs.pytest.org/en/stable/) (backend) • [Vitest](https://vitest.dev/) (frontend) • [Playwright](https://playwright.dev/) (end to end)
+- [pytest](https://docs.pytest.org/en/stable/) (backend) • [Vitest](https://vitest.dev/) (frontend) • [Playwright](https://playwright.dev/) (end to end)
 
 ### Localization
 

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -68,7 +68,7 @@ class VerifyEmailView(APIView):
         serializer = self.serializer_class(user)
 
         return Response(
-            {"message": "Email confirmed is verified.", "user": serializer.data},
+            {"message": "Email is verified.", "user": serializer.data},
             status=status.HTTP_200_OK,
         )
 
@@ -338,7 +338,7 @@ class VerifyAccountResetPassword(APIView):
         user.set_password(request.data.get("new_password"))
         user.save()
         return Response(
-            {"message": "Password reset has been successfully."},
+            {"message": "Password has been reset successfully."},
             status=status.HTTP_200_OK,
         )
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -86,14 +86,13 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "corsheaders.middleware.CorsMiddleware",
-    "django.middleware.common.CommonMiddleware",
     "djangorestframework_camel_case.middleware.CamelCaseMiddleWare",
 ]
 
@@ -260,7 +259,7 @@ SPECTACULAR_SETTINGS = {
 # https://docs.djangoproject.com/en/4.2/topics/logging/
 
 LOGGING = {
-    "version": 1.0,
+    "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {

--- a/backend/events/urls.py
+++ b/backend/events/urls.py
@@ -8,7 +8,7 @@ from rest_framework.routers import DefaultRouter
 
 from events.views import (
     EventAPIView,
-    EventCalenderAPIView,
+    EventCalendarAPIView,
     EventDetailAPIView,
     EventFaqViewSet,
     EventFlagAPIView,
@@ -43,6 +43,6 @@ urlpatterns = [
     path("events/<uuid:id>", EventDetailAPIView.as_view()),
     path("event_flags", EventFlagAPIView.as_view()),
     path("event_flags/<uuid:id>", EventFlagDetailAPIView.as_view()),
-    path("event_calendar", EventCalenderAPIView.as_view()),
+    path("event_calendar", EventCalendarAPIView.as_view()),
     path("event_texts/<uuid:id>", EventTextViewSet.as_view()),
 ]

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -459,7 +459,7 @@ class EventFaqViewSet(viewsets.ModelViewSet[EventFaq]):
             creator = event.created_by
 
         else:
-            raise ValueError("Org is None.")
+            raise ValueError("Event is None.")
 
         if request.user != creator and not request.user.is_staff:
             return Response(
@@ -507,7 +507,7 @@ class EventResourceViewSet(viewsets.ModelViewSet[EventResource]):
 
     def update(self, request: Request, pk: UUID | str) -> Response:
         try:
-            faq = EventResource.objects.get(id=pk)
+            resource = EventResource.objects.get(id=pk)
 
         except EventResource.DoesNotExist as e:
             logger.exception(f"Resource with id {pk} does not exist for update: {e}")
@@ -515,13 +515,13 @@ class EventResourceViewSet(viewsets.ModelViewSet[EventResource]):
                 {"detail": "Resource not found."}, status=status.HTTP_404_NOT_FOUND
             )
 
-        if request.user != faq.event.created_by and not request.user.is_staff:
+        if request.user != resource.event.created_by and not request.user.is_staff:
             return Response(
                 {"detail": "You are not authorized to update this Resource."},
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        serializer = self.get_serializer(faq, data=request.data, partial=True)
+        serializer = self.get_serializer(resource, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
@@ -723,7 +723,7 @@ class EventTextViewSet(GenericAPIView[EventText]):
 # MARK: Calendar
 
 
-class EventCalenderAPIView(APIView):
+class EventCalendarAPIView(APIView):
     queryset = Event.objects.all()
     permission_classes = [AllowAny]
 


### PR DESCRIPTION
I went through the codebase and noticed a few bugs, typos, and misconfigurations that needed fixing. Here's what I changed:

CONTRIBUTING.md

I renamed the duplicate Deployment heading to  Testing since it lists pytest, Vitest, and Playwright — clearly testing tools, not deployment.

backend/core/settings.py

I moved CorsMiddleware higher up in the MIDDLEWARE list, right after SecurityMiddleware. It was sitting below CsrfViewMiddleware which goes against the django-cors-headers setup guide.
I removed a duplicate CommonMiddleware entry that was listed twice.
I changed the LOGGING dictionary's "version" from 1.0 (float) to 1 (int) to match what Python's dictConfig actually expects.

backend/authentication/views.py

I fixed a grammatically broken response message — "Email confirmed is verified." is now "Email is verified.".
I fixed another broken message — "Password reset has been successfully." is now "Password has been reset successfully.".

backend/events/views.py

I changed the error message in EventFaqViewSet.destroy() from "Org is None." to "Event is None." since we're dealing with events here, not organizations.
I renamed a misleading variable faq to resource inside EventResourceViewSet.update() — it was holding an EventResource object, not a FAQ. Looks like it was left over from a copy-paste.
I fixed a spelling mistake in the class name — EventCalenderAPIView is now EventCalendarAPIView.

backend/events/urls.py

I updated the import to replace EventCalenderAPIView with EventCalendarAPIView.