### PR TITLE
fix(authentication): align VerifyEmailView with SignUpView, fix email…

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -56,13 +56,27 @@ class VerifyEmailView(APIView):
     serializer_class = UserSerializer
 
     def post(self, request: Request, code: None | uuid.UUID = None) -> Response:
-        user = UserModel.objects.filter(verification_code=code).first()
-        if not user:
+        # Handle invalid UUIDs gracefully.
+        try:
+            user = UserModel.objects.filter(verification_code=code).first()
+
+        except (ValueError, ValidationError):
+            # Invalid UUID format - treat as user not found.
+            logger.warning(f"Email verification failed: invalid UUID format {code}")
             return Response(
-                {"detail": "Invalid code."}, status=status.HTTP_400_BAD_REQUEST
+                {"detail": "User does not exist."},
+                status=status.HTTP_404_NOT_FOUND,
             )
+
+        if user is None:
+            logger.warning(f"Email verification failed: invalid code {code}")
+            return Response(
+                {"detail": "User does not exist."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
         user.is_confirmed = True
-        user.verification_code = None
+        user.verification_code = None  # None instead of empty string for UUIDField
         user.save()
 
         serializer = self.serializer_class(user)
@@ -118,7 +132,7 @@ class SignUpView(APIView):
 
         logger.info(f"User created successfully: {user.username} (ID: {user.id})")
 
-        if user.email != "":
+        if user.email:
             user.verification_code = uuid.uuid4()
 
             confirmation_link = (

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -96,7 +96,7 @@ class SignOutView(APIView):
     @extend_schema(
         request=None,
         responses={
-            200: OpenApiResponse(response={"message": "User logged out successfully."}),
+            200: OpenApiResponse(response={"message": "User was logged out successfully."}),
             401: OpenApiResponse(response={"detail": "You are not authenticated."}),
         },
     )
@@ -475,7 +475,7 @@ class UserFlagDetailAPIView(GenericAPIView[UserFlag]):
         responses={
             200: UserFlagSerializers,
             404: OpenApiResponse(
-                response={"detail": "Failed to retrieve the user flag."}
+                response={"detail": "Failed to retrieve the flag."}
             ),
         }
     )
@@ -507,7 +507,7 @@ class UserFlagDetailAPIView(GenericAPIView[UserFlag]):
             403: OpenApiResponse(
                 response={"detail": "You are not authorized to delete this flag."}
             ),
-            404: OpenApiResponse(response={"detail": "Failed to retrieve flag."}),
+            404: OpenApiResponse(response={"detail": "Failed not found flag."}),
         }
     )
     def delete(self, request: Request, id: str | uuid.UUID) -> Response:


### PR DESCRIPTION
Contributor checklist
- [x] This pull request is on a separate branch and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes

Description

This PR addresses the points raised in #2148:
- Refactored `VerifyEmailView.post` to align with the more robust `SignUpView.get` implementation (handles invalid UUIDs gracefully, adds logging)
- Changed the email check from `if user.email != "":` to `if user.email:` for safer falsy checking
- Fixed 3 message inconsistencies between `@extend_schema` documentation and actual API responses

Related issue
Closes #2148