### PR TITLE
fix: remover unsupported approovedGitRepositories from yarnrc

### DIFF
--- a/frontend/.yarnrc.yml
+++ b/frontend/.yarnrc.yml
@@ -1,6 +1,3 @@
-approvedGitRepositories:
-  - "**"
-
 enableScripts: true
 
 nodeLinker: node-modules


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Removes the "approvedGitRepositories" setting from "frontend/.yarnrc.yml" as it is not recognized by the version of yarn running in CI.


-->

Description of the proposed change...

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- #ISSUE_NUMBER
