### PR TITLE
Clear cached entity data before refresh in mutation composables (#2250)

### DIFF
--- a/frontend/app/composables/mutations/useEventFAQEntryMutations.ts
+++ b/frontend/app/composables/mutations/useEventFAQEntryMutations.ts
@@ -91,8 +91,10 @@ export function useEventFAQEntryMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    // Invalidate the useAsyncData cache so next read will refetch.
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useEventImageIconMutations.ts
+++ b/frontend/app/composables/mutations/useEventImageIconMutations.ts
@@ -32,7 +32,10 @@ export function useEventImageIconMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
     // Clear cached events to force refetch with new data.
     store.setItems([]);
   }

--- a/frontend/app/composables/mutations/useEventResourcesMutations.ts
+++ b/frontend/app/composables/mutations/useEventResourcesMutations.ts
@@ -90,7 +90,10 @@ export function useEventResourcesMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useEventSocialLinksMutations.ts
+++ b/frontend/app/composables/mutations/useEventSocialLinksMutations.ts
@@ -100,7 +100,10 @@ export function useEventSocialLinksMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useEventTextsMutations.ts
+++ b/frontend/app/composables/mutations/useEventTextsMutations.ts
@@ -35,7 +35,10 @@ export function useEventTextsMutations(eventId: MaybeRef<string>) {
   async function invalidateCacheRefreshEventData() {
     if (!currentEventId.value) return;
 
-    await refreshNuxtData(getKeyForGetEvent(currentEventId.value));
+    const key = getKeyForGetEvent(currentEventId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useGroupFAQEntryMutations.ts
+++ b/frontend/app/composables/mutations/useGroupFAQEntryMutations.ts
@@ -93,7 +93,10 @@ export function useGroupFAQEntryMutations(groupId: MaybeRef<string>) {
   async function invalidateCacheRefreshGroupData() {
     if (!currentGroupId.value) return;
 
-    await refreshNuxtData(getKeyForGetGroup(currentGroupId.value));
+    const key = getKeyForGetGroup(currentGroupId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useGroupResourcesMutations.ts
+++ b/frontend/app/composables/mutations/useGroupResourcesMutations.ts
@@ -94,7 +94,10 @@ export function useGroupResourcesMutations(groupId: MaybeRef<string>) {
   async function invalidateCacheRefreshGroupData() {
     if (!currentGroupId.value) return;
 
-    await refreshNuxtData(getKeyForGetGroup(currentGroupId.value));
+    const key = getKeyForGetGroup(currentGroupId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useGroupSocialLinksMutations.ts
+++ b/frontend/app/composables/mutations/useGroupSocialLinksMutations.ts
@@ -108,7 +108,10 @@ export function useGroupSocialLinksMutations(groupId: MaybeRef<string>) {
   async function invalidateCacheRefreshGroupData() {
     if (!currentGroupId.value) return;
 
-    await refreshNuxtData(getKeyForGetGroup(currentGroupId.value));
+    const key = getKeyForGetGroup(currentGroupId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useGroupTextsMutations.ts
+++ b/frontend/app/composables/mutations/useGroupTextsMutations.ts
@@ -41,7 +41,10 @@ export function useGroupTextsMutations(groupId: MaybeRef<string>) {
   async function invalidateCacheRefreshGroupData() {
     if (!currentGroupId.value) return;
 
-    await refreshNuxtData(getKeyForGetGroup(currentGroupId.value));
+    const key = getKeyForGetGroup(currentGroupId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useOrganizationFAQEntryMutations.ts
+++ b/frontend/app/composables/mutations/useOrganizationFAQEntryMutations.ts
@@ -108,9 +108,10 @@ export function useOrganizationFAQEntryMutations(
   async function invalidateCacheRefreshOrgData() {
     if (!currentOrganizationId.value) return;
 
-    await refreshNuxtData(
-      getKeyForGetOrganization(currentOrganizationId.value)
-    );
+    const key = getKeyForGetOrganization(currentOrganizationId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useOrganizationImageMutations.ts
+++ b/frontend/app/composables/mutations/useOrganizationImageMutations.ts
@@ -92,9 +92,10 @@ export function useOrganizationImageMutations(
   async function invalidateCacheRefreshOrgData() {
     if (!currentOrganizationId.value) return;
 
-    await refreshNuxtData(
-      getKeyForGetOrganization(currentOrganizationId.value)
-    );
+    const key = getKeyForGetOrganization(currentOrganizationId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
 
     // Clear the organizations list cache to ensure it refetches with updated data.
     store.setItems([]);

--- a/frontend/app/composables/mutations/useOrganizationResourcesMutations.ts
+++ b/frontend/app/composables/mutations/useOrganizationResourcesMutations.ts
@@ -113,9 +113,10 @@ export function useOrganizationResourcesMutations(
   async function invalidateCacheRefreshOrgData() {
     if (!currentOrganizationId.value) return;
 
-    await refreshNuxtData(
-      getKeyForGetOrganization(currentOrganizationId.value)
-    );
+    const key = getKeyForGetOrganization(currentOrganizationId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useOrganizationSocialLinksMutations.ts
+++ b/frontend/app/composables/mutations/useOrganizationSocialLinksMutations.ts
@@ -120,9 +120,10 @@ export function useOrganizationSocialLinksMutations(
   async function invalidateCacheRefreshOrgData() {
     if (!currentOrganizationId.value) return;
 
-    await refreshNuxtData(
-      getKeyForGetOrganization(currentOrganizationId.value)
-    );
+    const key = getKeyForGetOrganization(currentOrganizationId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {

--- a/frontend/app/composables/mutations/useOrganizationTextsMutations.ts
+++ b/frontend/app/composables/mutations/useOrganizationTextsMutations.ts
@@ -45,9 +45,10 @@ export function useOrganizationTextsMutations(
   async function invalidateCacheRefreshOrgData() {
     if (!currentOrganizationId.value) return;
 
-    await refreshNuxtData(
-      getKeyForGetOrganization(currentOrganizationId.value)
-    );
+    const key = getKeyForGetOrganization(currentOrganizationId.value);
+
+    clearNuxtData(key);
+    await refreshNuxtData(key);
   }
 
   return {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

Fixes #2250: after a save, the page could keep showing old content until a manual reload.

The mutation composables refresh entity data with `await refreshNuxtData(key)`, but the matching query composables (`useGetEvent`, `useGetOrganization`, `useGetGroup`) use `dedupe: "defer"`. If a fetch for the same key is already in flight when the refresh fires, the refresh is silently dropped and the pre-mutation data stays cached. This PR calls `clearNuxtData(key)` before `refreshNuxtData(key)` in each refresh helper so a real refetch always happens.

Same two-line change in all 14 entity-level mutation composables (event, organization, and group variants for FAQ entries, resources, social links, texts, and images).

**Testing performed**

- All 230 mutation composable unit tests pass
- The previously flaky e2e specs listed in #2250 (event/org FAQ, org and group social links) pass repeatedly with `--repeat-each` against a local preview build
- eslint, prettier, and typecheck are green

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #2250
