### PR TITLE
docs: add docs blocks to base components (#427)

### DIFF
--- a/frontend/app/components/Tabs.vue
+++ b/frontend/app/components/Tabs.vue
@@ -55,3 +55,12 @@ function changeTab(index: number) {
   }
 }
 </script>
+
+<docs>
+This component renders a responsive tab navigation bar.
+
+Usage:
+Provide an array of `TabPage` objects as the `tabs` prop.
+Provide the currently active tab index using `selectedTab`.
+The component uses Nuxt router to navigate to the tab's `routeUrl`.
+</docs>

--- a/frontend/app/components/modal/ModalBase.vue
+++ b/frontend/app/components/modal/ModalBase.vue
@@ -122,3 +122,12 @@ watch(route, () => {
   }
 });
 </script>
+
+<docs>
+This is the foundational modal wrapper component.
+
+Usage:
+Provide a `modalName` which matches the name used in the `useModals` store.
+Wrap the content of your modal inside the default slot.
+Use the `imageModal` prop if you are displaying an image (like a QR code or avatar) to adjust the layout.
+</docs>

--- a/frontend/app/components/tooltip/TooltipBase.vue
+++ b/frontend/app/components/tooltip/TooltipBase.vue
@@ -25,3 +25,10 @@ defineProps<{
 
 const slots = useSlots();
 </script>
+
+<docs>
+This is the foundational tooltip wrapper component.
+
+Usage:
+Use `header` and `text` props for a simple text tooltip, or provide a default slot for custom content.
+</docs>

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -34,7 +34,17 @@ export default defineNuxtConfig({
   },
 
   vite: {
-    plugins: [tailwindcss()],
+    plugins: [
+      tailwindcss(),
+      {
+        name: "vue-docs-block",
+        transform(code: string, id: string) {
+          if (/vue&type=docs/.test(id)) {
+            return "export default {}";
+          }
+        },
+      },
+    ],
     server: {
       watch: {
         usePolling: true,

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -8,6 +8,17 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default defineVitestConfig({
+  plugins: [
+    {
+      name: "vue-docs-block",
+      enforce: "pre",
+      transform(code: string, id: string) {
+        if (/type=docs/.test(id)) {
+          return { code: "export default {}", map: null };
+        }
+      },
+    },
+  ],
   test: {
     env: {
       VITE_FRONTEND_URL: "http://localhost:3000",


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a separate branch and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the testing section of the contributing guide

---

### Description

Fixes #427

This PR adds `<docs>` blocks to several foundational Vue components to help future contributors understand their usage. 

**Changes made:**
- Added `<docs>` blocks to `TooltipBase.vue`, `Tabs.vue`, and `ModalBase.vue`.
- Added a custom Vite plugin (`vue-docs-block`) in `nuxt.config.ts` and `vitest.config.mts` to safely ignore the `<docs>` blocks during compilation so that the frontend builds and the test suite passes successfully.
