### PR TITLE
chore(backend): isolate complexipy in its own dependency group

### DIFF
--- a/.github/workflows/ci_backend_static_analysis.yaml
+++ b/.github/workflows/ci_backend_static_analysis.yaml
@@ -60,4 +60,4 @@ jobs:
 
       - name: Run complexipy - Cognitive Complexity Check
         if: always()
-        run: uv run complexipy .
+        run: uv run --group complexity complexipy .

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "complexipy>=4.2.0",
     "factory-boy>=3.3.3",
     "i18n-check>=1.19.5",
     "mypy>=2.1.0",
@@ -39,6 +38,10 @@ dev = [
     "ts-backend-check>=1.6.0",
     "types-icalendar>=6.3.2.20260518",
 ]
+# complexipy is kept out of the default `dev` group because it ships no
+# musllinux wheel, so the Alpine dev container would try (and fail) to build it
+# from source. Install it explicitly with `--group complexity` where needed.
+complexity = ["complexipy>=4.2.0"]
 audit = ["pysentry-rs>=0.4.5"]
 
 [tool.ruff]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -133,8 +133,10 @@ dependencies = [
 audit = [
     { name = "pysentry-rs" },
 ]
-dev = [
+complexity = [
     { name = "complexipy" },
+]
+dev = [
     { name = "factory-boy" },
     { name = "i18n-check" },
     { name = "mypy" },
@@ -172,8 +174,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 audit = [{ name = "pysentry-rs", specifier = ">=0.4.5" }]
+complexity = [{ name = "complexipy", specifier = ">=4.2.0" }]
 dev = [
-    { name = "complexipy", specifier = ">=4.2.0" },
     { name = "factory-boy", specifier = ">=3.3.3" },
     { name = "i18n-check", specifier = ">=1.19.5" },
     { name = "mypy", specifier = ">=2.1.0" },


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

After `complexipy` was added, the backend Docker container would not start on Apple Silicon / ARM machines and kept restarting. It was trying to install `complexipy` on startup, which doesn't work on the type of image the container uses.

This change stops the container from installing `complexipy` (it never needs to run it), while keeping it available for the CI complexity check and for anyone who wants to run it directly. The tools the container actually needs to load sample data are untouched.

**Changes**
- `backend/pyproject.toml`: move `complexipy` into its own `complexity` group instead of the default `dev` group.
- `.github/workflows/ci_backend_static_analysis.yaml`: run the check with `uv run --group complexity complexipy .`.
- `backend/uv.lock`: updated to match.

**Testing**
- Rebuilt and started the backend container: it now starts normally, runs migrations, and loads the sample data (users, organizations, events, etc.).
- Confirmed the complexity check still works when run with the new group.

**Risk:** Low. Nothing about how the app runs changes.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #2184 