### PR TITLE
Add E2E empty state tests for organization group FAQ and resource pages

### DIFF
--- a/frontend/app/components/form/text/FormTextInput.vue
+++ b/frontend/app/components/form/text/FormTextInput.vue
@@ -120,7 +120,7 @@ const syncShrinkLabelState = () => {
     return false;
   }
   // Focus/blur/input events own label state during interaction. Guard for SSR/Vitest (no document).
-  if (document && document.activeElement === input) {
+  if (typeof document !== "undefined" && document.activeElement === input) {
     return false;
   }
   const hasAutofill = isAutofilled(input);

--- a/frontend/app/pages/organizations/[orgId]/groups/[groupId]/faq.vue
+++ b/frontend/app/pages/organizations/[orgId]/groups/[groupId]/faq.vue
@@ -69,7 +69,7 @@
         </template>
       </draggable>
     </div>
-    <EmptyState v-else pageType="faq" :permission="false" />
+    <EmptyState v-else pageType="faq" :permission="canEdit(group)" />
   </div>
 </template>
 

--- a/frontend/app/pages/organizations/[orgId]/groups/[groupId]/resources.vue
+++ b/frontend/app/pages/organizations/[orgId]/groups/[groupId]/resources.vue
@@ -12,7 +12,7 @@
       :tagline="$t('i18n.pages.organizations._global.resources_tagline')"
       :underDevelopment="false"
     >
-      <div class="flex space-x-2 pb-3 lg:space-x-3 lg:pb-4">
+      <div v-if="canEdit(group)" class="flex space-x-2 pb-3 lg:space-x-3 lg:pb-4">
         <BtnAction
           @click.stop="
             () =>
@@ -85,7 +85,7 @@
         </template>
       </draggable>
     </div>
-    <EmptyState v-else pageType="resources" :permission="false" />
+    <EmptyState v-else pageType="resources" :permission="canEdit(group)" />
   </div>
 </template>
 

--- a/frontend/app/pages/organizations/[orgId]/groups/[groupId]/resources.vue
+++ b/frontend/app/pages/organizations/[orgId]/groups/[groupId]/resources.vue
@@ -12,7 +12,10 @@
       :tagline="$t('i18n.pages.organizations._global.resources_tagline')"
       :underDevelopment="false"
     >
-      <div v-if="canEdit(group)" class="flex space-x-2 pb-3 lg:space-x-3 lg:pb-4">
+      <div
+        v-if="canEdit(group)"
+        class="flex space-x-2 pb-3 lg:space-x-3 lg:pb-4"
+      >
         <BtnAction
           @click.stop="
             () =>

--- a/frontend/playwright.config.mts
+++ b/frontend/playwright.config.mts
@@ -130,6 +130,9 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         // Memory optimization: Add launch options to prevent browser crashes in long test runs
         launchOptions: {
+          slowMo: process.env.PLAYWRIGHT_SLOW_MO
+            ? parseInt(process.env.PLAYWRIGHT_SLOW_MO)
+            : undefined,
           args: [
             "--disable-dev-shm-usage", // Use /tmp instead of /dev/shm for shared memory
             "--disable-background-timer-throttling",

--- a/frontend/test-e2e/specs/all/organizations/groups/organization-group-faq/organization-group-faq-empty-states.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/groups/organization-group-faq/organization-group-faq-empty-states.spec.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * Group FAQ lists come from `useGetGroup` (embedded `faqEntries`), not a separate list URL.
+ * Mock GET `/api/public/communities/groups/:id` before navigation (client-only fetch; see nuxt `ssr: false`).
+ */
+import { getEnglishText } from "#shared/utils/i18n";
+
+import { MEMBER_AUTH_STATE_PATH } from "~/test-e2e/constants/authPaths";
+import { expect, test } from "~/test-e2e/global-fixtures";
+import { newOrganizationPage } from "~/test-e2e/page-objects/organization/OrganizationPage";
+import {
+  MOCK_GROUP_EMPTY_STATE_ID,
+  MOCK_GROUP_EMPTY_STATE_ORG_ID,
+  mockGroupDetailPayload,
+  routeMockPublicGroupDetail,
+  sampleFaqEntryForMock,
+} from "~/test-e2e/utils/mock-public-group-detail";
+import { logTestPath } from "~/test-e2e/utils/test-traceability";
+
+test.describe(
+  "Admin sees editable empty state on organization group FAQ page",
+  { tag: ["@desktop", "@mobile"] },
+  () => {
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    // MARK: Empty State
+
+    test("Shows empty state with editable copy when group has no FAQ entries", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const { groupFaqPage } = newOrganizationPage(page);
+
+      await routeMockPublicGroupDetail(
+        page,
+        MOCK_GROUP_EMPTY_STATE_ID,
+        mockGroupDetailPayload(MOCK_GROUP_EMPTY_STATE_ID, { faqEntries: [] })
+      );
+      await page.goto(
+        `/organizations/${MOCK_GROUP_EMPTY_STATE_ORG_ID}/groups/${MOCK_GROUP_EMPTY_STATE_ID}/faq`
+      );
+
+      await expect(groupFaqPage.emptyState).toBeVisible({ timeout: 15000 });
+      await expect(groupFaqPage.faqList).not.toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(
+            getEnglishText("i18n.components.empty_state.faq_header"),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          level: 4,
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.empty_state.message_with_permission"
+            ),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(groupFaqPage.newFaqButton).toBeVisible();
+    });
+
+    // MARK: Not Empty
+
+    test("Does not show empty state when group has FAQ entries", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const { groupFaqPage } = newOrganizationPage(page);
+
+      await routeMockPublicGroupDetail(
+        page,
+        MOCK_GROUP_EMPTY_STATE_ID,
+        mockGroupDetailPayload(MOCK_GROUP_EMPTY_STATE_ID, {
+          faqEntries: [sampleFaqEntryForMock],
+        })
+      );
+      await page.goto(
+        `/organizations/${MOCK_GROUP_EMPTY_STATE_ORG_ID}/groups/${MOCK_GROUP_EMPTY_STATE_ID}/faq`
+      );
+
+      await expect(groupFaqPage.faqList).toBeVisible({ timeout: 15000 });
+      await expect(groupFaqPage.faqCards).toHaveCount(1);
+      await expect(groupFaqPage.emptyState).not.toBeVisible();
+    });
+  }
+);
+
+test.describe(
+  "Non-admin member sees read-only empty state on organization group FAQ page",
+  { tag: ["@desktop", "@mobile", "@member"] },
+  () => {
+    test.use({ storageState: MEMBER_AUTH_STATE_PATH });
+
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    // MARK: Empty State
+
+    test("Shows read-only empty state when group has no FAQ entries", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const { groupFaqPage } = newOrganizationPage(page);
+
+      await routeMockPublicGroupDetail(
+        page,
+        MOCK_GROUP_EMPTY_STATE_ID,
+        mockGroupDetailPayload(MOCK_GROUP_EMPTY_STATE_ID, { faqEntries: [] })
+      );
+      await page.goto(
+        `/organizations/${MOCK_GROUP_EMPTY_STATE_ORG_ID}/groups/${MOCK_GROUP_EMPTY_STATE_ID}/faq`
+      );
+
+      await expect(groupFaqPage.emptyState).toBeVisible({ timeout: 15000 });
+      await expect(
+        page.getByRole("heading", {
+          level: 4,
+          name: new RegExp(
+            getEnglishText("i18n.components.empty_state.message_no_permission"),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(groupFaqPage.newFaqButton).not.toBeVisible();
+    });
+  }
+);

--- a/frontend/test-e2e/specs/all/organizations/groups/organization-group-resources/organization-group-resources-empty-states.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/groups/organization-group-resources/organization-group-resources-empty-states.spec.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * Group resources lists come from `useGetGroup` (embedded `resources`), not a separate list URL.
+ * Mock GET `/api/public/communities/groups/:id` before navigation (client-only fetch; see nuxt `ssr: false`).
+ */
+import { getEnglishText } from "#shared/utils/i18n";
+
+import { MEMBER_AUTH_STATE_PATH } from "~/test-e2e/constants/authPaths";
+import { expect, test } from "~/test-e2e/global-fixtures";
+import { newOrganizationPage } from "~/test-e2e/page-objects/organization/OrganizationPage";
+import {
+  MOCK_GROUP_EMPTY_STATE_ID,
+  MOCK_GROUP_EMPTY_STATE_ORG_ID,
+  mockGroupDetailPayload,
+  routeMockPublicGroupDetail,
+  sampleResourceForMock,
+} from "~/test-e2e/utils/mock-public-group-detail";
+import { logTestPath } from "~/test-e2e/utils/test-traceability";
+
+test.describe(
+  "Admin sees editable empty state on organization group resources page",
+  { tag: ["@desktop", "@mobile"] },
+  () => {
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    // MARK: Empty State
+
+    test("Shows empty state with editable copy when group has no resources", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const { groupResourcesPage } = newOrganizationPage(page);
+
+      await routeMockPublicGroupDetail(
+        page,
+        MOCK_GROUP_EMPTY_STATE_ID,
+        mockGroupDetailPayload(MOCK_GROUP_EMPTY_STATE_ID, { resources: [] })
+      );
+      await page.goto(
+        `/organizations/${MOCK_GROUP_EMPTY_STATE_ORG_ID}/groups/${MOCK_GROUP_EMPTY_STATE_ID}/resources`
+      );
+
+      await expect(groupResourcesPage.emptyState).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(groupResourcesPage.resourcesList).not.toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(
+            getEnglishText("i18n.components.empty_state.resources_header"),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          level: 4,
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.empty_state.message_with_permission"
+            ),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", {
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.empty_state.create_resource_aria_label"
+            ),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(groupResourcesPage.newResourceButton).toBeVisible();
+    });
+
+    // MARK: Not Empty
+
+    test("Does not show empty state when group has resources", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const { groupResourcesPage } = newOrganizationPage(page);
+
+      await routeMockPublicGroupDetail(
+        page,
+        MOCK_GROUP_EMPTY_STATE_ID,
+        mockGroupDetailPayload(MOCK_GROUP_EMPTY_STATE_ID, {
+          resources: [sampleResourceForMock],
+        })
+      );
+      await page.goto(
+        `/organizations/${MOCK_GROUP_EMPTY_STATE_ORG_ID}/groups/${MOCK_GROUP_EMPTY_STATE_ID}/resources`
+      );
+
+      await expect(groupResourcesPage.resourcesList).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(groupResourcesPage.resourceCards).toHaveCount(1);
+      await expect(groupResourcesPage.emptyState).not.toBeVisible();
+    });
+  }
+);
+
+test.describe(
+  "Non-admin member sees read-only empty state on organization group resources page",
+  { tag: ["@desktop", "@mobile", "@member"] },
+  () => {
+    test.use({ storageState: MEMBER_AUTH_STATE_PATH });
+
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    // MARK: Empty State
+
+    test("Shows read-only empty state when group has no resources", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const { groupResourcesPage } = newOrganizationPage(page);
+
+      await routeMockPublicGroupDetail(
+        page,
+        MOCK_GROUP_EMPTY_STATE_ID,
+        mockGroupDetailPayload(MOCK_GROUP_EMPTY_STATE_ID, { resources: [] })
+      );
+      await page.goto(
+        `/organizations/${MOCK_GROUP_EMPTY_STATE_ORG_ID}/groups/${MOCK_GROUP_EMPTY_STATE_ID}/resources`
+      );
+
+      await expect(groupResourcesPage.emptyState).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(
+        page.getByRole("heading", {
+          level: 4,
+          name: new RegExp(
+            getEnglishText("i18n.components.empty_state.message_no_permission"),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", {
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.empty_state.create_resource_aria_label"
+            ),
+            "i"
+          ),
+        })
+      ).not.toBeVisible();
+      await expect(groupResourcesPage.newResourceButton).not.toBeVisible();
+    });
+  }
+);

--- a/frontend/test-e2e/specs/all/organizations/organization-about/organization-about-image-upload.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/organization-about/organization-about-image-upload.spec.ts
@@ -38,7 +38,7 @@ const purgeImages = async (page: Page, organizationId: string) => {
   await page.reload({ waitUntil: "networkidle" });
 };
 
-test.describe(
+test.describe.serial(
   "Organization About Page - Image Carousel",
   { tag: ["@desktop", "@mobile"] },
   () => {
@@ -80,6 +80,9 @@ test.describe(
       // Verify the image upload modal appears.
       await expect(organizationPage.uploadImageModal.modal).toBeVisible();
 
+      // Wait for the modal to finish loading existing images from the server.
+      await page.waitForLoadState("networkidle");
+
       // Verify the image upload form is visible.
       const imageUploadInput =
         organizationPage.uploadImageModal.imageUploadInput(
@@ -119,6 +122,10 @@ test.describe(
 
       // Open the modal and remove the first image
       await organizationPage.aboutPage.imageCarouselEditIcon.click();
+
+      // Wait for the modal to finish loading existing images from the server.
+      await page.waitForLoadState("networkidle");
+
       await organizationPage.uploadImageModal
         .removeButton(organizationPage.uploadImageModal.modal, 0)
         .click();
@@ -177,6 +184,9 @@ test.describe(
 
       // Verify the image upload modal appears.
       await expect(organizationPage.uploadImageModal.modal).toBeVisible();
+
+      // Wait for the modal to finish loading existing images from the server.
+      await page.waitForLoadState("networkidle");
 
       // Verify the image upload form is visible.
       const imageUploadInput =

--- a/frontend/test-e2e/utils/mock-public-group-detail.ts
+++ b/frontend/test-e2e/utils/mock-public-group-detail.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { Page } from "@playwright/test";
+
+/**
+ * Stable UUIDs for cold `page.goto` + `page.route` group-detail mocks (SSR off).
+ * The org ID is only used in the page URL; the API mock keys on the group ID.
+ */
+export const MOCK_GROUP_EMPTY_STATE_ORG_ID =
+  "00000000-0000-4000-8000-00000000b001";
+export const MOCK_GROUP_EMPTY_STATE_ID = "00000000-0000-4000-8000-00000000b002";
+
+export function isPublicGroupDetailGet(url: string): boolean {
+  try {
+    const u = new URL(url);
+    const m = u.pathname.match(/\/api\/public\/communities\/groups\/([^/?#]+)$/);
+    if (!m?.[1]) return false;
+    return /^[0-9a-f-]{36}$/i.test(m[1]);
+  } catch {
+    return false;
+  }
+}
+
+function groupIdFromDetailUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const m = u.pathname.match(/\/api\/public\/communities\/groups\/([^/?#]+)$/);
+    return m?.[1]?.toLowerCase() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fulfill GET `/api/public/communities/groups/:id` for a single group id; other requests continue.
+ * Matches the client fetch used by `getGroup` (`withoutAuth: true` -> public API base).
+ */
+export async function routeMockPublicGroupDetail(
+  page: Page,
+  expectedGroupId: string,
+  body: Record<string, unknown>
+): Promise<void> {
+  const want = expectedGroupId.toLowerCase();
+  await page.route("**/api/public/communities/groups/**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    if (!isPublicGroupDetailGet(route.request().url())) {
+      await route.continue();
+      return;
+    }
+    const id = groupIdFromDetailUrl(route.request().url());
+    if (!id || id !== want) {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+/** Minimal group JSON valid for `mapGroup` with empty faqEntries and resources by default. */
+export function mockGroupDetailPayload(
+  groupId: string,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    id: groupId,
+    groupName: "E2E empty-state group",
+    name: "E2E empty-state group",
+    tagline: "E2E tagline",
+    org: MOCK_GROUP_EMPTY_STATE_ORG_ID,
+    createdBy: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    iconUrl: null,
+    location: null,
+    socialLinks: [],
+    creationDate: "2024-01-01T00:00:00Z",
+    events: [],
+    images: [],
+    resources: [],
+    faqEntries: [],
+    texts: [],
+    ...overrides,
+  };
+}
+
+export const sampleFaqEntryForMock = {
+  id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  iso: "en",
+  order: 0,
+  question: "E2E question?",
+  answer: "E2E answer.",
+};
+
+export const sampleResourceForMock = {
+  id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  name: "E2E resource",
+  description: "E2E resource description",
+  url: "https://example.com/e2e-resource",
+  order: 0,
+  createdBy: {
+    id: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    userName: "e2e",
+    name: "E2E User",
+    socialLinks: [],
+  },
+};

--- a/frontend/test-e2e/utils/mock-public-group-detail.ts
+++ b/frontend/test-e2e/utils/mock-public-group-detail.ts
@@ -12,7 +12,9 @@ export const MOCK_GROUP_EMPTY_STATE_ID = "00000000-0000-4000-8000-00000000b002";
 export function isPublicGroupDetailGet(url: string): boolean {
   try {
     const u = new URL(url);
-    const m = u.pathname.match(/\/api\/public\/communities\/groups\/([^/?#]+)$/);
+    const m = u.pathname.match(
+      /\/api\/public\/communities\/groups\/([^/?#]+)$/
+    );
     if (!m?.[1]) return false;
     return /^[0-9a-f-]{36}$/i.test(m[1]);
   } catch {
@@ -23,7 +25,9 @@ export function isPublicGroupDetailGet(url: string): boolean {
 function groupIdFromDetailUrl(url: string): string | null {
   try {
     const u = new URL(url);
-    const m = u.pathname.match(/\/api\/public\/communities\/groups\/([^/?#]+)$/);
+    const m = u.pathname.match(
+      /\/api\/public\/communities\/groups\/([^/?#]+)$/
+    );
     return m?.[1]?.toLowerCase() ?? null;
   } catch {
     return null;


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

#### Files changed

**`frontend/test-e2e/utils/mock-public-group-detail.ts`** (new)

Utility that mirrors `mock-public-event-detail.ts`. Exports `routeMockPublicGroupDetail`, `mockGroupDetailPayload`, and sample FAQ/resource fixtures so specs can intercept the public group detail GET and return controlled payloads without hitting the backend.

**`frontend/app/pages/organizations/[orgId]/groups/[groupId]/faq.vue`** and **`resources.vue`** (bug fix)
`EmptyState :permission` was hardcoded to `false` on both pages, so the admin empty-state CTA was never shown. Fixed to `canEdit(group)`, matching `events/[eventId]/faq.vue` and `events/[eventId]/resources.vue`. The resources page also rendered the add button unconditionally; wrapped the containing div with `v-if="canEdit(group)"` to gate it correctly.

**`organization-group-faq-empty-states.spec.ts`** and **`organization-group-resources-empty-states.spec.ts`** (new)
Playwright specs covering three cases per page:
- Empty list, admin auth - empty state is visible with the add-CTA variant
- Empty list, member auth - empty state is visible with the read-only variant (no add CTA)
- Non-empty list - empty state is not shown, list container is visible

Tests use `page.route()` mocks for the public group detail endpoint and `test.use({ storageState })` for role switching, consistent with sibling empty-state specs.


### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #2144
