### PR TITLE
test(e2e): add server error tests for sign-in page

### DIFF
--- a/frontend/app/pages/auth/sign-in.vue
+++ b/frontend/app/pages/auth/sign-in.vue
@@ -120,7 +120,10 @@ const signInUser = async (values: Record<string, unknown>) => {
     // Redirect to home page after successful sign-in.
     navigateTo("/home");
   } catch (error) {
-    if (error instanceof FetchError && error?.response?.status === 400) {
+    if (
+      error instanceof FetchError &&
+      (error?.response?.status === 400 || error?.response?.status === 401)
+    ) {
       showToastError(t("i18n.pages.auth.sign_in.invalid_credentials"));
     } else {
       showToastError(t("i18n.pages.auth._global.error_occurred"));

--- a/frontend/test-e2e/specs/all/authentication/sign-in/sign-in-server-errors.spec.ts
+++ b/frontend/test-e2e/specs/all/authentication/sign-in/sign-in-server-errors.spec.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { getEnglishText } from "#shared/utils/i18n";
+
+import { expect, test } from "~/test-e2e/global-fixtures";
+import { newSignInPage } from "~/test-e2e/page-objects/SignInPage";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/auth/sign-in");
+});
+
+test.describe(
+  "Sign In Page - Server Errors",
+  { tag: ["@desktop", "@mobile", "@unauth"] },
+  () => {
+    // Override to run without authentication.
+    test.use({ storageState: undefined });
+
+    // Explicitly clear all cookies to ensure unauthenticated state.
+    test.beforeEach(async ({ context }) => {
+      await context.clearCookies();
+    });
+
+    // Remove all route mocks after each test to prevent leakage.
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    // MARK: Wrong Credentials
+
+    test("Page shows error for wrong credentials (401)", async ({ page }) => {
+      await page.route("**/api/session/login", (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Invalid credentials." }),
+        })
+      );
+
+      const signInPage = newSignInPage(page);
+      await signInPage.usernameInput.fill("wronguser");
+      await signInPage.passwordInput.fill("wrongpassword");
+
+      const { captcha } = signInPage;
+      if (await captcha.isVisible()) {
+        await captcha.click();
+      }
+
+      await signInPage.signInButton.click();
+
+      const errorToast = page.locator('[data-sonner-toast][data-type="error"]');
+      await expect(errorToast).toBeVisible();
+      await expect(errorToast).toContainText(
+        getEnglishText("i18n.pages.auth.sign_in.invalid_credentials")
+      );
+      expect(page.url()).toContain("/auth/sign-in");
+    });
+
+    test("Page shows same error for non-existent username (401)", async ({
+      page,
+    }) => {
+      await page.route("**/api/session/login", (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Invalid credentials." }),
+        })
+      );
+
+      const signInPage = newSignInPage(page);
+      await signInPage.usernameInput.fill("nonexistentuser12345");
+      await signInPage.passwordInput.fill("somepassword");
+
+      const { captcha } = signInPage;
+      if (await captcha.isVisible()) {
+        await captcha.click();
+      }
+
+      await signInPage.signInButton.click();
+
+      const errorToast = page.locator('[data-sonner-toast][data-type="error"]');
+      await expect(errorToast).toBeVisible();
+      await expect(errorToast).toContainText(
+        getEnglishText("i18n.pages.auth.sign_in.invalid_credentials")
+      );
+      expect(page.url()).toContain("/auth/sign-in");
+    });
+
+    // MARK: Rate Limiting
+
+    test("Page shows error when rate limited (429)", async ({ page }) => {
+      await page.route("**/api/session/login", (route) =>
+        route.fulfill({
+          status: 429,
+          headers: { "Retry-After": "60" },
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Too many requests." }),
+        })
+      );
+
+      const signInPage = newSignInPage(page);
+      await signInPage.usernameInput.fill("anyuser");
+      await signInPage.passwordInput.fill("anypassword");
+
+      const { captcha } = signInPage;
+      if (await captcha.isVisible()) {
+        await captcha.click();
+      }
+
+      await signInPage.signInButton.click();
+
+      const errorToast = page.locator('[data-sonner-toast][data-type="error"]');
+      await expect(errorToast).toBeVisible();
+      await expect(errorToast).toContainText(
+        getEnglishText("i18n.pages.auth._global.error_occurred")
+      );
+      expect(page.url()).toContain("/auth/sign-in");
+    });
+
+    // MARK: Network Failure
+
+    test("Page shows error on network failure", async ({ page }) => {
+      await page.route("**/api/session/login", (route) =>
+        route.abort("failed")
+      );
+
+      const signInPage = newSignInPage(page);
+      await signInPage.usernameInput.fill("anyuser");
+      await signInPage.passwordInput.fill("anypassword");
+
+      const { captcha } = signInPage;
+      if (await captcha.isVisible()) {
+        await captcha.click();
+      }
+
+      await signInPage.signInButton.click();
+
+      const errorToast = page.locator('[data-sonner-toast][data-type="error"]');
+      await expect(errorToast).toBeVisible();
+      expect(page.url()).toContain("/auth/sign-in");
+    });
+
+    // MARK: Recovery
+
+    test("User can recover and sign in after a mocked error", async ({
+      page,
+    }) => {
+      // Intercept with a 401 to trigger the error state.
+      await page.route("**/api/session/login", (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Invalid credentials." }),
+        })
+      );
+
+      const signInPage = newSignInPage(page);
+      await signInPage.usernameInput.fill("wronguser");
+      await signInPage.passwordInput.fill("wrongpassword");
+
+      const { captcha } = signInPage;
+      if (await captcha.isVisible()) {
+        await captcha.click();
+      }
+
+      await signInPage.signInButton.click();
+
+      const errorToast = page.locator('[data-sonner-toast][data-type="error"]');
+      await expect(errorToast).toBeVisible();
+
+      // Remove the mock so the next request hits the real backend.
+      await page.unrouteAll();
+
+      // Re-fill with valid credentials and resubmit.
+      await signInPage.usernameInput.fill("admin");
+      await signInPage.passwordInput.fill("admin");
+
+      const captchaAfterError = signInPage.captcha;
+      if (await captchaAfterError.isVisible()) {
+        await captchaAfterError.click();
+      }
+
+      await signInPage.signInButton.click();
+
+      await page.waitForURL("**/home");
+      expect(page.url()).toContain("/home");
+    });
+  }
+);


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

## Summary

Adds Playwright E2E specs covering all server-side failure paths on the sign-in page (`/auth/sign-in`) using `page.route()` mocks, and fixes the frontend error handler to correctly surface the "Invalid username or password" message for 401 responses.

### Changes

**`frontend/app/pages/auth/sign-in.vue`**

The existing error handler only showed the specific "Invalid username or password" toast for status `400`. The Nuxt session proxy (`server/api/session/login.ts`) maps any non-400 Django error to `401`, so unauthorized login attempts were falling through to the generic "An error occurred" toast. Extended the check to include `401`.

**`frontend/test-e2e/specs/all/authentication/sign-in/sign-in-server-errors.spec.ts`**

New spec with 5 tests:

| Scenario | Mock | Expected |
|---|---|---|
| Wrong credentials | `401` | "Invalid username or password" toast, stays on `/auth/sign-in` |
| Non-existent username | `401` | Same - documents no user enumeration |
| Rate limiting | `429` + `Retry-After: 60` | "An error occurred" toast, stays on `/auth/sign-in` |
| Network failure | `route.abort("failed")` | Any error toast visible, stays on `/auth/sign-in` |
| Recovery after error | `401` then `unrouteAll()` + real login | Redirects to `/home` |

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #2153 
