### PR TITLE
fix: close FAQ modal immediately on save success (#2245)

### DIFF
--- a/frontend/app/composables/mutations/useEventFAQEntryMutations.ts
+++ b/frontend/app/composables/mutations/useEventFAQEntryMutations.ts
@@ -18,7 +18,9 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
       // Service function handles the HTTP call and throws normalized errors.
       await createEventFaq(currentEventId.value, faqData as FaqEntry);
 
-      await invalidateCacheRefreshEventData();
+      // Don't block the caller (e.g. a modal closing) on the background
+      // refetch; the save has already succeeded at this point.
+      invalidateCacheRefreshEventData().catch((err) => handleError(err));
 
       return true;
     } catch (err) {
@@ -38,7 +40,9 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
       // Direct service call - no useAsyncData needed for mutations.
       await updateEventFaq(currentEventId.value, faq);
 
-      await invalidateCacheRefreshEventData();
+      // Don't block the caller (e.g. a modal closing) on the background
+      // refetch; the save has already succeeded at this point.
+      invalidateCacheRefreshEventData().catch((err) => handleError(err));
 
       return true;
     } catch (err) {
@@ -57,7 +61,9 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
     try {
       await reorderEventFaqs(currentEventId.value, faqs);
 
-      await invalidateCacheRefreshEventData();
+      // Don't block the caller (e.g. a modal closing) on the background
+      // refetch; the save has already succeeded at this point.
+      invalidateCacheRefreshEventData().catch((err) => handleError(err));
 
       return true;
     } catch (err) {
@@ -76,7 +82,9 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
     try {
       await deleteEventFaq(faqId);
 
-      await invalidateCacheRefreshEventData();
+      // Don't block the caller (e.g. a modal closing) on the background
+      // refetch; the save has already succeeded at this point.
+      invalidateCacheRefreshEventData().catch((err) => handleError(err));
 
       return true;
     } catch (err) {

--- a/frontend/app/composables/mutations/useOrganizationFAQEntryMutations.ts
+++ b/frontend/app/composables/mutations/useOrganizationFAQEntryMutations.ts
@@ -27,7 +27,14 @@ export function useOrganizationFAQEntryMutations(
         faqData as FaqEntry
       );
 
-      invalidateCacheRefreshOrgData();
+      // Don't block the caller (e.g. a modal closing) on the background
+      // refetch; the save has already succeeded at this point. Catch any
+      // refresh failure so it doesn't surface as an unhandled rejection.
+      invalidateCacheRefreshOrgData().catch((err) => {
+        const appError = errorHandler(err);
+        error.value = appError;
+        showToastError(appError.message);
+      });
 
       return true;
     } catch (err) {
@@ -49,7 +56,14 @@ export function useOrganizationFAQEntryMutations(
       // Direct service call - no useAsyncData needed for mutations.
       await updateOrganizationFaq(faq);
 
-      invalidateCacheRefreshOrgData();
+      // Don't block the caller (e.g. a modal closing) on the background
+      // refetch; the save has already succeeded at this point. Catch any
+      // refresh failure so it doesn't surface as an unhandled rejection.
+      invalidateCacheRefreshOrgData().catch((err) => {
+        const appError = errorHandler(err);
+        error.value = appError;
+        showToastError(appError.message);
+      });
 
       return true;
     } catch (err) {
@@ -70,7 +84,14 @@ export function useOrganizationFAQEntryMutations(
     try {
       await reorderOrganizationFaqs(faqs);
 
-      invalidateCacheRefreshOrgData();
+      // Don't block the caller (e.g. a modal closing) on the background
+      // refetch; the save has already succeeded at this point. Catch any
+      // refresh failure so it doesn't surface as an unhandled rejection.
+      invalidateCacheRefreshOrgData().catch((err) => {
+        const appError = errorHandler(err);
+        error.value = appError;
+        showToastError(appError.message);
+      });
 
       return true;
     } catch (err) {
@@ -91,7 +112,14 @@ export function useOrganizationFAQEntryMutations(
     try {
       await deleteOrganizationFaq(faqId);
 
-      invalidateCacheRefreshOrgData();
+      // Don't block the caller (e.g. a modal closing) on the background
+      // refetch; the save has already succeeded at this point. Catch any
+      // refresh failure so it doesn't surface as an unhandled rejection.
+      invalidateCacheRefreshOrgData().catch((err) => {
+        const appError = errorHandler(err);
+        error.value = appError;
+        showToastError(appError.message);
+      });
 
       return true;
     } catch (err) {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->
The FAQ mutation composables (`useEventFAQEntryMutations`,
`useOrganizationFAQEntryMutations`) were awaiting the background
cache-refresh call before returning success. Since the edit/create
modal waits for that return value before closing, this made the
modal visibly hang until the refetch finished — invisible on fast
connections but reliably reproducible under network throttling,
which is why it showed up as a flaky CI test.

Fix: the refresh is now fired in the background (not awaited) after
the actual save succeeds, with errors caught so a failed refresh
doesn't surface as an unhandled rejection. The modal now closes as
soon as the save itself completes.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- #2245
