### PR TITLE
test(e2e): add API error and navigation smoke tests for organizations listing (#2192)

### DIFF
--- a/frontend/test-e2e/specs/all/organizations/organizations-list/organizations-home-page.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/organizations-list/organizations-home-page.spec.ts
@@ -51,5 +51,31 @@ test.describe(
         }
       });
     });
+
+    test("User can navigate to an organization about page", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+
+      await withTestStep(testInfo, "Click on first organization", async () => {
+        const orgLink = page
+          .getByRole("link", {
+            name: getEnglishText(
+              "i18n.components._global.navigate_to_organization_aria_label"
+            ),
+          })
+          .first();
+        await orgLink.click();
+      });
+
+      await withTestStep(
+        testInfo,
+        "Verify navigation to organization about page",
+        async () => {
+          await expect(page).toHaveURL(/.*\/organizations\/.*\/about/);
+          await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+        }
+      );
+    });
   }
 );

--- a/frontend/test-e2e/specs/all/organizations/organizations-list/organizations-list-api-errors.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/organizations-list/organizations-list-api-errors.spec.ts
@@ -8,7 +8,7 @@ import type { Page } from "@playwright/test";
 import { getEnglishText } from "#shared/utils/i18n";
 
 import { expect, test } from "~/test-e2e/global-fixtures";
-import { logTestPath, withTestStep } from "~/test-e2e/utils/test-traceability";
+import { logTestPath } from "~/test-e2e/utils/test-traceability";
 
 /** Public list endpoint used by `listOrganizations` (`withoutAuth: true` → /api/public). */
 const ORGANIZATIONS_LIST_ROUTE = "**/api/public/communities/organizations**";
@@ -91,37 +91,6 @@ test.describe(
       });
 
       await expect(errorToasts(page)).toHaveCount(0);
-    });
-
-    test("User can navigate to an organization about page", async ({
-      page,
-    }, testInfo) => {
-      logTestPath(testInfo);
-
-      await page.goto("/organizations");
-      await expect(page.getByRole("heading", { level: 1 })).toHaveText(
-        getEnglishText("i18n.pages.organizations.index.header_title")
-      );
-
-      await withTestStep(testInfo, "Click on first organization", async () => {
-        const orgLink = page
-          .getByRole("link", {
-            name: getEnglishText(
-              "i18n.components._global.navigate_to_organization_aria_label"
-            ),
-          })
-          .first();
-        await orgLink.click();
-      });
-
-      await withTestStep(
-        testInfo,
-        "Verify navigation to organization about page",
-        async () => {
-          await expect(page).toHaveURL(/.*\/organizations\/.*\/about/);
-          await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
-        }
-      );
     });
   }
 );

--- a/frontend/test-e2e/specs/all/organizations/organizations-list/organizations-list-api-errors.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/organizations-list/organizations-list-api-errors.spec.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * Canonical E2E for the shared "list composable" failure pattern: GET list fails →
+ * toast + EmptyState (same UX as a true empty catalog). Mirrors events-list-api-errors.spec.ts.
+ */
+import type { Page } from "@playwright/test";
+
+import { getEnglishText } from "#shared/utils/i18n";
+
+import { expect, test } from "~/test-e2e/global-fixtures";
+import { logTestPath, withTestStep } from "~/test-e2e/utils/test-traceability";
+
+/** Public list endpoint used by `listOrganizations` (`withoutAuth: true` → /api/public). */
+const ORGANIZATIONS_LIST_ROUTE = "**/api/public/communities/organizations**";
+
+const errorToasts = (page: Page) =>
+  page.locator('[data-sonner-toast][data-type="error"]');
+
+test.describe(
+  "Organizations list API — errors and empty catalog",
+  { tag: ["@desktop", "@mobile"] },
+  () => {
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    test("List API failure shows error toast and empty state", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+
+      await page.route(ORGANIZATIONS_LIST_ROUTE, async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({
+            detail: "E2E: organizations list request failed.",
+          }),
+        });
+      });
+
+      await page.goto("/organizations");
+      await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+        getEnglishText("i18n.pages.organizations.index.header_title")
+      );
+
+      const toast = errorToasts(page).first();
+      await expect(toast).toBeVisible({ timeout: 15000 });
+      await expect(toast).toContainText(
+        /E2E: organizations list request failed/i
+      );
+
+      await expect(page.getByTestId("empty-state")).toBeVisible({
+        timeout: 15000,
+      });
+    });
+
+    test("Successful empty list shows empty state without error toast", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+
+      await page.route(ORGANIZATIONS_LIST_ROUTE, async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.continue();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            count: 0,
+            next: null,
+            previous: null,
+            results: [],
+          }),
+        });
+      });
+
+      await page.goto("/organizations");
+      await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+        getEnglishText("i18n.pages.organizations.index.header_title")
+      );
+
+      await expect(page.getByTestId("empty-state")).toBeVisible({
+        timeout: 15000,
+      });
+
+      await expect(errorToasts(page)).toHaveCount(0);
+    });
+
+    test("User can navigate to an organization about page", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+
+      await page.goto("/organizations");
+      await expect(page.getByRole("heading", { level: 1 })).toHaveText(
+        getEnglishText("i18n.pages.organizations.index.header_title")
+      );
+
+      await withTestStep(testInfo, "Click on first organization", async () => {
+        const orgLink = page
+          .getByRole("link", {
+            name: getEnglishText(
+              "i18n.components._global.navigate_to_organization_aria_label"
+            ),
+          })
+          .first();
+        await orgLink.click();
+      });
+
+      await withTestStep(
+        testInfo,
+        "Verify navigation to organization about page",
+        async () => {
+          await expect(page).toHaveURL(/.*\/organizations\/.*\/about/);
+          await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+        }
+      );
+    });
+  }
+);


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

Adds two missing specs for the organizations listing page to bring it to parity with the events listing.

- `organizations-list-api-errors.spec.ts` - new file mirroring `events-list-api-errors.spec.ts`: mocked 500 shows error toast + empty state; mocked empty 200 shows empty state without error toast
- `organizations-home-page.spec.ts` - adds a navigation smoke test (click first org card navigates to `/organizations/[id]/about`) mirroring the equivalent test in `events-home-page.spec.ts`

Both specs tag `@desktop @mobile`.

### Related issue

- Closes #2192