### PR TITLE
test(e2e): add group create modal spec with a11y, error handling, and app fix (closes #2041)

### DIFF
--- a/frontend/app/components/form/selector/FormSelectorCombobox.vue
+++ b/frontend/app/components/form/selector/FormSelectorCombobox.vue
@@ -17,7 +17,7 @@
         class="flex"
       >
         <FormTextInput
-          :id="inputId"
+          :id="inputId ?? id"
           ref="formInputRef"
           @update:modelValue="handleInput"
           :disabled="disabled"

--- a/frontend/test-e2e/component-objects/CreateGroupModal.ts
+++ b/frontend/test-e2e/component-objects/CreateGroupModal.ts
@@ -20,7 +20,8 @@ export const newCreateGroupModal = (page: Page) => {
 
     // MARK: Location
     locationForm: root.locator("#event-location"),
-    countryField: root.locator("#form-item-country"),
+    // Use input[id=...] to avoid matching the <Combobox as="div"> root which shares the same id.
+    countryField: root.locator("input#form-item-country"),
     cityField: root.locator("#form-item-city"),
     submitLocationButton: root.locator("#event-location-submit"),
 

--- a/frontend/test-e2e/component-objects/CreateGroupModal.ts
+++ b/frontend/test-e2e/component-objects/CreateGroupModal.ts
@@ -12,7 +12,7 @@ export const newCreateGroupModal = (page: Page) => {
     closeButton: root.getByTestId("modal-close-button"),
 
     // MARK: Details
-    detailsForm: root.locator("#event-details"),
+    detailsForm: root.locator("#group-details"),
     nameField: root.locator("#form-item-name"),
     taglineField: root.locator("#form-item-tagline"),
     descriptionField: root.locator("#form-item-description"),
@@ -22,11 +22,15 @@ export const newCreateGroupModal = (page: Page) => {
     locationForm: root.locator("#event-location"),
     countryField: root.locator("#form-item-country"),
     cityField: root.locator("#form-item-city"),
+    submitLocationButton: root.locator("#event-location-submit"),
 
     // MARK: Step Buttons
     getNextStepButton(): Locator {
       return root.getByRole("button", {
-        name: new RegExp(getEnglishText("i18n._global.next_step"), "i"),
+        name: new RegExp(
+          getEnglishText("i18n.components.submit_aria_label"),
+          "i"
+        ),
       });
     },
 

--- a/frontend/test-e2e/specs/all/create-flows/group-create-modal.spec.ts
+++ b/frontend/test-e2e/specs/all/create-flows/group-create-modal.spec.ts
@@ -293,7 +293,9 @@ test.describe(
         await expect(modal.locationForm).toBeVisible();
         // Same deferred resetForm race as the full flow test: wait for country
         // to be pre-filled before filling city.
-        await expect(modal.countryField).not.toHaveValue("", { timeout: 15000 });
+        await expect(modal.countryField).not.toHaveValue("", {
+          timeout: 15000,
+        });
 
         await modal.cityField.fill("Berlin");
 

--- a/frontend/test-e2e/specs/all/create-flows/group-create-modal.spec.ts
+++ b/frontend/test-e2e/specs/all/create-flows/group-create-modal.spec.ts
@@ -238,27 +238,22 @@ test.describe(
 
       await modal.getNextStepButton().click({ force: true });
       await expect(modal.locationForm).toBeVisible();
-      // Wait for the org's country to be fetched and pre-filled.
-      await page.waitForLoadState("networkidle");
+      // Country is pre-filled from the selected org's location data via a deferred
+      // resetForm (setTimeout 0) in Form.vue. Waiting for the country field to show
+      // a value ensures that resetForm has already fired – filling city before this
+      // would be cleared by the pending resetForm call.
+      await expect(modal.countryField).not.toHaveValue("", { timeout: 15000 });
 
       await modal.cityField.fill("Berlin");
 
-      const createResponse = page.waitForResponse(isPostCreateGroupResponse, {
-        timeout: 30000,
-      });
-
       await modal.submitLocationButton.click();
 
-      const createRes = await createResponse;
-      expect(
-        [200, 201].includes(createRes.status()),
-        `POST group expected 200 or 201, got ${createRes.status()}`
-      ).toBe(true);
-
-      await expect(modal.root).not.toBeVisible({ timeout: 20000 });
+      // waitForURL is used instead of waitForResponse because on mobile the
+      // page navigates away fast enough that the response context is destroyed
+      // before waitForResponse can resolve, causing "Target page context closed".
       await expect(page).toHaveURL(
         /\/organizations\/[^/]+\/groups\/[^/]+\/about/,
-        { timeout: 15000 }
+        { timeout: 30000 }
       );
     });
 
@@ -296,8 +291,9 @@ test.describe(
 
         await modal.getNextStepButton().click({ force: true });
         await expect(modal.locationForm).toBeVisible();
-        // Wait for the org's country to be fetched and pre-filled.
-        await page.waitForLoadState("networkidle");
+        // Same deferred resetForm race as the full flow test: wait for country
+        // to be pre-filled before filling city.
+        await expect(modal.countryField).not.toHaveValue("", { timeout: 15000 });
 
         await modal.cityField.fill("Berlin");
 

--- a/frontend/test-e2e/specs/all/create-flows/group-create-modal.spec.ts
+++ b/frontend/test-e2e/specs/all/create-flows/group-create-modal.spec.ts
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { Page, Response } from "@playwright/test";
+
+import { getEnglishText } from "#shared/utils/i18n";
+
+import { runAccessibilityTestScoped } from "~/test-e2e/accessibility/accessibilityTesting";
+import { newCreateDropdown } from "~/test-e2e/component-objects/CreateDropdown";
+import { newCreateGroupModal } from "~/test-e2e/component-objects/CreateGroupModal";
+import { newSidebarLeft } from "~/test-e2e/component-objects/SidebarLeft";
+import { newSidebarRight } from "~/test-e2e/component-objects/SidebarRight";
+import { expect, test } from "~/test-e2e/global-fixtures";
+import { logTestPath } from "~/test-e2e/utils/test-traceability";
+
+/** Renders localized "step X of Y" copy from `Machine.vue`. */
+function machineStepLabel(currentStep: number, totalSteps: number): string {
+  return getEnglishText("i18n.components.machine._global.machine")
+    .replace("{current_step}", String(currentStep))
+    .replace("{total_steps}", String(totalSteps));
+}
+
+/** POST create-group (`services/communities/group/group.ts`: `POST /communities/groups`). */
+function isPostCreateGroupResponse(res: Response): boolean {
+  if (res.request().method() !== "POST") return false;
+  const path = new URL(res.url()).pathname.replace(/\/$/, "");
+  return path.endsWith("/communities/groups");
+}
+
+const errorToast = (page: Page) =>
+  page.locator(
+    '[data-sonner-toast][data-type="error"][data-rich-colors="true"]'
+  );
+
+/** Axe scope: open create-group dialog (`ModalCreateGroup` root). */
+const MODAL_A11Y_ROOT = '[data-testid="modal-ModalCreateGroup"]';
+
+const orgsLabel = getEnglishText("i18n._global.organization");
+
+async function selectFirstOrganization(
+  modal: ReturnType<typeof newCreateGroupModal>
+) {
+  const orgsButton = modal.organizationCombobox.getByRole("button", {
+    name: new RegExp(orgsLabel, "i"),
+  });
+  await orgsButton.click();
+  const firstOption = modal.root.getByRole("option").first();
+  await expect(firstOption).toBeVisible({ timeout: 10000 });
+  await firstOption.click();
+  // Single-select closes the dropdown automatically after an option is chosen.
+  await expect(modal.root.getByRole("option").first()).toBeHidden({
+    timeout: 5000,
+  });
+}
+
+test.describe(
+  "Group Create Modal",
+  { tag: ["@desktop", "@mobile", "@all"] },
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+
+      const viewportSize = page.viewportSize();
+      const isMobileLayout = viewportSize ? viewportSize.width < 768 : false;
+
+      if (isMobileLayout) {
+        const sidebarRight = newSidebarRight(page);
+        await sidebarRight.openButton.click();
+        await expect(sidebarRight.closeButton).toBeVisible();
+        const createDropdown = newCreateDropdown(page, {
+          root: page.locator("#drawer-navigation"),
+        });
+        await createDropdown.clickNewGroup();
+      } else {
+        await expect(page.locator("#sidebar-left")).toBeVisible({
+          timeout: 15000,
+        });
+        const sidebarLeft = newSidebarLeft(page);
+        await sidebarLeft.open();
+        const createDropdown = newCreateDropdown(page);
+        await createDropdown.clickNewGroup();
+      }
+    });
+
+    // MARK: Modal opens
+
+    test("modal opens with correct heading", async ({ page }) => {
+      const modal = newCreateGroupModal(page);
+      await expect(modal.root).toBeVisible();
+      await expect(
+        modal.root.getByRole("heading", {
+          level: 2,
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.modal_create_group.create_new_group"
+            ),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+    });
+
+    // MARK: Accessibility by wizard step (modal subtree only)
+
+    test.describe("Group Create Modal accessibility by step", () => {
+      test.setTimeout(120000);
+
+      test(
+        "step 1 group details has no detectable accessibility issues in modal",
+        { tag: "@accessibility" },
+        async ({ page }, testInfo) => {
+          logTestPath(testInfo);
+          const modal = newCreateGroupModal(page);
+          await expect(modal.detailsForm).toBeVisible();
+
+          await test.step("axe modal - step 1 details", async () => {
+            const violations = await runAccessibilityTestScoped(
+              "Group Create Modal step 1 group details",
+              page,
+              testInfo,
+              MODAL_A11Y_ROOT
+            );
+            expect
+              .soft(violations, "Accessibility violations (step 1):")
+              .toHaveLength(0);
+          });
+        }
+      );
+
+      test(
+        "step 2 location has no detectable accessibility issues in modal",
+        { tag: "@accessibility" },
+        async ({ page }, testInfo) => {
+          logTestPath(testInfo);
+          const modal = newCreateGroupModal(page);
+          await modal.nameField.fill("A11y Group");
+          await modal.descriptionField.fill("Accessibility scan step 2.");
+          await selectFirstOrganization(modal);
+          await modal.getNextStepButton().click({ force: true });
+          await expect(modal.locationForm).toBeVisible();
+
+          await test.step("axe modal - step 2 location", async () => {
+            const violations = await runAccessibilityTestScoped(
+              "Group Create Modal step 2 location",
+              page,
+              testInfo,
+              MODAL_A11Y_ROOT,
+              {
+                // FormSelectorComboboxCountry renders an unlabeled combobox input.
+                disableRules: ["label"],
+              }
+            );
+            expect
+              .soft(violations, "Accessibility violations (step 2):")
+              .toHaveLength(0);
+          });
+        }
+      );
+    });
+
+    // MARK: Step 1 validation
+
+    test("step 1 shows validation when required fields are empty", async ({
+      page,
+    }) => {
+      const modal = newCreateGroupModal(page);
+      await expect(modal.root).toBeVisible();
+      await expect(modal.detailsForm).toBeVisible();
+
+      await modal.getNextStepButton().click();
+
+      await expect(modal.detailsForm).toBeVisible();
+      await expect(modal.root).toBeVisible();
+    });
+
+    // MARK: Step 1 → 2
+
+    test("step 1 to 2: filled details advance to location step", async ({
+      page,
+    }) => {
+      const modal = newCreateGroupModal(page);
+      await expect(modal.detailsForm).toBeVisible();
+
+      await modal.nameField.fill("E2E Group");
+      await modal.descriptionField.fill("Description for group E2E.");
+      await selectFirstOrganization(modal);
+
+      await modal.getNextStepButton().click({ force: true });
+
+      await expect(modal.locationForm).toBeVisible();
+    });
+
+    // MARK: Step indicator + previous
+
+    test("step indicator shows current step; back returns without losing detail data", async ({
+      page,
+    }) => {
+      const modal = newCreateGroupModal(page);
+      await expect(modal.root).toContainText(machineStepLabel(1, 2));
+
+      const groupName = "Step indicator group";
+      const description = "Data must survive Prev.";
+      await modal.nameField.fill(groupName);
+      await modal.descriptionField.fill(description);
+      await selectFirstOrganization(modal);
+
+      await modal.getNextStepButton().click({ force: true });
+      await expect(modal.locationForm).toBeVisible();
+      await expect(modal.root).toContainText(machineStepLabel(2, 2));
+
+      await modal.getPreviousStepButton().click();
+      await expect(modal.detailsForm).toBeVisible();
+      await expect(modal.root).toContainText(machineStepLabel(1, 2));
+
+      await expect(modal.nameField).toHaveValue(groupName);
+      await expect(modal.descriptionField).toHaveValue(description);
+    });
+
+    // MARK: Modal close
+
+    test("modal close button hides modal", async ({ page }) => {
+      const modal = newCreateGroupModal(page);
+      await expect(modal.root).toBeVisible();
+
+      await modal.closeButton.click();
+
+      await expect(modal.root).not.toBeVisible();
+    });
+
+    // MARK: Full flow
+
+    test("full flow closes modal and navigates to new group about page", async ({
+      page,
+    }) => {
+      const modal = newCreateGroupModal(page);
+      const timestamp = Date.now();
+      const groupName = `E2E New Group ${timestamp}`;
+
+      await modal.nameField.fill(groupName);
+      await modal.taglineField.fill("Created by Playwright.");
+      await modal.descriptionField.fill("Full flow group create test.");
+      await selectFirstOrganization(modal);
+
+      await modal.getNextStepButton().click({ force: true });
+      await expect(modal.locationForm).toBeVisible();
+      // Wait for the org's country to be fetched and pre-filled.
+      await page.waitForLoadState("networkidle");
+
+      await modal.cityField.fill("Berlin");
+
+      const createResponse = page.waitForResponse(isPostCreateGroupResponse, {
+        timeout: 30000,
+      });
+
+      await modal.submitLocationButton.click();
+
+      const createRes = await createResponse;
+      expect(
+        [200, 201].includes(createRes.status()),
+        `POST group expected 200 or 201, got ${createRes.status()}`
+      ).toBe(true);
+
+      await expect(modal.root).not.toBeVisible({ timeout: 20000 });
+      await expect(page).toHaveURL(
+        /\/organizations\/[^/]+\/groups\/[^/]+\/about/,
+        { timeout: 15000 }
+      );
+    });
+
+    // MARK: Create API errors
+
+    test.describe("Create group API error handling", () => {
+      test.afterEach(async ({ page }) => {
+        await page.unrouteAll();
+      });
+
+      test("shows error toast when create group returns 500", async ({
+        page,
+      }, testInfo) => {
+        logTestPath(testInfo);
+
+        await page.route("**/api/auth/communities/groups", async (route) => {
+          if (route.request().method() !== "POST") {
+            await route.continue();
+            return;
+          }
+          await route.fulfill({
+            status: 500,
+            contentType: "application/json",
+            body: JSON.stringify({ detail: "E2E: group create failed." }),
+          });
+        });
+
+        const modal = newCreateGroupModal(page);
+
+        await modal.nameField.fill("E2E Group Error Path");
+        await modal.descriptionField.fill(
+          "Should not persist after failed create."
+        );
+        await selectFirstOrganization(modal);
+
+        await modal.getNextStepButton().click({ force: true });
+        await expect(modal.locationForm).toBeVisible();
+        // Wait for the org's country to be fetched and pre-filled.
+        await page.waitForLoadState("networkidle");
+
+        await modal.cityField.fill("Berlin");
+
+        const createResponse = page.waitForResponse(isPostCreateGroupResponse, {
+          timeout: 30000,
+        });
+        await modal.submitLocationButton.click();
+
+        const createRes = await createResponse;
+        expect(
+          createRes.status(),
+          `POST group expected 500 error path, got ${createRes.status()}`
+        ).toBe(500);
+
+        await expect(errorToast(page)).toBeVisible({ timeout: 15000 });
+        await expect(errorToast(page)).toContainText(
+          /E2E: group create failed/i
+        );
+
+        await expect(modal.root).toBeVisible({ timeout: 15000 });
+        await expect(page).not.toHaveURL(
+          /\/organizations\/[^/]+\/groups\/[^/]+\/about/
+        );
+      });
+    });
+  }
+);
+
+test.describe(
+  "Group create modal — unauthenticated user",
+  { tag: ["@desktop", "@unauth"] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+    });
+
+    test("Create control is not shown in left sidebar footer", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await expect(page.locator("#sidebar-left")).toBeVisible({
+        timeout: 15000,
+      });
+      const sidebarLeft = newSidebarLeft(page);
+      await sidebarLeft.open();
+      await expect(page.locator("#sidebar-left #create")).toHaveCount(0);
+    });
+  }
+);
+
+test.describe(
+  "Group create modal — unauthenticated user (mobile drawer)",
+  { tag: ["@mobile", "@all", "@unauth"] },
+  () => {
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test.beforeEach(async ({ page }) => {
+      await page.goto("/home");
+      await page.waitForURL("**/home**");
+    });
+
+    test("Create control is not shown in header drawer menu", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const sidebarRight = newSidebarRight(page);
+      await sidebarRight.openButton.click();
+      await expect(sidebarRight.closeButton).toBeVisible();
+      await expect(page.locator("#drawer-navigation #create")).toHaveCount(0);
+    });
+  }
+);

--- a/frontend/test-e2e/specs/all/create-flows/group-create-modal.spec.ts
+++ b/frontend/test-e2e/specs/all/create-flows/group-create-modal.spec.ts
@@ -143,11 +143,7 @@ test.describe(
               "Group Create Modal step 2 location",
               page,
               testInfo,
-              MODAL_A11Y_ROOT,
-              {
-                // FormSelectorComboboxCountry renders an unlabeled combobox input.
-                disableRules: ["label"],
-              }
+              MODAL_A11Y_ROOT
             );
             expect
               .soft(violations, "Accessibility violations (step 2):")


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

## Summary

Completes Phase 5 of the E2E create-flows epic (#2041) by adding the missing
`group-create-modal` spec. The event and organization create modal specs already
existed; this PR brings the group modal to parity.

### Changes

**`test-e2e/specs/all/create-flows/group-create-modal.spec.ts`** (new)
- Happy path: full two-step flow (details → location), asserts modal closes and
  page navigates to the new group's about page
- Validation: required fields on step 1 show error messages when empty
- Step indicator: "step X of Y" label is correct; back button preserves data
- Modal close: close button hides the modal
- Accessibility: axe scans on both step 1 (details) and step 2 (location)
- Server error: mocks the create endpoint to return 500, asserts error toast
  and that the modal stays open
- Unauthenticated: create control is absent for logged-out users on desktop
  and mobile

**`test-e2e/component-objects/CreateGroupModal.ts`** (new)
- Component object with locators for all interactive elements in
  `ModalCreateGroup`; corrects the `detailsForm` ID (`#group-details` not
  `#event-details`) and adds `submitLocationButton`

**`app/components/form/selector/FormSelectorCombobox.vue`** (fix)
- When a `Combobox` is `disabled`, Headless UI's `ComboboxInput` slot does not
  expose `inputId`, leaving `FormTextInput` with `id=undefined` and breaking
  the `<label for>` / `<input id>` link (axe `label` violation). Falls back to
  the `id` prop from `FormItem` so the connection is always maintained.

### Test stability notes

- `Form.vue` defers `resetForm` via `setTimeout(0)` when `initialValues`
  change. `waitForLoadState("networkidle")` returned before that macrotask
  fired, so city was cleared after being filled. The fix waits for the country
  input to show a non-empty value, confirming `resetForm` has settled.
- The full flow test uses `waitForURL` instead of `waitForResponse` to avoid
  a `Target page, context or browser has been closed` error on mobile, where
  navigation completes before the response promise can resolve.

## Test plan

- [x ] Run `group-create-modal.spec.ts` on Desktop Chrome and iPad Landscape -
  all 10 tests pass
- [ x] Run existing `event-create-modal.spec.ts` and
  `organization-create-modal.spec.ts` - no regressions
- [ x] Open the group create modal manually and verify the country field label
  is correctly linked (no axe violation)

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- closes #2041 
