### PR TITLE
fix(backend): add authentication enforcement and proper authorization to OrganizationDetailAPIView

### DIFF
--- a/backend/communities/organizations/tests/test_org_delete.py
+++ b/backend/communities/organizations/tests/test_org_delete.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 import pytest
 from django.test import Client
 
-from authentication.factories import UserFactory
 from communities.organizations.factories import OrganizationFactory
 
 pytestmark = pytest.mark.django_db

--- a/backend/communities/organizations/tests/test_org_delete.py
+++ b/backend/communities/organizations/tests/test_org_delete.py
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Test cases for deleting organizations.
+"""
+
 from uuid import uuid4
 
 import pytest
@@ -12,91 +16,76 @@ pytestmark = pytest.mark.django_db
 ORGS_URL = "/v1/communities/organizations"
 
 
-def test_org_delete(client: Client) -> None:
-    test_username = "test_user"
-    test_password = "test_pass"
-    user = UserFactory(username=test_username, plaintext_password=test_password)
+# MARK: Unauthenticated
+
+
+def test_org_delete_unauthenticated_401(client: Client) -> None:
+    """
+    Unauthenticated user receives 401 when trying to delete an organization.
+
+    Parameters
+    ----------
+    client : Client
+        An unauthenticated Django test client.
+    """
     org = OrganizationFactory()
 
-    """
-    Un-authorized user deleting org info.
-    """
     response = client.delete(
         path=f"{ORGS_URL}/{org.id}",
-        data={"orgName": "new_org", "name": "test_org"},
     )
 
     assert response.status_code == 401
+
+
+# MARK: Non-Owner
+
+
+def test_org_delete_non_owner_403(authenticated_client) -> None:
+    """
+    Authenticated user who is not the owner receives 403 when trying to delete.
+
+    Parameters
+    ----------
+    authenticated_client : tuple[APIClient, UserModel]
+        An authenticated client with a test user.
+    """
+    client, user = authenticated_client
+
+    org = OrganizationFactory()
+
+    response = client.delete(
+        path=f"{ORGS_URL}/{org.id}",
+    )
+
+    assert response.status_code == 403
 
     response_body = response.json()
     assert (
         response_body["detail"] == "You are not authorized to delete this organization."
     )
 
+
+# MARK: Not Found
+
+
+def test_org_delete_not_found_404(authenticated_client) -> None:
     """
-    Org does not exist.
+    Authenticated user receives 404 when trying to delete a non-existent organization.
+
+    Parameters
+    ----------
+    authenticated_client : tuple[APIClient, UserModel]
+        An authenticated client with a test user.
     """
-    user.is_confirmed = True
-    user.verified = True
-    user.is_staff = True
-    user.save()
-
-    # Login to get token.
-    login_response = client.post(
-        path="/v1/auth/sign_in",
-        data={
-            "username": test_username,
-            "password": test_password,
-        },
-    )
-
-    assert login_response.status_code == 200
-
-    login_response_json = login_response.json()
-    token = login_response_json["access"]
+    client, user = authenticated_client
 
     bad_org_id = uuid4()
-    org.created_by = user
 
     response = client.delete(
         path=f"{ORGS_URL}/{bad_org_id}",
-        headers={"Authorization": f"Token {token}"},
     )
 
     assert response.status_code == 404
 
     response_body = response.json()
     assert response_body["detail"] == "Organization not found."
-
-    """
-    Authorized User deleting Org info.
-    Uncomment test when the StatusType Class is more developed.
-    """
-    # user.is_confirmed = True
-    # user.verified = True
-    # user.is_staff = True
-    # user.save()
-
-    # Login to get token.
-    # login_response = client.post(
-    #     path="/v1/auth/sign_in",
-    #     data={
-    #         "username": test_username,
-    #         "password": test_password,
-    #     }
-    # )
-
-    # assert login_response.status_code == 200
-    # login_response_json = login_response.json()
-    # token = login_response_json["token"]
-
-    # org.created_by = user
-
-    # response = client.delete(
-    #     path=f"{ORGS_URL}/{org.id}",
-    #     headers={"Authorization": f"Token {token}"},
-    # )
-
-    # assert response.status_code == 200
-    # response_body = response.json()
-    # assert response_body["message"] == "Organization deleted successfully."

--- a/backend/communities/organizations/tests/test_org_update.py
+++ b/backend/communities/organizations/tests/test_org_update.py
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+Test cases for updating organizations.
+"""
+
 from uuid import uuid4
 
 import pytest
@@ -12,55 +16,78 @@ pytestmark = pytest.mark.django_db
 ORGS_URL = "/v1/communities/organizations"
 
 
-def test_org_update(client: Client) -> None:
-    test_username = "test_user"
-    test_password = "test_pass"
-    user = UserFactory(username=test_username, plaintext_password=test_password)
+# MARK: Unauthenticated
+
+
+def test_org_update_unauthenticated_401(client: Client) -> None:
+    """
+    Unauthenticated user receives 401 when trying to update an organization.
+
+    Parameters
+    ----------
+    client : Client
+        An unauthenticated Django test client.
+    """
     org = OrganizationFactory()
 
-    """
-    Un-authorized user updating org info.
-    """
     response = client.put(
         path=f"{ORGS_URL}/{org.id}",
         data={"orgName": "new_org", "name": "test_org"},
+        content_type="application/json",
     )
 
     assert response.status_code == 401
+
+
+# MARK: Non-Owner
+
+
+def test_org_update_non_owner_403(authenticated_client) -> None:
+    """
+    Authenticated user who is not the owner receives 403 when trying to update.
+
+    Parameters
+    ----------
+    authenticated_client : tuple[APIClient, UserModel]
+        An authenticated client with a test user.
+    """
+    client, user = authenticated_client
+
+    org = OrganizationFactory()
+
+    response = client.put(
+        path=f"{ORGS_URL}/{org.id}",
+        data={"orgName": "new_org", "name": "test_org"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 403
+
     response_body = response.json()
     assert (
         response_body["detail"] == "You are not authorized to update this organization."
     )
 
+
+# MARK: Not Found
+
+
+def test_org_update_not_found_404(authenticated_client) -> None:
     """
-    Org does not exist.
+    Authenticated user receives 404 when trying to update a non-existent organization.
+
+    Parameters
+    ----------
+    authenticated_client : tuple[APIClient, UserModel]
+        An authenticated client with a test user.
     """
-    user.is_confirmed = True
-    user.verified = True
-    user.is_staff = True
-    user.save()
-
-    # Login to get token.
-    login_response = client.post(
-        path="/v1/auth/sign_in",
-        data={
-            "username": test_username,
-            "password": test_password,
-        },
-    )
-
-    assert login_response.status_code == 200
-
-    login_response_json = login_response.json()
-    token = login_response_json["access"]
+    client, user = authenticated_client
 
     bad_org_id = uuid4()
-    org.created_by = user
 
     response = client.put(
         path=f"{ORGS_URL}/{bad_org_id}",
         data={"orgName": "new_org", "name": "test_org"},
-        headers={"Authorization": f"Token {token}"},
         content_type="application/json",
     )
 
@@ -69,35 +96,30 @@ def test_org_update(client: Client) -> None:
     response_body = response.json()
     assert response_body["detail"] == "Organization not found."
 
+
+# MARK: Owner
+
+
+def test_org_update_owner_200(authenticated_client) -> None:
     """
-    Authorized User updating Org info.
+    Owner of the organization can successfully update it.
+
+    Parameters
+    ----------
+    authenticated_client : tuple[APIClient, UserModel]
+        An authenticated client with a test user.
     """
-    user.is_confirmed = True
-    user.verified = True
-    user.is_staff = True
-    user.save()
+    client, user = authenticated_client
 
-    # Login to get token.
-    login_response = client.post(
-        path="/v1/auth/sign_in",
-        data={
-            "username": test_username,
-            "password": test_password,
-        },
-    )
-
-    assert login_response.status_code == 200
-
-    login_response_json = login_response.json()
-    token = login_response_json["access"]
-
-    org.created_by = user
+    org = OrganizationFactory(created_by=user)
 
     response = client.put(
         path=f"{ORGS_URL}/{org.id}",
-        data={"orgName": "new_org", "name": "test_org"},
-        headers={"Authorization": f"Token {token}"},
+        data={"name": "updated_org_name"},
         content_type="application/json",
     )
 
     assert response.status_code == 200
+
+    response_body = response.json()
+    assert response_body["name"] == "updated_org_name"

--- a/backend/communities/organizations/tests/test_org_update.py
+++ b/backend/communities/organizations/tests/test_org_update.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 import pytest
 from django.test import Client
 
-from authentication.factories import UserFactory
 from communities.organizations.factories import OrganizationFactory
 
 pytestmark = pytest.mark.django_db

--- a/backend/communities/organizations/views.py
+++ b/backend/communities/organizations/views.py
@@ -6,7 +6,7 @@ API views for organization management.
 
 import logging
 import os
-from typing import Type
+from typing import Any, Sequence, Type
 from uuid import UUID
 
 from django.contrib.auth.models import AnonymousUser
@@ -24,7 +24,7 @@ from drf_spectacular.utils import (
 from rest_framework import status, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import GenericAPIView
-from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
+from rest_framework.permissions import AllowAny, IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -235,6 +235,19 @@ class OrganizationDetailAPIView(APIView):
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
 
+    def get_permissions(self) -> Sequence[Any]:
+        """
+        Return permissions based on the HTTP method.
+
+        Returns
+        -------
+        Sequence[Any]
+            AllowAny for GET requests, IsAuthenticated for PUT and DELETE.
+        """
+        if self.request.method in ("PUT", "DELETE"):
+            return [IsAuthenticated()]
+        return [AllowAny()]
+
     @extend_schema(
         summary="Retrieve a single organization by ID",
         responses={
@@ -296,6 +309,19 @@ class OrganizationDetailAPIView(APIView):
                     )
                 ],
             ),
+            403: OpenApiResponse(
+                response=OpenApiTypes.OBJECT,
+                description="You are not authorized to update this organization",
+                examples=[
+                    OpenApiExample(
+                        name="Forbidden",
+                        value={
+                            "detail": "You are not authorized to update this organization."
+                        },
+                        media_type="application/json",
+                    )
+                ],
+            ),
             404: OpenApiResponse(
                 response=OpenApiTypes.OBJECT,
                 description="Organization not found",
@@ -328,7 +354,7 @@ class OrganizationDetailAPIView(APIView):
         if request.user != org.created_by and not request.user.is_staff:
             return Response(
                 {"detail": "You are not authorized to update this organization."},
-                status=status.HTTP_401_UNAUTHORIZED,
+                status=status.HTTP_403_FORBIDDEN,
             )
 
         serializer = self.serializer_class(org, data=request.data, partial=True)
@@ -340,7 +366,7 @@ class OrganizationDetailAPIView(APIView):
     @extend_schema(
         summary="Delete an organization by ID",
         responses={
-            200: OpenApiResponse(
+            204: OpenApiResponse(
                 response=OpenApiTypes.OBJECT,
                 description="Organization deleted successfully",
                 examples=[
@@ -362,12 +388,12 @@ class OrganizationDetailAPIView(APIView):
                     )
                 ],
             ),
-            401: OpenApiResponse(
+            403: OpenApiResponse(
                 response=OpenApiTypes.OBJECT,
                 description="You are not authorized to delete this organization",
                 examples=[
                     OpenApiExample(
-                        name="Unauthorized",
+                        name="Forbidden",
                         value={
                             "detail": "You are not authorized to delete this organization."
                         },
@@ -407,7 +433,7 @@ class OrganizationDetailAPIView(APIView):
         if request.user != org.created_by and not request.user.is_staff:
             return Response(
                 {"detail": "You are not authorized to delete this organization."},
-                status=status.HTTP_401_UNAUTHORIZED,
+                status=status.HTTP_403_FORBIDDEN,
             )
 
         org.status = StatusType.objects.get(id=3)  # 3 is the id of the deleted status

--- a/backend/communities/organizations/views.py
+++ b/backend/communities/organizations/views.py
@@ -24,7 +24,11 @@ from drf_spectacular.utils import (
 from rest_framework import status, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.generics import GenericAPIView
-from rest_framework.permissions import AllowAny, IsAuthenticated, IsAuthenticatedOrReadOnly
+from rest_framework.permissions import (
+    AllowAny,
+    IsAuthenticated,
+    IsAuthenticatedOrReadOnly,
+)
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView


### PR DESCRIPTION
Follow-up to #2129 as requested by @andrewtavis — applying the same authentication enforcement pattern to `OrganizationDetailAPIView`.

I found that `OrganizationDetailAPIView` had the same issues that `EventDetailAPIView` had before #2129:

### What I changed

**`backend/communities/organizations/views.py`**
- Added a `get_permissions()` method that returns `AllowAny` for `GET` requests and `IsAuthenticated` for `PUT`/`DELETE` — this ensures DRF enforces authentication before the view logic runs.
- Changed the authorization status code from `401 Unauthorized` to `403 Forbidden`. HTTP 401 means "not authenticated" while 403 means "authenticated but not allowed" — the existing code was using the wrong one since the user *is* authenticated but just isn't the owner.
- Updated the OpenAPI schema annotations to reflect the corrected status codes (including `200` → `204` for the delete endpoint).

**`backend/communities/organizations/tests/test_org_update.py`**
- Refactored the single monolithic test into 4 focused test functions: unauthenticated user gets 401, non-owner gets 403, non-existent org gets 404, and org owner can successfully update (200).

**`backend/communities/organizations/tests/test_org_delete.py`**
- Refactored the single monolithic test into 3 focused test functions: unauthenticated user gets 401, non-owner gets 403, and non-existent org gets 404. The owner-delete success test is intentionally omitted because soft-delete requires StatusType fixtures that aren't set up in the test environment (same reason the original test had it commented out).
