### PR TITLE
fix: wire New Group/Event buttons to create modals and add E2E tests (#2159)

### DIFF
--- a/frontend/app/pages/organizations/[orgId]/events.vue
+++ b/frontend/app/pages/organizations/[orgId]/events.vue
@@ -17,7 +17,9 @@
       :tagline="$t('i18n.pages.organizations._global.events_tagline')"
     >
       <div class="flex space-x-2 lg:space-x-3">
-        <BtnRouteInternal
+        <BtnAction
+          @click="openModal()"
+          @keydown.enter="openModal()"
           ariaLabel="i18n.pages.organizations.events.new_org_event_aria_label"
           class="w-max"
           :cta="true"
@@ -25,7 +27,6 @@
           iconSize="1.35em"
           label="i18n._global.new_event"
           :leftIcon="IconMap.PLUS"
-          linkTo="/"
         />
         <BtnAction
           @click="downloadCalendarEntries"
@@ -60,6 +61,8 @@
 const { data: organization } = useGetOrganization(
   useRoute().params.orgId as string
 );
+
+const { openModal } = useModalHandlers("ModalCreateEvent");
 
 const downloadCalendarEntries = () => {};
 </script>

--- a/frontend/app/pages/organizations/[orgId]/groups/[groupId]/events.vue
+++ b/frontend/app/pages/organizations/[orgId]/groups/[groupId]/events.vue
@@ -17,7 +17,9 @@
       :underDevelopment="false"
     >
       <div class="flex space-x-2 pb-3 lg:space-x-3 lg:pb-4">
-        <BtnRouteInternal
+        <BtnAction
+          @click="openModal()"
+          @keydown.enter="openModal()"
           ariaLabel="i18n.pages.organizations.groups.events.new_group_event_aria_label"
           class="w-max"
           :cta="true"
@@ -25,7 +27,6 @@
           iconSize="1.35em"
           label="i18n._global.new_event"
           :leftIcon="IconMap.PLUS"
-          linkTo="/"
         />
         <BtnAction
           @click="downloadCalendarEntries"
@@ -59,6 +60,8 @@ const groupId = typeof paramsGroupId === "string" ? paramsGroupId : "";
 
 const { data: group } = useGetGroup(groupId);
 const groupTabs = useGetGroupTabs();
+
+const { openModal } = useModalHandlers("ModalCreateEvent");
 
 const downloadCalendarEntries = () => {};
 </script>

--- a/frontend/app/pages/organizations/[orgId]/groups/index.vue
+++ b/frontend/app/pages/organizations/[orgId]/groups/index.vue
@@ -17,7 +17,9 @@
       :tagline="$t('i18n.pages.organizations.groups.index.tagline')"
     >
       <div class="flex space-x-2 lg:space-x-3">
-        <BtnRouteInternal
+        <BtnAction
+          @click="openModal()"
+          @keydown.enter="openModal()"
           ariaLabel="i18n.pages.organizations.groups.index.new_group_aria_label"
           class="w-max"
           :cta="true"
@@ -25,7 +27,6 @@
           iconSize="1.35em"
           label="i18n._global.new_group"
           :leftIcon="IconMap.PLUS"
-          linkTo="/"
         />
       </div>
     </HeaderAppPageOrganization>
@@ -50,4 +51,6 @@
 const { data: organization } = useGetOrganization(
   (useRoute().params.orgId as string) ?? ""
 );
+
+const { openModal } = useModalHandlers("ModalCreateGroup");
 </script>

--- a/frontend/test-e2e/page-objects/organization/OrganizationGroupsPage.ts
+++ b/frontend/test-e2e/page-objects/organization/OrganizationGroupsPage.ts
@@ -6,7 +6,7 @@ import { getEnglishText } from "#shared/utils/i18n";
 export const newOrganizationGroupsPage = (page: Page) => ({
   // MARK: Header Action
 
-  newGroupButton: page.getByRole("link", {
+  newGroupButton: page.getByRole("button", {
     name: new RegExp(
       getEnglishText(
         "i18n.pages.organizations.groups.index.new_group_aria_label"

--- a/frontend/test-e2e/page-objects/organization/events/OrganizationEventsPage.ts
+++ b/frontend/test-e2e/page-objects/organization/events/OrganizationEventsPage.ts
@@ -6,7 +6,7 @@ import { getEnglishText } from "#shared/utils/i18n";
 export const newOrganizationEventsPage = (page: Page) => ({
   // MARK: Header Action
 
-  eventsNewButton: page.getByRole("link", {
+  eventsNewButton: page.getByRole("button", {
     name: new RegExp(
       getEnglishText(
         "i18n.pages.organizations.events.new_org_event_aria_label"

--- a/frontend/test-e2e/page-objects/organization/groups/events/OrganizationGroupEventsPage.ts
+++ b/frontend/test-e2e/page-objects/organization/groups/events/OrganizationGroupEventsPage.ts
@@ -12,7 +12,14 @@ export const newOrganizationGroupEventsPage = (page: Page) => {
     // MARK: Header
 
     get newEventButton() {
-      return page.getByRole("link", { name: /new event/i });
+      return page.getByRole("button", {
+        name: new RegExp(
+          getEnglishText(
+            "i18n.pages.organizations.groups.events.new_group_event_aria_label"
+          ),
+          "i"
+        ),
+      });
     },
 
     get subscribeToEventsButton() {

--- a/frontend/test-e2e/specs/all/organizations/groups/organization-group-events/organization-group-events-page.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/groups/organization-group-events/organization-group-events-page.spec.ts
@@ -135,18 +135,5 @@ test.describe(
       // If neither events nor empty state is visible, that's also valid (handled by early return above).
     });
 
-    test("User can access new event creation", async ({ page }, testInfo) => {
-      logTestPath(testInfo);
-      const organizationPage = newOrganizationPage(page);
-      const { groupEventsPage } = organizationPage;
-
-      // Verify new event button is visible and functional.
-      await expect(groupEventsPage.newEventButton).toBeVisible();
-      await expect(groupEventsPage.newEventButton).toHaveAttribute(
-        "href",
-        /.+/
-      );
-      // Note: We don't click it as it would navigate away from the current page.
-    });
   }
 );

--- a/frontend/test-e2e/specs/all/organizations/groups/organization-group-events/organization-group-events-page.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/groups/organization-group-events/organization-group-events-page.spec.ts
@@ -134,6 +134,5 @@ test.describe(
       }
       // If neither events nor empty state is visible, that's also valid (handled by early return above).
     });
-
   }
 );

--- a/frontend/test-e2e/specs/all/organizations/groups/organization-group-events/organization-group-events-page.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/groups/organization-group-events/organization-group-events-page.spec.ts
@@ -46,6 +46,27 @@ test.describe(
       });
     });
 
+    // MARK: Create
+
+    test("New event button opens create event modal", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      const organizationPage = newOrganizationPage(page);
+      const { groupEventsPage } = organizationPage;
+
+      await expect(groupEventsPage.newEventButton).toBeVisible();
+      await groupEventsPage.newEventButton.click();
+
+      const modal = page.getByTestId("modal-ModalCreateEvent");
+      await expect(modal).toBeVisible({ timeout: 10000 });
+
+      await modal.getByTestId("modal-close-button").click();
+      await expect(modal).not.toBeVisible({ timeout: 5000 });
+    });
+
+    // MARK: Display
+
     test("User can view group events", async ({ page }, testInfo) => {
       logTestPath(testInfo);
       const organizationPage = newOrganizationPage(page);

--- a/frontend/test-e2e/specs/all/organizations/organization-events/organization-events-interactions.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/organization-events/organization-events-interactions.spec.ts
@@ -14,16 +14,18 @@ test.describe(
   () => {
     // MARK: Create
 
-    test("User can access new event creation", async ({ page }) => {
+    test("New event button opens create event modal", async ({ page }) => {
       const organizationPage = newOrganizationPage(page);
       const { eventsPage } = organizationPage;
 
-      // Verify new event button is visible and functional.
       await expect(eventsPage.eventsNewButton).toBeVisible();
-      await expect(eventsPage.eventsNewButton).toHaveAttribute("href", /.+/);
+      await eventsPage.eventsNewButton.click();
 
-      // Note: We don't click it as it would navigate away from the current page
-      // and we want to keep the test focused on the events page functionality.
+      const modal = page.getByTestId("modal-ModalCreateEvent");
+      await expect(modal).toBeVisible({ timeout: 10000 });
+
+      await modal.getByTestId("modal-close-button").click();
+      await expect(modal).not.toBeVisible({ timeout: 5000 });
     });
 
     // MARK: Subscribe

--- a/frontend/test-e2e/specs/all/organizations/organization-groups/organization-groups-page.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/organization-groups/organization-groups-page.spec.ts
@@ -128,6 +128,24 @@ test.describe(
       }
     });
 
+    // MARK: Create
+
+    test("New group button opens create group modal", async ({ page }) => {
+      const organizationPage = newOrganizationPage(page);
+      const { groupsPage } = organizationPage;
+
+      await expect(groupsPage.newGroupButton).toBeVisible();
+      await groupsPage.newGroupButton.click();
+
+      const modal = page.getByTestId("modal-ModalCreateGroup");
+      await expect(modal).toBeVisible({ timeout: 10000 });
+
+      await modal.getByTestId("modal-close-button").click();
+      await expect(modal).not.toBeVisible({ timeout: 5000 });
+    });
+
+    // MARK: Share
+
     test("User can share organization groups", async ({ page }) => {
       const organizationPage = newOrganizationPage(page);
       const { groupsPage, shareModal } = organizationPage;


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

## Summary

Three pages had "New X" action buttons using `BtnRouteInternal` with `linkTo="/"` as a placeholder, so clicking them navigated to `/` instead of opening the appropriate create modal. This PR wires them up correctly and adds E2E tests to prevent regressions.

**App fixes:**
- `organizations/[orgId]/groups/index.vue` — "New Group" now opens `ModalCreateGroup`
- `organizations/[orgId]/events.vue` — "New Event" now opens `ModalCreateEvent`
- `organizations/[orgId]/groups/[groupId]/events.vue` — "New Event" now opens `ModalCreateEvent`

**E2E tests:**
- Updated `newGroupButton`, `eventsNewButton`, and `newEventButton` locators in three page objects from `getByRole("link")` to `getByRole("button")` to match the new `BtnAction` components
- Added "New group button opens create group modal" test to `organization-groups-page.spec.ts`
- Replaced the stale `href`-assertion test with "New event button opens create event modal" in `organization-events-interactions.spec.ts`
- Added "New event button opens create event modal" test to `organization-group-events-page.spec.ts`

Closes #2159

## Test plan

- [ x] Click "New Group" on an org's Groups page — `ModalCreateGroup` opens
- [ x] Click "New Event" on an org's Events page — `ModalCreateEvent` opens
- [ x] Click "New Event" on a group's Events page — `ModalCreateEvent` opens
- [ x] All three new E2E tests pass on Desktop Chrome and iPad Landscape and Mobile Chrome

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- closes #2159 
