### PR TITLE
fix(frontend): resolve duplicate cards issue on events and organizations lists

### DIFF
--- a/frontend/app/composables/queries/useGetEvents.ts
+++ b/frontend/app/composables/queries/useGetEvents.ts
@@ -9,6 +9,15 @@ export function useGetEvents(
   const page = ref(1);
   const { handleError } = useAppError();
   const eventFilters = computed(() => unref(filters));
+  watch(
+    eventFilters,
+    (newFilters, oldFilters) => {
+      if (JSON.stringify(newFilters) !== JSON.stringify(oldFilters)) {
+        page.value = 1;
+      }
+    },
+    { deep: true }
+  );
   // UseAsyncData for SSR, hydration, and cache.
   const { data, pending, error, refresh } = useAsyncData<CommunityEvent[]>(
     () => getKeyForGetEvents(),
@@ -34,13 +43,13 @@ export function useGetEvents(
             store.setIsLastPage(false);
           }
         }
+        const isFilterChanged =
+          JSON.stringify(store.getFilters()) !==
+          JSON.stringify(eventFilters.value);
+
         const { data: events, isLastPage } = await listEvents({
           ...eventFilters.value,
-          page:
-            JSON.stringify(store.getFilters()) ===
-            JSON.stringify(eventFilters.value)
-              ? page.value
-              : 1,
+          page: isFilterChanged ? 1 : page.value,
           page_size: 10,
         });
         const eventsCached = store.getItems();
@@ -48,27 +57,18 @@ export function useGetEvents(
 
         // Append new events to cached events if page > 1.
         if (
+          !isFilterChanged &&
           eventsCached.length > 0 &&
-          JSON.stringify(store.getFilters()) ===
-            JSON.stringify(eventFilters.value) &&
-          (page.value > pageCached || (page.value === 1 && pageCached === 1))
+          page.value > pageCached
         ) {
           store.setItems([...eventsCached, ...events]);
           store.setIsLastPage(isLastPage);
+          store.setPage(page.value);
           return [...eventsCached, ...events] as CommunityEvent[];
         }
         store.setItems(events);
         store.setIsLastPage(isLastPage);
-        // Reset to page 1 if filters changed.
-        if (
-          JSON.stringify(store.getFilters()) !==
-          JSON.stringify(eventFilters.value)
-        ) {
-          store.setPage(1);
-          page.value = 1;
-        } else {
-          store.setPage(page.value);
-        }
+        store.setPage(isFilterChanged ? 1 : page.value);
         store.setFilters(eventFilters.value);
         return events as CommunityEvent[];
       } catch (err) {

--- a/frontend/app/composables/queries/useGetOrganizations.ts
+++ b/frontend/app/composables/queries/useGetOrganizations.ts
@@ -9,6 +9,15 @@ export function useGetOrganizations(
   const page = ref(1);
   const { handleError } = useAppError();
   const orgFilters = computed(() => unref(filters));
+  watch(
+    orgFilters,
+    (newFilters, oldFilters) => {
+      if (JSON.stringify(newFilters) !== JSON.stringify(oldFilters)) {
+        page.value = 1;
+      }
+    },
+    { deep: true }
+  );
   // Use AsyncData for SSR, hydration, and cache.
   const { data, pending, error, refresh } = useAsyncData<Organization[]>(
     () => getKeyForGetOrganizations(),
@@ -35,43 +44,33 @@ export function useGetOrganizations(
             store.setIsLastPage(false);
           }
         }
+        const isFilterChanged =
+          JSON.stringify(store.getFilters()) !==
+          JSON.stringify(orgFilters.value);
+
         const { data: organizations, isLastPage } = await listOrganizations({
           ...orgFilters.value,
-          page:
-            JSON.stringify(store.getFilters()) ===
-            JSON.stringify(orgFilters.value)
-              ? page.value
-              : 1,
+          page: isFilterChanged ? 1 : page.value,
           page_size: 10,
         });
         const organizationsCached = store.getItems();
         const pageCached = store.getPage();
         store.setIsLastPage(isLastPage);
 
-        // Append new events to cached events if page > 1.
+        // Append new organizations to cached organizations if page > 1.
         if (
+          !isFilterChanged &&
           organizationsCached.length > 0 &&
-          JSON.stringify(store.getFilters()) ===
-            JSON.stringify(orgFilters.value) &&
-          (page.value > pageCached || (page.value === 1 && pageCached === 1))
+          page.value > pageCached
         ) {
           store.setItems([...organizationsCached, ...organizations]);
+          store.setPage(page.value);
           return [...organizationsCached, ...organizations] as Organization[];
         }
 
         store.setItems(organizations);
-        if (
-          JSON.stringify(store.getFilters()) !==
-          JSON.stringify(orgFilters.value)
-        ) {
-          store.setPage(1);
-          page.value = 1;
-        } else {
-          store.setPage(page.value);
-        }
-
+        store.setPage(isFilterChanged ? 1 : page.value);
         store.setFilters(orgFilters.value);
-        store.setPage(page.value);
         return organizations as Organization[];
       } catch (error) {
         handleError(error);


### PR DESCRIPTION
Fixes #2204

This PR resolves the issue where applying a filter after loading multiple pages of events or organizations causes the list to show duplicate items, extra cards, or stale items.

### Root Cause:
1. When filters change, `page.value` was being mutated inside the `useAsyncData` fetcher, triggering a redundant secondary fetch because `page` is a watched dependency.
2. A condition `|| (page.value === 1 && pageCached === 1)` was incorrectly appending the new page 1 items to the cached page 1 items, causing duplicates.

### Fix:
- Extracted the `page.value = 1` reset into an external `watch` on the filters so that `useAsyncData` is triggered cleanly without internal ref mutations.
- Removed the strict append condition so the store is properly overwritten when filters change.