### PR TITLE
fix(backend): organizations_by_user 500s for non-admin users

### DIFF
--- a/backend/communities/organizations/tests/test_org_by_user.py
+++ b/backend/communities/organizations/tests/test_org_by_user.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from authentication.factories import UserFactory
+from communities.organizations.factories import OrganizationFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -39,6 +40,49 @@ def test_org_by_user_ok_200():
     print(response.json())
 
     assert response.status_code == status.HTTP_200_OK
+
+
+def test_org_by_user_non_admin_ok_200() -> None:
+    """
+    Regression test: non-admin users previously got a FieldError (HTTP 500)
+    from the invalid created_by__user__id lookup, and a bare list instead of
+    the paginated envelope the frontend expects.
+    """
+    client = APIClient()
+
+    test_username = "test_user"
+    test_password = "test_pass"
+    user = UserFactory(username=test_username, plaintext_password=test_password)
+    user.is_confirmed = True
+    user.verified = True
+    user.save()
+
+    own_orgs = OrganizationFactory.create_batch(2, created_by=user)
+    OrganizationFactory()  # another user's org that must not be returned
+
+    user_login = client.post(
+        path="/v1/auth/sign_in",
+        data={
+            "username": test_username,
+            "password": test_password,
+        },
+    )
+
+    user_login_body = user_login.json()
+    token = user_login_body["access"]
+    assert user_login.status_code == status.HTTP_200_OK
+
+    response = client.get(
+        path=f"/v1/communities/organizations_by_user/{user.id}",
+        headers={"Authorization": f"Token {token}"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+    body = response.json()
+    assert set(body.keys()) >= {"count", "next", "previous", "results"}
+    assert body["count"] == 2
+    assert {org["id"] for org in body["results"]} == {str(org.id) for org in own_orgs}
 
 
 def test_org_by_user_forbidden_403():

--- a/backend/communities/organizations/views.py
+++ b/backend/communities/organizations/views.py
@@ -226,11 +226,18 @@ class OrganizationByUserAPIView(GenericAPIView[Organization]):
             serializer = self.get_serializer(page, many=True)
             return self.get_paginated_response(serializer.data)
 
-        orgs = Organization.objects.filter(created_by__user__id=user_id).order_by(
+        orgs = Organization.objects.filter(created_by__id=user_id).order_by(
             "acceptance_date"
         )
-        serializer = OrganizationSerializer(orgs, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        try:
+            page = self.paginate_queryset(orgs)
+        except NotFound:
+            return Response(
+                {"count": 0, "next": None, "previous": None, "results": []},
+                status=status.HTTP_200_OK,
+            )
+        serializer = self.get_serializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
 
 
 # MARK: Detail API


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

Regular (non-admin) users could not use flows that load their organizations, such as creating an event or group. The `organizations_by_user` endpoint returned HTTP 500 with a `FieldError` for unsupported lookup `user__id` on `User`.

**Changes:**
- `backend/communities/organizations/views.py`: Replace invalid `created_by__user__id` lookup with `created_by__id`, and return a paginated response envelope (`count`, `next`, `previous`, `results`) for non-admin users, matching what the frontend expects and what admin users already receive.
- `backend/communities/organizations/tests/test_org_by_user.py`: Add regression test ensuring a non-admin user gets HTTP 200, only their own organizations, and the paginated response shape.

**Testing:**
- `pytest backend/communities/organizations/tests/test_org_by_user.py`
- Manually verified: sign in as a regular user, open Create event, organization selector loads without error.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #2201