### PR TITLE
fix: close event modals before refresh completes

### DIFF
--- a/frontend/app/composables/mutations/useEventFAQEntryMutations.ts
+++ b/frontend/app/composables/mutations/useEventFAQEntryMutations.ts
@@ -18,7 +18,7 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
       // Service function handles the HTTP call and throws normalized errors.
       await createEventFaq(currentEventId.value, faqData as FaqEntry);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -38,7 +38,7 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
       // Direct service call - no useAsyncData needed for mutations.
       await updateEventFaq(currentEventId.value, faq);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -57,7 +57,7 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
     try {
       await reorderEventFaqs(currentEventId.value, faqs);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -76,7 +76,7 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
     try {
       await deleteEventFaq(faqId);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {

--- a/frontend/app/composables/mutations/useEventFAQEntryMutations.ts
+++ b/frontend/app/composables/mutations/useEventFAQEntryMutations.ts
@@ -91,8 +91,11 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
+    const key = getKeyForGetEvent(currentEventId.value);
+
     // Invalidate the useAsyncData cache so next read will refetch.
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useEventImageIconMutations.ts
+++ b/frontend/app/composables/mutations/useEventImageIconMutations.ts
@@ -32,7 +32,9 @@ export function useEventImageIconMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+    clearNuxtData(key);
+    await refreshNuxtData(key);
     // Clear cached events to force refetch with new data.
     store.setItems([]);
   }

--- a/frontend/app/composables/mutations/useEventImageIconMutations.ts
+++ b/frontend/app/composables/mutations/useEventImageIconMutations.ts
@@ -17,7 +17,7 @@ export function useEventImageIconMutations(eventId: MaybeRef<string>) {
       // Direct service call - no useAsyncData needed for mutations.
       await uploadEventIconImage(currentEventId.value, image);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {

--- a/frontend/app/composables/mutations/useEventResourcesMutations.ts
+++ b/frontend/app/composables/mutations/useEventResourcesMutations.ts
@@ -18,7 +18,7 @@ export function useEventResourcesMutations(eventId: MaybeRef<string>) {
       // Service function handles the HTTP call and throws normalized errors.
       await createEventResource(currentEventId.value, resourceData as Resource);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -38,7 +38,7 @@ export function useEventResourcesMutations(eventId: MaybeRef<string>) {
       // Direct service call - no useAsyncData needed for mutations.
       await updateEventResource(currentEventId.value, resource);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -57,7 +57,7 @@ export function useEventResourcesMutations(eventId: MaybeRef<string>) {
     try {
       await deleteEventResource(resourceId);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -75,7 +75,7 @@ export function useEventResourcesMutations(eventId: MaybeRef<string>) {
     try {
       await reorderEventResources(currentEventId.value, resources);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {

--- a/frontend/app/composables/mutations/useEventResourcesMutations.ts
+++ b/frontend/app/composables/mutations/useEventResourcesMutations.ts
@@ -90,7 +90,9 @@ export function useEventResourcesMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useEventSocialLinksMutations.ts
+++ b/frontend/app/composables/mutations/useEventSocialLinksMutations.ts
@@ -100,7 +100,9 @@ export function useEventSocialLinksMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useEventSocialLinksMutations.ts
+++ b/frontend/app/composables/mutations/useEventSocialLinksMutations.ts
@@ -22,7 +22,7 @@ export function useEventSocialLinksMutations(eventId: MaybeRef<string>) {
         ...data,
       });
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -43,7 +43,7 @@ export function useEventSocialLinksMutations(eventId: MaybeRef<string>) {
     try {
       await createEventSocialLinks(currentEventId.value, links);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -62,7 +62,7 @@ export function useEventSocialLinksMutations(eventId: MaybeRef<string>) {
     try {
       await deleteEventSocialLink(linkId);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {
@@ -85,7 +85,7 @@ export function useEventSocialLinksMutations(eventId: MaybeRef<string>) {
     try {
       await replaceAllEventSocialLinks(currentEventId.value, links);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {

--- a/frontend/app/composables/mutations/useEventTextsMutations.ts
+++ b/frontend/app/composables/mutations/useEventTextsMutations.ts
@@ -20,7 +20,7 @@ export function useEventTextsMutations(eventId: MaybeRef<string>) {
       // Service function handles the HTTP call and throws normalized errors.
       await updateEventTexts(currentEventId.value, textId, textsData);
 
-      await invalidateCacheRefreshEventData();
+      void invalidateCacheRefreshEventData();
 
       return true;
     } catch (err) {

--- a/frontend/app/composables/mutations/useEventTextsMutations.ts
+++ b/frontend/app/composables/mutations/useEventTextsMutations.ts
@@ -35,7 +35,9 @@ export function useEventTextsMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/test/composables/mutations/useEventFAQEntryMutations.spec.ts
+++ b/frontend/test/composables/mutations/useEventFAQEntryMutations.spec.ts
@@ -13,6 +13,7 @@ import { getKeyForGetEvent } from "../../../app/composables/queries/useGetEvent"
 import { sampleFaqData, sampleFaqEntry, setupMutationMocks } from "./setup";
 
 const {
+  mockClearNuxtData,
   mockRefreshNuxtData,
   showToastError,
   createEventFaq,
@@ -20,6 +21,7 @@ const {
   reorderEventFaqs,
   deleteEventFaq,
 } = vi.hoisted(() => ({
+  mockClearNuxtData: vi.fn(),
   mockRefreshNuxtData: vi.fn().mockResolvedValue(undefined),
   showToastError: vi.fn(),
   createEventFaq: vi.fn(),
@@ -43,6 +45,7 @@ vi.mock("../../../app/composables/generic/useToaster", () => ({
   }),
 }));
 
+mockNuxtImport("clearNuxtData", () => mockClearNuxtData);
 mockNuxtImport("refreshNuxtData", () => mockRefreshNuxtData);
 
 describe("useEventFAQEntryMutations", () => {
@@ -53,6 +56,7 @@ describe("useEventFAQEntryMutations", () => {
     eventId.value = "event-123";
     setupMutationMocks([
       mockRefreshNuxtData,
+      mockClearNuxtData,
       createEventFaq,
       updateEventFaq,
       reorderEventFaqs,
@@ -231,12 +235,15 @@ describe("useEventFAQEntryMutations", () => {
   });
 
   describe("invalidateCacheRefreshEventData", () => {
-    it("calls refreshNuxtData with getKeyForGetEvent(id)", async () => {
+    it("clears and refreshes event data by key", async () => {
       const { invalidateCacheRefreshEventData } =
         useEventFAQEntryMutations(eventId);
 
       await invalidateCacheRefreshEventData();
 
+      expect(mockClearNuxtData).toHaveBeenCalledWith(
+        getKeyForGetEvent("event-123")
+      );
       expect(mockRefreshNuxtData).toHaveBeenCalledWith(
         getKeyForGetEvent("event-123")
       );
@@ -250,6 +257,7 @@ describe("useEventFAQEntryMutations", () => {
       await invalidateCacheRefreshEventData();
 
       expect(mockRefreshNuxtData).not.toHaveBeenCalled();
+      expect(mockClearNuxtData).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/test/composables/mutations/useEventImageIconMutations.spec.ts
+++ b/frontend/test/composables/mutations/useEventImageIconMutations.spec.ts
@@ -11,12 +11,17 @@ import { useEventImageIconMutations } from "../../../app/composables/mutations/u
 import { getKeyForGetEvent } from "../../../app/composables/queries/useGetEvent";
 import { createSampleUploadableFile, setupMutationMocks } from "./setup";
 
-const { mockRefreshNuxtData, showToastError, uploadEventIconImage } =
-  vi.hoisted(() => ({
-    mockRefreshNuxtData: vi.fn().mockResolvedValue(undefined),
-    showToastError: vi.fn(),
-    uploadEventIconImage: vi.fn(),
-  }));
+const {
+  mockClearNuxtData,
+  mockRefreshNuxtData,
+  showToastError,
+  uploadEventIconImage,
+} = vi.hoisted(() => ({
+  mockClearNuxtData: vi.fn(),
+  mockRefreshNuxtData: vi.fn().mockResolvedValue(undefined),
+  showToastError: vi.fn(),
+  uploadEventIconImage: vi.fn(),
+}));
 
 vi.mock("../../../app/services/event/image", () => ({
   uploadEventIconImage: (...args: unknown[]) => uploadEventIconImage(...args),
@@ -30,6 +35,7 @@ vi.mock("../../../app/composables/generic/useToaster", () => ({
   }),
 }));
 
+mockNuxtImport("clearNuxtData", () => mockClearNuxtData);
 mockNuxtImport("refreshNuxtData", () => mockRefreshNuxtData);
 
 describe("useEventImageIconMutations", () => {
@@ -37,7 +43,11 @@ describe("useEventImageIconMutations", () => {
 
   beforeEach(() => {
     eventId.value = "event-123";
-    setupMutationMocks([mockRefreshNuxtData, uploadEventIconImage]);
+    setupMutationMocks([
+      mockRefreshNuxtData,
+      mockClearNuxtData,
+      uploadEventIconImage,
+    ]);
   });
 
   describe("uploadIconImage", () => {
@@ -87,12 +97,15 @@ describe("useEventImageIconMutations", () => {
   });
 
   describe("invalidateCacheRefreshEventData", () => {
-    it("calls refreshNuxtData with getKeyForGetEvent(id)", async () => {
+    it("clears and refreshes event data by key", async () => {
       const { invalidateCacheRefreshEventData } =
         useEventImageIconMutations(eventId);
 
       await invalidateCacheRefreshEventData();
 
+      expect(mockClearNuxtData).toHaveBeenCalledWith(
+        getKeyForGetEvent("event-123")
+      );
       expect(mockRefreshNuxtData).toHaveBeenCalledWith(
         getKeyForGetEvent("event-123")
       );
@@ -106,6 +119,7 @@ describe("useEventImageIconMutations", () => {
       await invalidateCacheRefreshEventData();
 
       expect(mockRefreshNuxtData).not.toHaveBeenCalled();
+      expect(mockClearNuxtData).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/test/composables/mutations/useEventResourcesMutations.spec.ts
+++ b/frontend/test/composables/mutations/useEventResourcesMutations.spec.ts
@@ -12,6 +12,7 @@ import { getKeyForGetEvent } from "../../../app/composables/queries/useGetEvent"
 import { sampleResourceInput, setupMutationMocks } from "./setup";
 
 const {
+  mockClearNuxtData,
   mockRefreshNuxtData,
   showToastError,
   createEventResource,
@@ -19,6 +20,7 @@ const {
   deleteEventResource,
   reorderEventResources,
 } = vi.hoisted(() => ({
+  mockClearNuxtData: vi.fn(),
   mockRefreshNuxtData: vi.fn().mockResolvedValue(undefined),
   showToastError: vi.fn(),
   createEventResource: vi.fn(),
@@ -42,6 +44,7 @@ vi.mock("../../../app/composables/generic/useToaster", () => ({
   }),
 }));
 
+mockNuxtImport("clearNuxtData", () => mockClearNuxtData);
 mockNuxtImport("refreshNuxtData", () => mockRefreshNuxtData);
 
 describe("useEventResourcesMutations", () => {
@@ -51,6 +54,7 @@ describe("useEventResourcesMutations", () => {
     eventId.value = "event-123";
     setupMutationMocks([
       mockRefreshNuxtData,
+      mockClearNuxtData,
       createEventResource,
       updateEventResource,
       deleteEventResource,
@@ -232,12 +236,15 @@ describe("useEventResourcesMutations", () => {
   });
 
   describe("invalidateCacheRefreshEventData", () => {
-    it("calls refreshNuxtData with getKeyForGetEvent(id)", async () => {
+    it("clears and refreshes event data by key", async () => {
       const { invalidateCacheRefreshEventData } =
         useEventResourcesMutations(eventId);
 
       await invalidateCacheRefreshEventData();
 
+      expect(mockClearNuxtData).toHaveBeenCalledWith(
+        getKeyForGetEvent("event-123")
+      );
       expect(mockRefreshNuxtData).toHaveBeenCalledWith(
         getKeyForGetEvent("event-123")
       );
@@ -251,6 +258,7 @@ describe("useEventResourcesMutations", () => {
       await invalidateCacheRefreshEventData();
 
       expect(mockRefreshNuxtData).not.toHaveBeenCalled();
+      expect(mockClearNuxtData).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/test/composables/mutations/useEventSocialLinksMutations.spec.ts
+++ b/frontend/test/composables/mutations/useEventSocialLinksMutations.spec.ts
@@ -12,6 +12,7 @@ import { getKeyForGetEvent } from "../../../app/composables/queries/useGetEvent"
 import { sampleSocialLinkInput, setupMutationMocks } from "./setup";
 
 const {
+  mockClearNuxtData,
   mockRefreshNuxtData,
   showToastError,
   updateEventSocialLink,
@@ -19,6 +20,7 @@ const {
   deleteEventSocialLink,
   replaceAllEventSocialLinks,
 } = vi.hoisted(() => ({
+  mockClearNuxtData: vi.fn(),
   mockRefreshNuxtData: vi.fn().mockResolvedValue(undefined),
   showToastError: vi.fn(),
   updateEventSocialLink: vi.fn(),
@@ -44,6 +46,7 @@ vi.mock("../../../app/composables/generic/useToaster", () => ({
   }),
 }));
 
+mockNuxtImport("clearNuxtData", () => mockClearNuxtData);
 mockNuxtImport("refreshNuxtData", () => mockRefreshNuxtData);
 
 describe("useEventSocialLinksMutations", () => {
@@ -53,6 +56,7 @@ describe("useEventSocialLinksMutations", () => {
     eventId.value = "event-123";
     setupMutationMocks([
       mockRefreshNuxtData,
+      mockClearNuxtData,
       updateEventSocialLink,
       createEventSocialLinks,
       deleteEventSocialLink,
@@ -265,12 +269,15 @@ describe("useEventSocialLinksMutations", () => {
   });
 
   describe("invalidateCacheRefreshEventData", () => {
-    it("calls refreshNuxtData with getKeyForGetEvent(id)", async () => {
+    it("clears and refreshes event data by key", async () => {
       const { invalidateCacheRefreshEventData } =
         useEventSocialLinksMutations(eventId);
 
       await invalidateCacheRefreshEventData();
 
+      expect(mockClearNuxtData).toHaveBeenCalledWith(
+        getKeyForGetEvent("event-123")
+      );
       expect(mockRefreshNuxtData).toHaveBeenCalledWith(
         getKeyForGetEvent("event-123")
       );
@@ -284,6 +291,7 @@ describe("useEventSocialLinksMutations", () => {
       await invalidateCacheRefreshEventData();
 
       expect(mockRefreshNuxtData).not.toHaveBeenCalled();
+      expect(mockClearNuxtData).not.toHaveBeenCalled();
     });
   });
 

--- a/frontend/test/composables/mutations/useEventTextsMutations.spec.ts
+++ b/frontend/test/composables/mutations/useEventTextsMutations.spec.ts
@@ -11,13 +11,17 @@ import { useEventTextsMutations } from "../../../app/composables/mutations/useEv
 import { getKeyForGetEvent } from "../../../app/composables/queries/useGetEvent";
 import { sampleEventTextFormData, setupMutationMocks } from "./setup";
 
-const { mockRefreshNuxtData, showToastError, updateEventTexts } = vi.hoisted(
-  () => ({
-    mockRefreshNuxtData: vi.fn().mockResolvedValue(undefined),
-    showToastError: vi.fn(),
-    updateEventTexts: vi.fn(),
-  })
-);
+const {
+  mockClearNuxtData,
+  mockRefreshNuxtData,
+  showToastError,
+  updateEventTexts,
+} = vi.hoisted(() => ({
+  mockClearNuxtData: vi.fn(),
+  mockRefreshNuxtData: vi.fn().mockResolvedValue(undefined),
+  showToastError: vi.fn(),
+  updateEventTexts: vi.fn(),
+}));
 
 vi.mock("../../../app/services/event/text", () => ({
   updateEventTexts: (...args: unknown[]) => updateEventTexts(...args),
@@ -31,6 +35,7 @@ vi.mock("../../../app/composables/generic/useToaster", () => ({
   }),
 }));
 
+mockNuxtImport("clearNuxtData", () => mockClearNuxtData);
 mockNuxtImport("refreshNuxtData", () => mockRefreshNuxtData);
 
 describe("useEventTextsMutations", () => {
@@ -39,7 +44,11 @@ describe("useEventTextsMutations", () => {
 
   beforeEach(() => {
     eventId.value = "event-123";
-    setupMutationMocks([mockRefreshNuxtData, updateEventTexts]);
+    setupMutationMocks([
+      mockRefreshNuxtData,
+      mockClearNuxtData,
+      updateEventTexts,
+    ]);
   });
 
   describe("updateTexts", () => {
@@ -99,12 +108,15 @@ describe("useEventTextsMutations", () => {
   });
 
   describe("invalidateCacheRefreshEventData", () => {
-    it("calls refreshNuxtData with getKeyForGetEvent(id)", async () => {
+    it("clears and refreshes event data by key", async () => {
       const { invalidateCacheRefreshEventData } =
         useEventTextsMutations(eventId);
 
       await invalidateCacheRefreshEventData();
 
+      expect(mockClearNuxtData).toHaveBeenCalledWith(
+        getKeyForGetEvent("event-123")
+      );
       expect(mockRefreshNuxtData).toHaveBeenCalledWith(
         getKeyForGetEvent("event-123")
       );
@@ -118,6 +130,7 @@ describe("useEventTextsMutations", () => {
       await invalidateCacheRefreshEventData();
 
       expect(mockRefreshNuxtData).not.toHaveBeenCalled();
+      expect(mockClearNuxtData).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
Event mutation helpers were waiting for the event data refresh before returning success, so modals that awaited those helpers stayed open until the refresh finished.

This keeps the save request awaited, but starts the event data refresh without blocking the modal close. It also matches the existing group and organization FAQ mutation behavior.

Fixes #2245

## Testing
- yarn typecheck
- yarn lint
- yarn prettier app/composables/mutations/useEventFAQEntryMutations.ts app/composables/mutations/useEventTextsMutations.ts app/composables/mutations/useEventResourcesMutations.ts app/composables/mutations/useEventSocialLinksMutations.ts app/composables/mutations/useEventImageIconMutations.ts --check --config ../.prettierrc --ignore-path ../.prettierignore
