### PR TITLE
test(e2e): add unit tests for card, dropdown, discussion, feed, footer, events and form selector components

### DIFF
--- a/frontend/app/components/card/discussion/CardDiscussionInput.vue
+++ b/frontend/app/components/card/discussion/CardDiscussionInput.vue
@@ -119,7 +119,9 @@
           <Icon class="mx-1" :name="IconMap.MARKDOWN" size="1.25em"></Icon>
         </p>
         <div class="flex items-center space-x-3">
-          <Button
+          <!-- Native button: there is no registered `Button` component, so
+               using it crashed the app with "Failed to resolve component". -->
+          <button
             @blur="showTooltip = false"
             @click="showTooltip = showTooltip == true ? false : true"
             @focus="showTooltip = true"
@@ -130,6 +132,7 @@
               'style-action': discussionInput.highRisk,
               'style-warn': !discussionInput.highRisk,
             }"
+            type="button"
           >
             <Icon
               v-if="discussionInput.highRisk"
@@ -141,7 +144,7 @@
               v-show="showTooltip"
               class="-mt-64 md:-mt-56"
             />
-          </Button>
+          </button>
           <BtnAction
             ariaLabel="i18n.components.card_discussion_input.comment_aria_label"
             class="w-small inline-flex items-center justify-center"
@@ -156,6 +159,7 @@
 </template>
 
 <script setup lang="ts">
+import { TooltipMentionList } from "#components";
 import Link from "@tiptap/extension-link";
 import Mention from "@tiptap/extension-mention";
 import Placeholder from "@tiptap/extension-placeholder";
@@ -170,6 +174,9 @@ const props = defineProps<{
 
 const { t } = useI18n();
 const markdown = ref("");
+// Drives the @mention autocomplete dropdown below; previously this called
+// an undefined `Suggestion` identifier, which crashed on mount.
+const { getItems, renderer } = useMentionSuggestion(TooltipMentionList);
 
 const isMarkdownPreview = ref("Write");
 const isMarkdown = ref(true);
@@ -189,7 +196,9 @@ watch(markdown, () => {
 });
 
 const writeEditor = useEditor({
-  content: markdown,
+  // `.value`: useEditor expects the initial string content, not the ref itself
+  // (passing the ref threw "Unknown node type" from prosemirror).
+  content: markdown.value,
   editable: !isMarkdownPreview.value,
   extensions: [
     StarterKit,
@@ -204,8 +213,11 @@ const writeEditor = useEditor({
         class:
           "hover:underline font-bold rounded-2xl box-decoration-clone px-1 py-0.5",
       },
-      // @ts-expect-error: Ignore mismatched types.
-      suggestion: Suggestion,
+      suggestion: {
+        items: getItems,
+        // @ts-expect-error: `useMentionSuggestion`'s renderer types are looser than tiptap's.
+        render: renderer,
+      },
     }),
     Markdown,
   ],

--- a/frontend/app/components/feed/FeedItem.vue
+++ b/frontend/app/components/feed/FeedItem.vue
@@ -8,8 +8,12 @@
       class="cursor-pointer rounded-md border border-section-div bg-layer-2 p-2 elem-shadow-sm sm:p-3"
     >
       <div class="flex items-center space-x-3 pb-2">
+        <!-- `===`, not `=`: the assignment form always evaluated truthy,
+             which both showed the PEOPLE icon unconditionally and
+             overwrote item.itemType on every render, making the
+             mastodon/facebook/instagram branches below unreachable. -->
         <Icon
-          v-if="item.itemType = 'group'"
+          v-if="item.itemType === 'group'"
           :name="IconMap.PEOPLE"
           size="1.5em"
         />

--- a/frontend/app/components/footer/FooterWebsite.vue
+++ b/frontend/app/components/footer/FooterWebsite.vue
@@ -55,8 +55,13 @@
         </p>
         <div class="mt-1 flex gap-10 sm:mt-0 sm:flex-col sm:gap-0">
           <template v-for="(connect, index) in links.connectLinks">
+            <!-- aria-label uses `connect.ariaLabel`, not `connect.name` (the
+                 visible label): each link defines its own descriptive
+                 `ariaLabel` text, which was previously being shadowed by a
+                 redundant repeat of the visible "GitHub"/"Matrix"/"Instagram"
+                 label. -->
             <a
-              :aria-label="$t(connect.name)"
+              :aria-label="$t(connect.ariaLabel)"
               class="mt-2 flex items-center space-x-2 text-base text-primary-text focus-brand hover:text-distinct-text"
               :class="{ 'mt-3': index === 0 }"
               :href="connect.url"

--- a/frontend/test/components/Collapsable.spec.ts
+++ b/frontend/test/components/Collapsable.spec.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import Collapsable from "../../app/components/Collapsable.vue";
+import render from "../render";
+
+const stubs = {
+  Icon: {
+    template: '<span :class="$attrs.class" />',
+  },
+};
+
+describe("Collapsable", () => {
+  it("renders the label on the button", async () => {
+    await render(Collapsable, {
+      props: { label: "Section title" },
+      global: { stubs },
+    });
+
+    expect(screen.getByRole("button", { name: /section title/i })).toBeTruthy();
+  });
+
+  it("hides slot content by default", async () => {
+    await render(Collapsable, {
+      props: { label: "Section title" },
+      slots: { default: "<p>Hidden content</p>" },
+      global: { stubs },
+    });
+
+    expect(screen.queryByText("Hidden content")).toBeNull();
+  });
+
+  it("shows slot content when isOpen prop is true", async () => {
+    await render(Collapsable, {
+      props: { label: "Section title", isOpen: true },
+      slots: { default: "<p>Visible content</p>" },
+      global: { stubs },
+    });
+
+    expect(screen.getByText("Visible content")).toBeTruthy();
+  });
+
+  it("toggles slot content open on button click", async () => {
+    await render(Collapsable, {
+      props: { label: "Section title" },
+      slots: { default: "<p>Toggle content</p>" },
+      global: { stubs },
+    });
+
+    expect(screen.queryByText("Toggle content")).toBeNull();
+
+    await fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByText("Toggle content")).toBeTruthy();
+  });
+
+  it("toggles slot content closed on second button click", async () => {
+    await render(Collapsable, {
+      props: { label: "Section title" },
+      slots: { default: "<p>Toggle content</p>" },
+      global: { stubs },
+    });
+
+    await fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("Toggle content")).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button"));
+    expect(screen.queryByText("Toggle content")).toBeNull();
+  });
+
+  it("applies rotate class to icon when open", async () => {
+    const { container } = await render(Collapsable, {
+      props: { label: "Section title", isOpen: true },
+      global: { stubs },
+    });
+
+    const icon = container.querySelector("span");
+    expect(icon?.classList.contains("rotate-180")).toBe(true);
+  });
+
+  it("does not apply rotate class to icon when closed", async () => {
+    const { container } = await render(Collapsable, {
+      props: { label: "Section title", isOpen: false },
+      global: { stubs },
+    });
+
+    const icon = container.querySelector("span");
+    expect(icon?.classList.contains("rotate-180")).toBe(false);
+  });
+});

--- a/frontend/test/components/EmptyState.spec.ts
+++ b/frontend/test/components/EmptyState.spec.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import EmptyState from "../../app/components/EmptyState.vue";
+import render from "../render";
+
+const stubs = {
+  PageContent: {
+    template: "<div><slot /></div>",
+  },
+  PageCommunityFooter: {
+    template: "<div><slot /></div>",
+  },
+  BtnRouteInternal: {
+    template: '<a :href="linkTo" :aria-label="ariaLabel" />',
+    props: ["linkTo", "ariaLabel", "label", "cta", "fontSize"],
+  },
+};
+
+describe("EmptyState", () => {
+  it("renders the empty state container", async () => {
+    await render(EmptyState, {
+      props: { pageType: "organizations", permission: true },
+      global: { stubs },
+    });
+
+    expect(screen.getByTestId("empty-state")).toBeTruthy();
+  });
+
+  describe("pageType headers", () => {
+    const pageTypes = [
+      "organizations",
+      "groups",
+      "events",
+      "resources",
+      "faq",
+      "team",
+      "affiliates",
+      "tasks",
+      "discussions",
+    ] as const;
+
+    it.each(pageTypes)(
+      'renders a heading for pageType "%s"',
+      async (pageType) => {
+        await render(EmptyState, {
+          props: { pageType, permission: true },
+          global: { stubs },
+        });
+
+        expect(screen.getByRole("heading", { level: 2 })).toBeTruthy();
+      }
+    );
+  });
+
+  describe("permission prop", () => {
+    it("shows return home link when permission is false", async () => {
+      await render(EmptyState, {
+        props: { pageType: "organizations", permission: false },
+        global: { stubs },
+      });
+
+      const links = screen.getAllByRole("link");
+      expect(links.some((l) => l.getAttribute("href") === "/home")).toBe(true);
+    });
+
+    it("shows create organization link when pageType is organizations and has permission", async () => {
+      await render(EmptyState, {
+        props: { pageType: "organizations", permission: true },
+        global: { stubs },
+      });
+
+      const links = screen.getAllByRole("link");
+      expect(
+        links.some((l) => l.getAttribute("href") === "/organizations/create")
+      ).toBe(true);
+    });
+
+    it("shows create group link when pageType is groups and has permission", async () => {
+      await render(EmptyState, {
+        props: { pageType: "groups", permission: true },
+        global: { stubs },
+      });
+
+      const links = screen.getAllByRole("link");
+      expect(
+        links.some((l) => l.getAttribute("href") === "/groups/create")
+      ).toBe(true);
+    });
+
+    it("shows create event link when pageType is events and has permission", async () => {
+      await render(EmptyState, {
+        props: { pageType: "events", permission: true },
+        global: { stubs },
+      });
+
+      const links = screen.getAllByRole("link");
+      expect(
+        links.some((l) => l.getAttribute("href") === "/events/create")
+      ).toBe(true);
+    });
+
+    it("shows create resource link when pageType is resources and has permission", async () => {
+      await render(EmptyState, {
+        props: { pageType: "resources", permission: true },
+        global: { stubs },
+      });
+
+      const links = screen.getAllByRole("link");
+      expect(
+        links.some((l) => l.getAttribute("href") === "/resources/create")
+      ).toBe(true);
+    });
+
+    it("does not show a create link when pageType has no create action", async () => {
+      await render(EmptyState, {
+        props: { pageType: "faq", permission: true },
+        global: { stubs },
+      });
+
+      const links = screen.getAllByRole("link");
+      expect(links).toHaveLength(1);
+      expect(links[0].getAttribute("href")).toBe("/home");
+    });
+  });
+});

--- a/frontend/test/components/btn/BtnRoadMap.spec.ts
+++ b/frontend/test/components/btn/BtnRoadMap.spec.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import BtnRoadMap from "../../../app/components/btn/BtnRoadMap.vue";
+import render from "../../render";
+
+const stubs = {
+  NuxtLink: {
+    template: '<a :id="$attrs.id" :href="to" :aria-label="$attrs[\'aria-label\']"><slot /></a>',
+    props: ["to"],
+  },
+};
+
+describe("BtnRoadMap", () => {
+  it("renders with the correct id", async () => {
+    await render(BtnRoadMap, { global: { stubs } });
+
+    expect(document.getElementById("btn-roadmap")).toBeTruthy();
+  });
+
+  it("links to the roadmap URL", async () => {
+    await render(BtnRoadMap, { global: { stubs } });
+
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe(
+      "https://docs.activist.org/activist/product/about/roadmap"
+    );
+  });
+});

--- a/frontend/test/components/btn/action/BtnActionAdd.spec.ts
+++ b/frontend/test/components/btn/action/BtnActionAdd.spec.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import BtnActionAdd from "../../../../app/components/btn/action/BtnActionAdd.vue";
+import render from "../../../render";
+
+const stubs = {
+  BtnAction: {
+    template: `<button :id="id" :aria-label="ariaLabel">{{ label }}</button>`,
+    props: ["id", "ariaLabel", "label", "cta", "fontSize", "iconSize", "leftIcon"],
+  },
+};
+
+describe("BtnActionAdd", () => {
+  beforeEach(() => {
+    vi.stubGlobal("useUserSession", () => ({
+      loggedIn: ref(true),
+      user: ref(null),
+      clear: vi.fn(),
+    }));
+  });
+
+  it("renders the button when canCreate returns true", async () => {
+    await render(BtnActionAdd, {
+      props: { element: "Event", ariaLabel: "Add event", onClick: vi.fn() },
+      global: { stubs },
+    });
+
+    expect(screen.getByRole("button")).toBeTruthy();
+  });
+
+  it("does not render when user is not signed in", async () => {
+    vi.stubGlobal("useUserSession", () => ({
+      loggedIn: ref(false),
+      user: ref(null),
+      clear: vi.fn(),
+    }));
+
+    await render(BtnActionAdd, {
+      props: { element: "Event", ariaLabel: "Add event", onClick: vi.fn() },
+      global: { stubs },
+    });
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("sets the correct id from the element prop", async () => {
+    await render(BtnActionAdd, {
+      props: { element: "Event", ariaLabel: "Add event", onClick: vi.fn() },
+      global: { stubs },
+    });
+
+    expect(document.getElementById("btn-add-event")).toBeTruthy();
+  });
+
+  it("calls onClick when button is clicked", async () => {
+    const onClick = vi.fn();
+
+    await render(BtnActionAdd, {
+      props: { element: "Event", ariaLabel: "Add event", onClick },
+      global: { stubs },
+    });
+
+    await fireEvent.click(screen.getByRole("button"));
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClick when Enter key is pressed", async () => {
+    const onClick = vi.fn();
+
+    await render(BtnActionAdd, {
+      props: { element: "Event", ariaLabel: "Add event", onClick },
+      global: { stubs },
+    });
+
+    await fireEvent.keyDown(screen.getByRole("button"), {
+      key: "Enter",
+      code: "Enter",
+    });
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/test/components/card/CardDangerZone.spec.ts
+++ b/frontend/test/components/card/CardDangerZone.spec.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardDangerZone from "../../../app/components/card/CardDangerZone.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+const defaultProps = {
+  description: "This action cannot be undone.",
+  ctaBtnText: "Delete account",
+  ctaBtnAriaLabel: "Delete your account",
+};
+
+describe("CardDangerZone", () => {
+  it("renders the header", async () => {
+    await render(CardDangerZone, { props: defaultProps });
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.card_danger_zone.header")
+      )
+    ).toBeTruthy();
+  });
+
+  it("renders the description prop", async () => {
+    await render(CardDangerZone, { props: defaultProps });
+
+    expect(screen.getByText(defaultProps.description)).toBeTruthy();
+  });
+
+  it("renders username and password fields", async () => {
+    const { container } = await render(CardDangerZone, {
+      props: defaultProps,
+    });
+
+    const usernameLabel = getEnglishText(
+      "i18n.components.card_danger_zone.username_label"
+    );
+    const passwordLabel = getEnglishText(
+      "i18n.components.card_danger_zone.password_label"
+    );
+    expect(
+      screen.getByText((text) => text.startsWith(usernameLabel))
+    ).toBeTruthy();
+    expect(
+      screen.getByText((text) => text.startsWith(passwordLabel))
+    ).toBeTruthy();
+
+    const usernameInput = container.querySelector("#username");
+    const passwordInput = container.querySelector("#password");
+    expect(usernameInput).toBeTruthy();
+    expect(passwordInput).toBeTruthy();
+    expect(passwordInput?.getAttribute("type")).toBe("password");
+  });
+
+  it("renders the CTA button with the provided text and aria-label", async () => {
+    await render(CardDangerZone, { props: defaultProps });
+
+    const button = screen.getByRole("button", {
+      name: defaultProps.ctaBtnAriaLabel,
+    });
+    expect(button).toBeTruthy();
+    expect(button.textContent).toContain(defaultProps.ctaBtnText);
+  });
+});

--- a/frontend/test/components/card/CardDatePicker.spec.ts
+++ b/frontend/test/components/card/CardDatePicker.spec.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardDatePicker from "../../../app/components/card/CardDatePicker.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+describe("CardDatePicker", () => {
+  it("renders the date heading", async () => {
+    await render(CardDatePicker);
+
+    expect(
+      screen.getByText(
+        `${getEnglishText("i18n.components.card_date_picker.date")} *`
+      )
+    ).toBeTruthy();
+  });
+
+  it("renders the all day and multiple days checkboxes", async () => {
+    const { container } = await render(CardDatePicker);
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.card_date_picker.all_day")
+      )
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.card_date_picker.multiple_days")
+      )
+    ).toBeTruthy();
+
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    expect(checkboxes.length).toBe(2);
+  });
+
+  it("renders the time and expanded calendar pickers", async () => {
+    const { container } = await render(CardDatePicker);
+
+    // Two time-mode pickers plus one expanded calendar picker.
+    const calendars = container.querySelectorAll(".vc-container");
+    expect(calendars.length).toBe(3);
+  });
+
+  it("applies dark mode class by default", async () => {
+    const { container } = await render(CardDatePicker);
+
+    const calendars = container.querySelectorAll(".vc-container");
+    calendars.forEach((calendar) => {
+      expect(calendar.classList.contains("vc-dark")).toBe(true);
+    });
+  });
+});

--- a/frontend/test/components/card/CardDetails.spec.ts
+++ b/frontend/test/components/card/CardDetails.spec.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import CardDetails from "../../../app/components/card/CardDetails.vue";
+import { useModals } from "../../../app/stores/modals";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import {
+  createMockEvent,
+  createMockPhysicalLocation,
+} from "../../mocks/factories";
+import render from "../../render";
+
+const stubs = {
+  ModalQRCodeBtn: { template: '<div data-testid="modal-qr-code-btn" />' },
+  MetaTagOrganization: {
+    props: ["organization"],
+    template: '<div data-testid="meta-tag-organization" />',
+  },
+  MetaTagLocation: {
+    props: ["location"],
+    template: '<div data-testid="meta-tag-location">{{ location }}</div>',
+  },
+  MetaTagDates: {
+    props: ["dates"],
+    template: '<div data-testid="meta-tag-dates" />',
+  },
+};
+
+const mockCanEdit = vi.hoisted(() => ({ value: true }));
+
+mockNuxtImport("useUser", () => () => ({
+  userIsSignedIn: true,
+  userIsAdmin: false,
+  roles: [],
+  signOutUser: () => {},
+  canDelete: () => false,
+  canCreate: () => false,
+  canView: () => true,
+  canEdit: () => mockCanEdit.value,
+  user: null,
+}));
+
+beforeEach(() => {
+  mockCanEdit.value = true;
+});
+
+describe("CardDetails", () => {
+  it("renders the header", async () => {
+    await render(CardDetails, {
+      props: { event: null },
+      global: { stubs },
+    });
+
+    expect(
+      screen.getByText(getEnglishText("i18n.components.card_details.header"))
+    ).toBeTruthy();
+  });
+
+  it("renders nothing event-specific when event is null", async () => {
+    await render(CardDetails, {
+      props: { event: null },
+      global: { stubs },
+    });
+
+    expect(screen.queryByTestId("modal-qr-code-btn")).toBeNull();
+    expect(screen.queryByTestId("meta-tag-organization")).toBeNull();
+    expect(screen.queryByTestId("meta-tag-location")).toBeNull();
+    expect(screen.queryByTestId("meta-tag-dates")).toBeNull();
+  });
+
+  it("renders event details when an event is provided", async () => {
+    const event = createMockEvent({
+      onlineLocationLink: "https://example.com/stream",
+      physicalLocation: createMockPhysicalLocation({
+        addressOrName: "123 Main St, Springfield",
+      }),
+      times: [
+        {
+          startTime: "2024-01-01T10:00:00Z",
+          endTime: "2024-01-01T12:00:00Z",
+          allDay: false,
+          date: "2024-01-01",
+        },
+      ],
+    });
+
+    await render(CardDetails, {
+      props: { event },
+      global: { stubs },
+    });
+
+    expect(screen.getByTestId("modal-qr-code-btn")).toBeTruthy();
+    expect(screen.getByTestId("meta-tag-organization")).toBeTruthy();
+    expect(screen.getByTestId("meta-tag-dates")).toBeTruthy();
+
+    const link = screen.getByText(
+      "https://example.com/stream"
+    ).closest("a");
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe("https://example.com/stream");
+
+    // Only the part of the address before the first comma is shown.
+    expect(
+      screen.getByTestId("meta-tag-location").textContent
+    ).toContain("123 Main St");
+  });
+
+  it("shows the edit icon when the user can edit and opens the edit-text modal on click", async () => {
+    const event = createMockEvent({ id: "event-1" });
+
+    await render(CardDetails, {
+      props: { event },
+      global: { stubs },
+    });
+
+    const editIcon = screen.getByTestId("icon-edit");
+    expect(editIcon).toBeTruthy();
+
+    await fireEvent.click(editIcon);
+
+    const modals = useModals();
+    expect(modals.modals["ModalTextEvent"]?.isOpen).toBe(true);
+    expect(modals.modals["ModalTextEvent"]?.props).toEqual({
+      entityId: "event-1",
+    });
+  });
+
+  it("hides the edit icon when the user cannot edit", async () => {
+    mockCanEdit.value = false;
+    const event = createMockEvent();
+
+    await render(CardDetails, {
+      props: { event },
+      global: { stubs },
+    });
+
+    expect(screen.queryByTestId("icon-edit")).toBeNull();
+  });
+});

--- a/frontend/test/components/card/CardDonate.spec.ts
+++ b/frontend/test/components/card/CardDonate.spec.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardDonate from "../../../app/components/card/CardDonate.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+describe("CardDonate", () => {
+  it("renders the header", async () => {
+    await render(CardDonate, { props: { userIsAdmin: false } });
+
+    expect(
+      screen.getByRole("heading", {
+        name: getEnglishText("i18n.components.card_donate.donate"),
+      })
+    ).toBeTruthy();
+  });
+
+  it("renders the template text when no donationPrompt is provided", async () => {
+    await render(CardDonate, { props: { userIsAdmin: false } });
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.card_donate.template_text")
+      )
+    ).toBeTruthy();
+  });
+
+  it("renders the donationPrompt when provided", async () => {
+    await render(CardDonate, {
+      props: { userIsAdmin: false, donationPrompt: "Support our mission!" },
+    });
+
+    expect(screen.getByText("Support our mission!")).toBeTruthy();
+    expect(
+      screen.queryByText(
+        getEnglishText("i18n.components.card_donate.template_text")
+      )
+    ).toBeNull();
+  });
+
+  it("renders the donate link", async () => {
+    await render(CardDonate, { props: { userIsAdmin: false } });
+
+    const link = screen.getByRole("link", {
+      name: getEnglishText(
+        "i18n.components.card_donate.go_to_donation_page_aria_label"
+      ),
+    });
+    expect(link).toBeTruthy();
+    expect(link.textContent).toContain(
+      getEnglishText("i18n.components.card_donate.donate")
+    );
+  });
+
+  it("does not render the edit toggle button for non-admins", async () => {
+    await render(CardDonate, { props: { userIsAdmin: false } });
+
+    expect(
+      screen.queryByRole("button", {
+        name: getEnglishText(
+          "i18n.components.card_donate.edit_donation_info_alt_text"
+        ),
+      })
+    ).toBeNull();
+  });
+
+  it("renders the edit toggle button for admins and toggles its label/icon on click", async () => {
+    await render(CardDonate, { props: { userIsAdmin: true } });
+
+    const editLabel = getEnglishText(
+      "i18n.components.card_donate.edit_donation_info_alt_text"
+    );
+    const cancelLabel = getEnglishText(
+      "i18n.components.card_donate.cancel_edit_donation_info_alt_text"
+    );
+
+    const button = screen.getByRole("button", { name: editLabel });
+    expect(screen.getByRole("img", { name: "bi:pencil-square" })).toBeTruthy();
+
+    await fireEvent.click(button);
+
+    expect(screen.getByRole("button", { name: cancelLabel })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: editLabel })).toBeNull();
+  });
+});

--- a/frontend/test/components/card/CardFAQEntry.spec.ts
+++ b/frontend/test/components/card/CardFAQEntry.spec.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { FaqEntry } from "../../../shared/types/faq-entry";
+
+import CardFAQEntry from "../../../app/components/card/CardFAQEntry.vue";
+import { useModals } from "../../../app/stores/modals";
+import { EntityType } from "../../../shared/types/entity";
+import { createMockOrganization } from "../../mocks/factories";
+import render from "../../render";
+
+const mockPermissions = vi.hoisted(() => ({
+  canEdit: true,
+  canDelete: true,
+}));
+
+mockNuxtImport("useUser", () => () => ({
+  userIsSignedIn: true,
+  userIsAdmin: false,
+  roles: [],
+  signOutUser: () => {},
+  canDelete: () => mockPermissions.canDelete,
+  canCreate: () => false,
+  canView: () => true,
+  canEdit: () => mockPermissions.canEdit,
+  user: null,
+}));
+
+const faqEntry: FaqEntry = {
+  id: "faq-1",
+  iso: "en-US",
+  order: 1,
+  question: "What is activism?",
+  answer: "Taking action for change.",
+};
+
+beforeEach(() => {
+  mockPermissions.canEdit = true;
+  mockPermissions.canDelete = true;
+});
+
+describe("CardFAQEntry", () => {
+  it("renders the question", async () => {
+    await render(CardFAQEntry, {
+      props: { faqEntry, pageType: EntityType.EVENT },
+    });
+
+    expect(screen.getByTestId("faq-question").textContent).toContain(
+      faqEntry.question
+    );
+  });
+
+  it("reveals the answer when the disclosure button is clicked", async () => {
+    await render(CardFAQEntry, {
+      props: { faqEntry, pageType: EntityType.EVENT },
+    });
+
+    expect(screen.queryByTestId("faq-answer")).toBeNull();
+    expect(screen.getByTestId("faq-chevron-down")).toBeTruthy();
+
+    await fireEvent.click(screen.getByTestId("faq-disclosure-button"));
+
+    expect(screen.getByTestId("faq-answer").textContent).toContain(
+      faqEntry.answer
+    );
+    expect(screen.getByTestId("faq-chevron-up")).toBeTruthy();
+    expect(screen.queryByTestId("faq-chevron-down")).toBeNull();
+  });
+
+  it("opens the edit-FAQ modal with the entry and entity id when the edit icon is clicked", async () => {
+    const organization = createMockOrganization({ id: "org-1" });
+
+    await render(CardFAQEntry, {
+      props: {
+        faqEntry,
+        pageType: EntityType.ORGANIZATION,
+        entity: organization,
+      },
+    });
+
+    await fireEvent.click(screen.getByTestId("faq-edit-button"));
+
+    const modals = useModals();
+    expect(modals.modals["ModalFaqEntryOrganization"]?.isOpen).toBe(true);
+    expect(modals.modals["ModalFaqEntryOrganization"]?.props).toEqual({
+      faqEntry,
+      entityId: "org-1",
+    });
+  });
+
+  it("opens the delete-FAQ modal with the entity and entry ids when the delete icon is clicked", async () => {
+    const organization = createMockOrganization({ id: "org-1" });
+
+    await render(CardFAQEntry, {
+      props: {
+        faqEntry,
+        pageType: EntityType.ORGANIZATION,
+        entity: organization,
+      },
+    });
+
+    await fireEvent.click(screen.getByTestId("faq-delete-button"));
+
+    const modals = useModals();
+    expect(modals.modals["ModalFaqEntryDeleteOrganization"]?.isOpen).toBe(
+      true
+    );
+    expect(modals.modals["ModalFaqEntryDeleteOrganization"]?.props).toEqual({
+      entityId: "org-1",
+      faqEntryId: faqEntry.id,
+    });
+  });
+
+  it("hides the edit, delete, and drag controls when the user lacks permission", async () => {
+    mockPermissions.canEdit = false;
+    mockPermissions.canDelete = false;
+
+    await render(CardFAQEntry, {
+      props: { faqEntry, pageType: EntityType.EVENT },
+    });
+
+    expect(screen.queryByTestId("faq-edit-button")).toBeNull();
+    expect(screen.queryByTestId("faq-delete-button")).toBeNull();
+    expect(screen.queryByTestId("faq-drag-handle")).toBeNull();
+  });
+});

--- a/frontend/test/components/card/CardLegalDisclaimer.spec.ts
+++ b/frontend/test/components/card/CardLegalDisclaimer.spec.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardLegalDisclaimer from "../../../app/components/card/CardLegalDisclaimer.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+describe("CardLegalDisclaimer", () => {
+  it("renders the header", async () => {
+    await render(CardLegalDisclaimer, {
+      props: { disclaimer: "Some legal text." },
+    });
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.card_legal_disclaimer.header")
+      )
+    ).toBeTruthy();
+  });
+
+  it("hides the disclaimer text until expanded", async () => {
+    await render(CardLegalDisclaimer, {
+      props: { disclaimer: "Some legal text." },
+    });
+
+    expect(screen.queryByText("Some legal text.")).toBeNull();
+    expect(screen.getByRole("img", { name: "bi:chevron-down" })).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByText("Some legal text.")).toBeTruthy();
+    expect(screen.getByRole("img", { name: "bi:chevron-up" })).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/CardMetric.spec.ts
+++ b/frontend/test/components/card/CardMetric.spec.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardMetric from "../../../app/components/card/CardMetric.vue";
+import render from "../../render";
+
+const defaultProps = {
+  text: "Members",
+  number: 42,
+  textColor: "text-primary-text",
+  borderColor: "border-action-red",
+  backgroundColor: "bg-action-red/10",
+};
+
+describe("CardMetric", () => {
+  it("renders the number and text", async () => {
+    await render(CardMetric, { props: defaultProps });
+
+    expect(screen.getByText("42")).toBeTruthy();
+    expect(screen.getByText("Members")).toBeTruthy();
+  });
+
+  it("applies the color classes", async () => {
+    const { container } = await render(CardMetric, { props: defaultProps });
+
+    const card = container.querySelector(".card-style");
+    expect(card?.classList.contains("text-primary-text")).toBe(true);
+    expect(card?.classList.contains("border-action-red")).toBe(true);
+    expect(card?.classList.contains("bg-action-red/10")).toBe(true);
+  });
+});

--- a/frontend/test/components/card/CardOrgApplicationVote.spec.ts
+++ b/frontend/test/components/card/CardOrgApplicationVote.spec.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardOrgApplicationVote from "../../../app/components/card/CardOrgApplicationVote.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import {
+  createMockContentImage,
+  createMockOrganization,
+} from "../../mocks/factories";
+import render from "../../render";
+
+describe("CardOrgApplicationVote", () => {
+  it("renders the title", async () => {
+    await render(CardOrgApplicationVote, {
+      props: {
+        title: "Pending applications",
+        organizations: [],
+        upVotes: 0,
+        downVotes: 0,
+      },
+    });
+
+    expect(screen.getByText("Pending applications")).toBeTruthy();
+  });
+
+  it("renders a fallback icon for organizations without a logo", async () => {
+    const organization = createMockOrganization({ iconUrl: undefined });
+
+    await render(CardOrgApplicationVote, {
+      props: {
+        title: "Pending applications",
+        organizations: [organization],
+        upVotes: 0,
+        downVotes: 0,
+      },
+    });
+
+    expect(
+      screen.getByRole("img", { name: "IconOrganization" })
+    ).toBeTruthy();
+  });
+
+  it("renders the organization logo when iconUrl is present", async () => {
+    const organization = createMockOrganization({
+      name: "Test Org",
+      iconUrl: createMockContentImage(),
+    });
+
+    const { container } = await render(CardOrgApplicationVote, {
+      props: {
+        title: "Pending applications",
+        organizations: [organization],
+        upVotes: 0,
+        downVotes: 0,
+      },
+    });
+
+    const img = container.querySelector("img[src='/test/image.png']");
+    expect(img).toBeTruthy();
+  });
+
+  it("renders the up-vote and down-vote counters", async () => {
+    await render(CardOrgApplicationVote, {
+      props: {
+        title: "Pending applications",
+        organizations: [],
+        upVotes: 3,
+        downVotes: 1,
+      },
+    });
+
+    expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("disables voting buttons by default", async () => {
+    await render(CardOrgApplicationVote, {
+      props: {
+        title: "Pending applications",
+        organizations: [],
+        upVotes: 0,
+        downVotes: 0,
+      },
+    });
+
+    const upVoteButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components._global.upvote_application_aria_label"
+      ),
+    });
+    expect(upVoteButton.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("emits up-vote and down-vote when enabled and clicked", async () => {
+    const { emitted } = await render(CardOrgApplicationVote, {
+      props: {
+        title: "Pending applications",
+        organizations: [],
+        upVotes: 0,
+        downVotes: 0,
+        isVotingDisabled: false,
+      },
+    });
+
+    const upVoteButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components._global.upvote_application_aria_label"
+      ),
+    });
+    const downVoteButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_org_application_vote.downvote_application_aria_label"
+      ),
+    });
+
+    await fireEvent.click(upVoteButton);
+    await fireEvent.click(downVoteButton);
+
+    expect(emitted()["up-vote"]).toBeTruthy();
+    expect(emitted()["down-vote"]).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/CardResource.spec.ts
+++ b/frontend/test/components/card/CardResource.spec.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import CardResource from "../../../app/components/card/CardResource.vue";
+import { useModals } from "../../../app/stores/modals";
+import { EntityType } from "../../../shared/types/entity";
+import { createMockOrganization, createResource } from "../../mocks/factories";
+import render from "../../render";
+
+const stubs = {
+  NuxtLink: {
+    props: ["to"],
+    template: '<a :href="to"><slot /></a>',
+  },
+  MenuSearchResult: { template: '<div data-testid="menu-search-result" />' },
+  MetaTagOrganization: {
+    props: ["organization"],
+    template: '<div data-testid="meta-tag-organization" />',
+  },
+};
+
+const mockPermissions = vi.hoisted(() => ({
+  canEdit: true,
+  canDelete: true,
+}));
+
+mockNuxtImport("useUser", () => () => ({
+  userIsSignedIn: true,
+  userIsAdmin: false,
+  roles: [],
+  signOutUser: () => {},
+  canDelete: () => mockPermissions.canDelete,
+  canCreate: () => false,
+  canView: () => true,
+  canEdit: () => mockPermissions.canEdit,
+  user: null,
+}));
+
+vi.stubGlobal("useLocalePath", () => (path: string) => `/en${path}`);
+
+beforeEach(() => {
+  mockPermissions.canEdit = true;
+  mockPermissions.canDelete = true;
+});
+
+describe("CardResource", () => {
+  it("renders the resource name and description", async () => {
+    const resource = createResource({
+      name: "Community Toolkit",
+      description: "A guide for organizers.",
+    });
+    const entity = createMockOrganization({ id: "org-1" });
+
+    await render(CardResource, {
+      props: { resource, entityType: EntityType.ORGANIZATION, entity },
+      global: { stubs },
+    });
+
+    expect(screen.getByText("Community Toolkit")).toBeTruthy();
+    expect(screen.getByText("A guide for organizers.")).toBeTruthy();
+  });
+
+  it("renders the resource link with the localized url", async () => {
+    const resource = createResource({ url: "https://example.com/resource" });
+    const entity = createMockOrganization({ id: "org-1" });
+
+    const { container } = await render(CardResource, {
+      props: { resource, entityType: EntityType.ORGANIZATION, entity },
+      global: { stubs },
+    });
+
+    const link = container.querySelector(
+      "a[href='/enhttps://example.com/resource']"
+    );
+    expect(link).toBeTruthy();
+  });
+
+  it("renders the organization meta tag when the resource has an org and is not reduced", async () => {
+    const resource = createResource({ org: createMockOrganization() });
+    const entity = createMockOrganization({ id: "org-1" });
+
+    await render(CardResource, {
+      props: {
+        resource,
+        entityType: EntityType.ORGANIZATION,
+        entity,
+        isReduced: false,
+      },
+      global: { stubs },
+    });
+
+    expect(screen.getByTestId("meta-tag-organization")).toBeTruthy();
+  });
+
+  it("hides the organization meta tag when reduced", async () => {
+    const resource = createResource({ org: createMockOrganization() });
+    const entity = createMockOrganization({ id: "org-1" });
+
+    await render(CardResource, {
+      props: {
+        resource,
+        entityType: EntityType.ORGANIZATION,
+        entity,
+        isReduced: true,
+      },
+      global: { stubs },
+    });
+
+    expect(screen.queryByTestId("meta-tag-organization")).toBeNull();
+  });
+
+  it("shows the drag handle, edit, and delete controls when permitted", async () => {
+    const resource = createResource();
+    const entity = createMockOrganization({ id: "org-1" });
+
+    await render(CardResource, {
+      props: { resource, entityType: EntityType.ORGANIZATION, entity },
+      global: { stubs },
+    });
+
+    expect(screen.getByTestId("resource-drag-handle")).toBeTruthy();
+    expect(screen.getByTestId("icon-edit")).toBeTruthy();
+    expect(screen.getByTestId("icon-delete")).toBeTruthy();
+  });
+
+  it("hides the edit and delete controls when not permitted", async () => {
+    mockPermissions.canEdit = false;
+    mockPermissions.canDelete = false;
+    const resource = createResource();
+    const entity = createMockOrganization({ id: "org-1" });
+
+    await render(CardResource, {
+      props: { resource, entityType: EntityType.ORGANIZATION, entity },
+      global: { stubs },
+    });
+
+    expect(screen.queryByTestId("icon-edit")).toBeNull();
+    expect(screen.queryByTestId("icon-delete")).toBeNull();
+  });
+
+  it("opens the edit-resource modal with the resource and entity id when the edit icon is clicked", async () => {
+    const resource = createResource({ id: "resource-1" });
+    const entity = createMockOrganization({ id: "org-1" });
+
+    await render(CardResource, {
+      props: { resource, entityType: EntityType.ORGANIZATION, entity },
+      global: { stubs },
+    });
+
+    await fireEvent.click(screen.getByTestId("icon-edit"));
+
+    const modals = useModals();
+    expect(modals.modals["ModalResourceOrganization"]?.isOpen).toBe(true);
+    expect(modals.modals["ModalResourceOrganization"]?.props).toEqual({
+      resource,
+      entityId: "org-1",
+    });
+  });
+
+  it("opens the delete-resource modal with the resource and entity ids when the delete icon is clicked", async () => {
+    const resource = createResource({ id: "resource-1" });
+    const entity = createMockOrganization({ id: "org-1" });
+
+    await render(CardResource, {
+      props: { resource, entityType: EntityType.ORGANIZATION, entity },
+      global: { stubs },
+    });
+
+    await fireEvent.click(screen.getByTestId("icon-delete"));
+
+    const modals = useModals();
+    expect(
+      modals.modals["ModalResourceDeleteOrganization"]?.isOpen
+    ).toBe(true);
+    expect(modals.modals["ModalResourceDeleteOrganization"]?.props).toEqual({
+      resourceId: "resource-1",
+      entityId: "org-1",
+    });
+  });
+});

--- a/frontend/test/components/card/CardTextArea.spec.ts
+++ b/frontend/test/components/card/CardTextArea.spec.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardTextArea from "../../../app/components/card/CardTextArea.vue";
+import render from "../../render";
+
+const baseProps = {
+  header: "Feedback",
+  description: "Tell us what you think.",
+  placeholder: "Type here...",
+  textAreaAriaLabel: "Feedback input",
+};
+
+describe("CardTextArea", () => {
+  it("renders the header and description", async () => {
+    await render(CardTextArea, { props: { ...baseProps, multiline: false } });
+
+    expect(screen.getByText("Feedback")).toBeTruthy();
+    expect(screen.getByText("Tell us what you think.")).toBeTruthy();
+  });
+
+  it("does not render the description when it is empty", async () => {
+    await render(CardTextArea, {
+      props: { ...baseProps, description: "", multiline: false },
+    });
+
+    expect(screen.queryByText("Tell us what you think.")).toBeNull();
+  });
+
+  it("renders a single-line input when multiline is false", async () => {
+    const { container } = await render(CardTextArea, {
+      props: { ...baseProps, multiline: false },
+    });
+
+    const input = container.querySelector("input[type='text']");
+    expect(input).toBeTruthy();
+    expect(input?.getAttribute("placeholder")).toBe("Type here...");
+    expect(input?.getAttribute("aria-label")).toBe("Feedback input");
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+
+  it("renders a textarea when multiline is true", async () => {
+    const { container } = await render(CardTextArea, {
+      props: { ...baseProps, multiline: true },
+    });
+
+    const textareas = container.querySelectorAll("textarea");
+    // Only one of the mobile/desktop textareas renders, based on breakpoint.
+    expect(textareas.length).toBe(1);
+    expect(textareas[0]?.getAttribute("placeholder")).toBe("Type here...");
+    expect(textareas[0]?.getAttribute("aria-label")).toBe("Feedback input");
+    expect(container.querySelector("input[type='text']")).toBeNull();
+  });
+});

--- a/frontend/test/components/card/CardTopicSelection.spec.ts
+++ b/frontend/test/components/card/CardTopicSelection.spec.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardTopicSelection from "../../../app/components/card/CardTopicSelection.vue";
+import { TopicEnum } from "../../../shared/types/topics";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+describe("CardTopicSelection", () => {
+  it("renders the topics heading", async () => {
+    await render(CardTopicSelection, {
+      props: { modelValue: [], pageType: "organization" },
+    });
+
+    expect(
+      screen.getByText(getEnglishText("i18n.components._global.topics"))
+    ).toBeTruthy();
+  });
+
+  it.each([
+    ["organization", "subtext_organization"],
+    ["group", "subtext_group"],
+    ["resource", "subtext_resource"],
+  ] as const)(
+    "renders the %s subtext for pageType %s",
+    async (pageType, key) => {
+      await render(CardTopicSelection, {
+        props: { modelValue: [], pageType },
+      });
+
+      expect(
+        screen.getByText(
+          getEnglishText(`i18n.components.card_topic_selection.${key}`)
+        )
+      ).toBeTruthy();
+    }
+  );
+
+  it("does not render a subtext for pageType event", async () => {
+    await render(CardTopicSelection, {
+      props: { modelValue: [], pageType: "event" },
+    });
+
+    expect(
+      screen.queryByText(
+        getEnglishText(
+          "i18n.components.card_topic_selection.subtext_organization"
+        )
+      )
+    ).toBeNull();
+  });
+
+  it("renders all global topics in the desktop list", async () => {
+    const { container } = await render(CardTopicSelection, {
+      props: { modelValue: [], pageType: "organization" },
+    });
+
+    expect(container.querySelectorAll(".topic").length).toBe(15);
+  });
+
+  it("emits update:modelValue with the topic added when an unselected topic is clicked", async () => {
+    const { container, emitted } = await render(CardTopicSelection, {
+      props: { modelValue: [], pageType: "organization" },
+    });
+
+    const firstTopic = container.querySelector(".topic");
+    expect(firstTopic).toBeTruthy();
+
+    await fireEvent.click(firstTopic!);
+
+    const events = emitted()["update:modelValue"];
+    expect(events).toBeTruthy();
+    expect((events![0] as [TopicEnum[]])[0]).toHaveLength(1);
+  });
+
+  it("emits update:modelValue with the topic removed when a selected topic is clicked", async () => {
+    const { container, emitted } = await render(CardTopicSelection, {
+      props: {
+        modelValue: [TopicEnum.ENVIRONMENT],
+        pageType: "organization",
+      },
+    });
+
+    // Selected topics are sorted first, so the first `.topic` is the selected one.
+    const firstTopic = container.querySelector(".topic");
+    expect(firstTopic).toBeTruthy();
+
+    await fireEvent.click(firstTopic!);
+
+    const events = emitted()["update:modelValue"];
+    expect(events).toBeTruthy();
+    expect((events![0] as [TopicEnum[]])[0]).toEqual([]);
+  });
+
+  it("shows the view-all-topics toggle and switches its label when clicked", async () => {
+    await render(CardTopicSelection, {
+      props: { modelValue: [], pageType: "organization" },
+    });
+
+    const toggleButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_topic_selection.view_all_topics"
+      ),
+    });
+    expect(toggleButton).toBeTruthy();
+
+    await fireEvent.click(toggleButton);
+
+    expect(
+      screen.getByRole("button", {
+        name: getEnglishText(
+          "i18n.components.card_topic_selection.hide_all_topics"
+        ),
+      })
+    ).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/about/CardAbout.spec.ts
+++ b/frontend/test/components/card/about/CardAbout.spec.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardAbout from "../../../../app/components/card/about/CardAbout.vue";
+import render from "../../../render";
+
+describe("CardAbout", () => {
+  it("renders the card wrapper", async () => {
+    await render(CardAbout);
+
+    expect(screen.getByTestId("card-about")).toBeTruthy();
+  });
+
+  it("renders slotted content", async () => {
+    await render(CardAbout, {
+      slots: { default: "<p>Slot content</p>" },
+    });
+
+    expect(screen.getByText("Slot content")).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/about/CardAboutEvent.spec.ts
+++ b/frontend/test/components/card/about/CardAboutEvent.spec.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
+
+import CardAboutEvent from "../../../../app/components/card/about/CardAboutEvent.vue";
+import { useModals } from "../../../../app/stores/modals";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import { createMockEvent, createMockEventText } from "../../../mocks/factories";
+import render from "../../../render";
+
+mockNuxtImport("useUser", () => () => ({
+  userIsSignedIn: true,
+  userIsAdmin: false,
+  roles: [],
+  signOutUser: () => {},
+  canDelete: () => false,
+  canCreate: () => false,
+  canView: () => true,
+  canEdit: () => true,
+  user: null,
+}));
+
+function makeOverflow(paragraph: HTMLElement) {
+  Object.defineProperty(paragraph, "scrollHeight", {
+    configurable: true,
+    value: 100,
+  });
+  Object.defineProperty(paragraph, "clientHeight", {
+    configurable: true,
+    value: 20,
+  });
+}
+
+describe("CardAboutEvent", () => {
+  it("renders the About header and description", async () => {
+    const event = createMockEvent({
+      texts: [createMockEventText({ description: "A great community event." })],
+    });
+
+    await render(CardAboutEvent, { props: { event } });
+
+    expect(
+      screen.getByText(getEnglishText("i18n._global.about"))
+    ).toBeTruthy();
+    expect(screen.getByText("A great community event.")).toBeTruthy();
+  });
+
+  it("opens the edit-text modal with the event id when the edit icon is clicked", async () => {
+    const event = createMockEvent({ id: "event-1" });
+
+    await render(CardAboutEvent, { props: { event } });
+
+    await fireEvent.click(screen.getByTestId("icon-edit"));
+
+    const modals = useModals();
+    expect(modals.modals["ModalTextEvent"]?.isOpen).toBe(true);
+    expect(modals.modals["ModalTextEvent"]?.props).toEqual({
+      entityId: "event-1",
+    });
+  });
+
+  it("does not show the expand button when the description does not overflow", async () => {
+    const event = createMockEvent();
+
+    await render(CardAboutEvent, { props: { event } });
+
+    expect(
+      screen.queryByText(
+        getEnglishText("i18n.components.card.about._global.full_text")
+      )
+    ).toBeNull();
+  });
+
+  it("shows the expand button when the description overflows, and toggles to collapse on click", async () => {
+    const event = createMockEvent();
+
+    const { container, emitted } = await render(CardAboutEvent, {
+      props: { event },
+    });
+
+    const paragraph = container.querySelector("p")!;
+    makeOverflow(paragraph);
+    window.dispatchEvent(new Event("resize"));
+
+    const expandButton = await vi.waitFor(() =>
+      screen.getByText(
+        getEnglishText("i18n.components.card.about._global.full_text")
+      )
+    );
+
+    await fireEvent.click(expandButton);
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.card.about._global.reduce_text")
+      )
+    ).toBeTruthy();
+    expect(emitted()["expand-reduce-text"]).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/about/CardAboutGroup.spec.ts
+++ b/frontend/test/components/card/about/CardAboutGroup.spec.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import CardAboutGroup from "../../../../app/components/card/about/CardAboutGroup.vue";
+import { useModals } from "../../../../app/stores/modals";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import { createUseRouteMock } from "../../../mocks/composableMocks";
+import { createMockGroup, createMockGroupText } from "../../../mocks/factories";
+import render from "../../../render";
+
+const stubs = {
+  ModalQRCodeBtn: { template: '<div data-testid="modal-qr-code-btn" />' },
+};
+
+const { groupData, mockUserIsSignedIn } = vi.hoisted(() => ({
+  groupData: { value: null as ReturnType<typeof createMockGroup> | null },
+  mockUserIsSignedIn: { value: true },
+}));
+
+mockNuxtImport("useGetGroup", async () => {
+  const { ref } = await import("vue");
+  return () => ({ data: ref(groupData.value) });
+});
+
+mockNuxtImport("useUser", () => () => ({
+  userIsSignedIn: mockUserIsSignedIn.value,
+  userIsAdmin: false,
+  roles: [],
+  signOutUser: () => {},
+  canDelete: () => false,
+  canCreate: () => false,
+  canView: () => true,
+  canEdit: () => true,
+  user: null,
+}));
+
+beforeEach(() => {
+  groupData.value = null;
+  mockUserIsSignedIn.value = true;
+  vi.stubGlobal("useRoute", createUseRouteMock({ groupId: "group-1" }));
+});
+
+function makeOverflow(paragraph: HTMLElement) {
+  Object.defineProperty(paragraph, "scrollHeight", {
+    configurable: true,
+    value: 100,
+  });
+  Object.defineProperty(paragraph, "clientHeight", {
+    configurable: true,
+    value: 20,
+  });
+}
+
+describe("CardAboutGroup", () => {
+  it("renders the About header and description", async () => {
+    groupData.value = createMockGroup({
+      texts: [createMockGroupText({ description: "A group of activists." })],
+    });
+
+    await render(CardAboutGroup, { global: { stubs } });
+
+    expect(
+      screen.getByText(getEnglishText("i18n._global.about"))
+    ).toBeTruthy();
+    expect(screen.getByText("A group of activists.")).toBeTruthy();
+  });
+
+  it("renders the group's location", async () => {
+    groupData.value = createMockGroup();
+
+    await render(CardAboutGroup, { global: { stubs } });
+
+    expect(
+      screen.getByText((text) => text.startsWith("Test City"))
+    ).toBeTruthy();
+  });
+
+  it("renders the QR code button when a group is loaded", async () => {
+    groupData.value = createMockGroup();
+
+    await render(CardAboutGroup, { global: { stubs } });
+
+    expect(screen.getByTestId("modal-qr-code-btn")).toBeTruthy();
+  });
+
+  it("shows the edit icon when signed in and opens the edit-text modal with the group id", async () => {
+    groupData.value = createMockGroup({ id: "group-1" });
+
+    await render(CardAboutGroup, { global: { stubs } });
+
+    const editIcon = screen.getByTestId("icon-edit");
+    expect(editIcon).toBeTruthy();
+
+    await fireEvent.click(editIcon);
+
+    const modals = useModals();
+    expect(modals.modals["ModalTextGroup"]?.isOpen).toBe(true);
+    expect(modals.modals["ModalTextGroup"]?.props).toEqual({
+      entityId: "group-1",
+    });
+  });
+
+  it("hides the edit icon when not signed in", async () => {
+    mockUserIsSignedIn.value = false;
+    groupData.value = createMockGroup();
+
+    await render(CardAboutGroup, { global: { stubs } });
+
+    expect(screen.queryByTestId("icon-edit")).toBeNull();
+  });
+
+  it("shows the expand button when the description overflows, and toggles to collapse on click", async () => {
+    groupData.value = createMockGroup();
+
+    const { container, emitted } = await render(CardAboutGroup, {
+      global: { stubs },
+    });
+
+    const paragraph = container.querySelector("p.line-clamp-5")!;
+    makeOverflow(paragraph);
+    window.dispatchEvent(new Event("resize"));
+
+    const expandButton = await vi.waitFor(() =>
+      screen.getByTestId("expand-text-button")
+    );
+
+    await fireEvent.click(expandButton);
+
+    expect(screen.getByTestId("collapse-text-button")).toBeTruthy();
+    expect(emitted()["expand-reduce-text"]).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/about/CardAboutOrganization.spec.ts
+++ b/frontend/test/components/card/about/CardAboutOrganization.spec.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import CardAboutOrganization from "../../../../app/components/card/about/CardAboutOrganization.vue";
+import { useModals } from "../../../../app/stores/modals";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import { createUseRouteMock } from "../../../mocks/composableMocks";
+import {
+  createMockOrganization,
+  createMockOrganizationText,
+} from "../../../mocks/factories";
+import render from "../../../render";
+
+const stubs = {
+  ModalQRCodeBtn: { template: '<div data-testid="modal-qr-code-btn" />' },
+};
+
+const { organizationData, mockUserIsSignedIn } = vi.hoisted(() => ({
+  organizationData: {
+    value: null as ReturnType<typeof createMockOrganization> | null,
+  },
+  mockUserIsSignedIn: { value: true },
+}));
+
+mockNuxtImport("useGetOrganization", async () => {
+  const { ref } = await import("vue");
+  return () => ({ data: ref(organizationData.value) });
+});
+
+mockNuxtImport("useUser", () => () => ({
+  userIsSignedIn: mockUserIsSignedIn.value,
+  userIsAdmin: false,
+  roles: [],
+  signOutUser: () => {},
+  canDelete: () => false,
+  canCreate: () => false,
+  canView: () => true,
+  canEdit: () => true,
+  user: null,
+}));
+
+beforeEach(() => {
+  organizationData.value = null;
+  mockUserIsSignedIn.value = true;
+  vi.stubGlobal("useRoute", createUseRouteMock({ orgId: "org-1" }));
+});
+
+function makeOverflow(paragraph: HTMLElement) {
+  Object.defineProperty(paragraph, "scrollHeight", {
+    configurable: true,
+    value: 100,
+  });
+  Object.defineProperty(paragraph, "clientHeight", {
+    configurable: true,
+    value: 20,
+  });
+}
+
+describe("CardAboutOrganization", () => {
+  it("renders the About header and description", async () => {
+    organizationData.value = createMockOrganization({
+      texts: [
+        createMockOrganizationText({
+          description: "An organization for activists.",
+        }),
+      ],
+    });
+
+    await render(CardAboutOrganization, { global: { stubs } });
+
+    expect(
+      screen.getByText(getEnglishText("i18n._global.about"))
+    ).toBeTruthy();
+    expect(screen.getByText("An organization for activists.")).toBeTruthy();
+  });
+
+  it("renders the organization's location", async () => {
+    organizationData.value = createMockOrganization();
+
+    await render(CardAboutOrganization, { global: { stubs } });
+
+    expect(
+      screen.getByText((text) => text.startsWith("Test City"))
+    ).toBeTruthy();
+  });
+
+  it("renders the QR code button when an organization is loaded", async () => {
+    organizationData.value = createMockOrganization();
+
+    await render(CardAboutOrganization, { global: { stubs } });
+
+    expect(screen.getByTestId("modal-qr-code-btn")).toBeTruthy();
+  });
+
+  it("shows the edit icon when signed in and opens the edit-text modal with the organization id", async () => {
+    organizationData.value = createMockOrganization({ id: "org-1" });
+
+    await render(CardAboutOrganization, { global: { stubs } });
+
+    const editIcon = screen.getByTestId("icon-edit");
+    expect(editIcon).toBeTruthy();
+
+    await fireEvent.click(editIcon);
+
+    const modals = useModals();
+    expect(modals.modals["ModalTextOrganization"]?.isOpen).toBe(true);
+    expect(modals.modals["ModalTextOrganization"]?.props).toEqual({
+      entityId: "org-1",
+    });
+  });
+
+  it("hides the edit icon when not signed in", async () => {
+    mockUserIsSignedIn.value = false;
+    organizationData.value = createMockOrganization();
+
+    await render(CardAboutOrganization, { global: { stubs } });
+
+    expect(screen.queryByTestId("icon-edit")).toBeNull();
+  });
+
+  it("shows the expand button when the description overflows, and toggles to collapse on click", async () => {
+    organizationData.value = createMockOrganization();
+
+    const { container, emitted } = await render(CardAboutOrganization, {
+      global: { stubs },
+    });
+
+    const paragraph = container.querySelector("p.line-clamp-5")!;
+    makeOverflow(paragraph);
+    window.dispatchEvent(new Event("resize"));
+
+    const expandButton = await vi.waitFor(() =>
+      screen.getByTestId("expand-text-button")
+    );
+
+    await fireEvent.click(expandButton);
+
+    expect(screen.getByTestId("collapse-text-button")).toBeTruthy();
+    expect(emitted()["expand-reduce-text"]).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/change-account-info/CardChangeAccountInfo.spec.ts
+++ b/frontend/test/components/card/change-account-info/CardChangeAccountInfo.spec.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardChangeAccountInfo from "../../../../app/components/card/change-account-info/CardChangeAccountInfo.vue";
+import render from "../../../render";
+
+describe("CardChangeAccountInfo", () => {
+  it("renders slotted content", async () => {
+    await render(CardChangeAccountInfo, {
+      props: { ctaLabel: "Save", ctaAriaLabel: "Save changes" },
+      slots: { default: "<p>Form fields</p>" },
+    });
+
+    expect(screen.getByText("Form fields")).toBeTruthy();
+  });
+
+  it("renders the CTA button with the provided label and aria-label", async () => {
+    await render(CardChangeAccountInfo, {
+      props: { ctaLabel: "Save", ctaAriaLabel: "Save changes" },
+    });
+
+    const button = screen.getByRole("button", { name: "Save changes" });
+    expect(button).toBeTruthy();
+    expect(button.textContent).toContain("Save");
+  });
+});

--- a/frontend/test/components/card/change-account-info/CardChangeAccountInfoEmail.spec.ts
+++ b/frontend/test/components/card/change-account-info/CardChangeAccountInfoEmail.spec.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardChangeAccountInfoEmail from "../../../../app/components/card/change-account-info/CardChangeAccountInfoEmail.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import render from "../../../render";
+
+describe("CardChangeAccountInfoEmail", () => {
+  it("renders the header", async () => {
+    await render(CardChangeAccountInfoEmail);
+
+    expect(
+      screen.getAllByText(
+        getEnglishText(
+          "i18n.components.card_change_account_info_email.header_cta"
+        )
+      ).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders the old email, new email, and password fields", async () => {
+    const { container } = await render(CardChangeAccountInfoEmail);
+
+    expect(container.querySelector("#old-email")).toBeTruthy();
+    expect(container.querySelector("#new-email")).toBeTruthy();
+    expect(container.querySelector("#password")).toBeTruthy();
+
+    expect(
+      container
+        .querySelector("#old-email")
+        ?.getAttribute("placeholder")
+    ).toBe(
+      getEnglishText(
+        "i18n.components.card_change_account_info_email.enter_old_email"
+      )
+    );
+  });
+
+  it("renders the CTA button", async () => {
+    await render(CardChangeAccountInfoEmail);
+
+    const button = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_change_account_info_email.cta_aria_label"
+      ),
+    });
+    expect(button).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/change-account-info/CardChangeAccountInfoPassword.spec.ts
+++ b/frontend/test/components/card/change-account-info/CardChangeAccountInfoPassword.spec.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardChangeAccountInfoPassword from "../../../../app/components/card/change-account-info/CardChangeAccountInfoPassword.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import render from "../../../render";
+
+describe("CardChangeAccountInfoPassword", () => {
+  it("renders the header", async () => {
+    await render(CardChangeAccountInfoPassword);
+
+    expect(
+      screen.getAllByText(
+        getEnglishText(
+          "i18n.components.card_change_account_info_password.header_cta"
+        )
+      ).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders the current password, new password, and confirm password fields", async () => {
+    const { container } = await render(CardChangeAccountInfoPassword);
+
+    expect(container.querySelector("#current-password")).toBeTruthy();
+    expect(container.querySelector("#password")).toBeTruthy();
+    expect(container.querySelector("#confirm-password")).toBeTruthy();
+  });
+
+  it("renders the CTA button", async () => {
+    await render(CardChangeAccountInfoPassword);
+
+    const button = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_change_account_info_password.cta_aria_label"
+      ),
+    });
+    expect(button).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/change-account-info/CardChangeAccountInfoUsername.spec.ts
+++ b/frontend/test/components/card/change-account-info/CardChangeAccountInfoUsername.spec.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardChangeAccountInfoUsername from "../../../../app/components/card/change-account-info/CardChangeAccountInfoUsername.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import render from "../../../render";
+
+describe("CardChangeAccountInfoUsername", () => {
+  it("renders the header", async () => {
+    await render(CardChangeAccountInfoUsername);
+
+    expect(
+      screen.getAllByText(
+        getEnglishText(
+          "i18n.components.card_change_account_info_username.header_cta"
+        )
+      ).length
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders the new username and password fields", async () => {
+    const { container } = await render(CardChangeAccountInfoUsername);
+
+    expect(container.querySelector("#new-username")).toBeTruthy();
+    expect(container.querySelector("#password")).toBeTruthy();
+  });
+
+  it("renders the CTA button", async () => {
+    await render(CardChangeAccountInfoUsername);
+
+    const button = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_change_account_info_username.cta_aria_label"
+      ),
+    });
+    expect(button).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/connect/CardConnect.spec.ts
+++ b/frontend/test/components/card/connect/CardConnect.spec.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import CardConnect from "../../../../app/components/card/connect/CardConnect.vue";
+import { useModals } from "../../../../app/stores/modals";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import { createMockOrganization, createMockSocialLink } from "../../../mocks/factories";
+import render from "../../../render";
+
+const mockUserIsSignedIn = vi.hoisted(() => ({ value: true }));
+
+mockNuxtImport("useUser", () => () => ({
+  userIsSignedIn: mockUserIsSignedIn.value,
+  userIsAdmin: false,
+  roles: [],
+  signOutUser: () => {},
+  canDelete: () => false,
+  canCreate: () => false,
+  canView: () => true,
+  canEdit: () => true,
+  user: null,
+}));
+
+beforeEach(() => {
+  mockUserIsSignedIn.value = true;
+});
+
+describe("CardConnect", () => {
+  it("renders the header", async () => {
+    await render(CardConnect, {
+      props: { socialLinks: [], pageType: "organization" },
+    });
+
+    expect(
+      screen.getByText(getEnglishText("i18n.components._global.connect"))
+    ).toBeTruthy();
+  });
+
+  it("renders a social link per entry with its label", async () => {
+    const socialLinks = [
+      createMockSocialLink({ link: "https://example.com", label: "Website" }),
+      createMockSocialLink({
+        link: "https://mastodon.social/@activist",
+        label: "Mastodon",
+      }),
+    ];
+
+    const { container } = await render(CardConnect, {
+      props: { socialLinks, pageType: "organization" },
+    });
+
+    const links = container.querySelectorAll("[data-testid='social-link']");
+    expect(links.length).toBe(2);
+    expect(screen.getByText("Website")).toBeTruthy();
+    expect(screen.getByText("Mastodon")).toBeTruthy();
+  });
+
+  it("shows the edit icon when signed in and opens the social-links modal with the entity id", async () => {
+    const organization = createMockOrganization({ id: "org-1" });
+
+    await render(CardConnect, {
+      props: {
+        socialLinks: [],
+        pageType: "organization",
+        entity: organization,
+      },
+    });
+
+    const editIcon = screen.getByTestId("icon-edit");
+    expect(editIcon).toBeTruthy();
+
+    await fireEvent.click(editIcon);
+
+    const modals = useModals();
+    expect(modals.modals["ModalSocialLinksOrganization"]?.isOpen).toBe(true);
+    expect(modals.modals["ModalSocialLinksOrganization"]?.props).toEqual({
+      entityId: "org-1",
+    });
+  });
+
+  it("hides the edit icon when not signed in", async () => {
+    mockUserIsSignedIn.value = false;
+
+    await render(CardConnect, {
+      props: { socialLinks: [], pageType: "organization" },
+    });
+
+    expect(screen.queryByTestId("icon-edit")).toBeNull();
+  });
+});

--- a/frontend/test/components/card/connect/CardConnectEvent.spec.ts
+++ b/frontend/test/components/card/connect/CardConnectEvent.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardConnectEvent from "../../../../app/components/card/connect/CardConnectEvent.vue";
+import {
+  createMockEvent,
+  createMockSocialLink,
+} from "../../../mocks/factories";
+import render from "../../../render";
+
+describe("CardConnectEvent", () => {
+  it("renders the event's social links", async () => {
+    const event = createMockEvent({
+      socialLinks: [
+        createMockSocialLink({ link: "https://example.com", label: "Site" }),
+      ],
+    });
+
+    await render(CardConnectEvent, {
+      props: { event },
+    });
+
+    expect(screen.getByText("Site")).toBeTruthy();
+  });
+
+  it("renders no social links when the event is null", async () => {
+    const { container } = await render(CardConnectEvent, {
+      props: { event: null },
+    });
+
+    expect(
+      container.querySelectorAll("[data-testid='social-link']").length
+    ).toBe(0);
+  });
+});

--- a/frontend/test/components/card/connect/CardConnectGroup.spec.ts
+++ b/frontend/test/components/card/connect/CardConnectGroup.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardConnectGroup from "../../../../app/components/card/connect/CardConnectGroup.vue";
+import {
+  createMockGroup,
+  createMockSocialLink,
+} from "../../../mocks/factories";
+import render from "../../../render";
+
+describe("CardConnectGroup", () => {
+  it("renders the group's social links", async () => {
+    const group = createMockGroup({
+      socialLinks: [
+        createMockSocialLink({ link: "https://example.com", label: "Site" }),
+      ],
+    });
+
+    await render(CardConnectGroup, {
+      props: { group },
+    });
+
+    expect(screen.getByText("Site")).toBeTruthy();
+  });
+
+  it("renders no social links when the group is null", async () => {
+    const { container } = await render(CardConnectGroup, {
+      props: { group: null },
+    });
+
+    expect(
+      container.querySelectorAll("[data-testid='social-link']").length
+    ).toBe(0);
+  });
+});

--- a/frontend/test/components/card/connect/CardConnectOrganization.spec.ts
+++ b/frontend/test/components/card/connect/CardConnectOrganization.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardConnectOrganization from "../../../../app/components/card/connect/CardConnectOrganization.vue";
+import {
+  createMockOrganization,
+  createMockSocialLink,
+} from "../../../mocks/factories";
+import render from "../../../render";
+
+describe("CardConnectOrganization", () => {
+  it("renders the organization's social links", async () => {
+    const organization = createMockOrganization({
+      socialLinks: [
+        createMockSocialLink({ link: "https://example.com", label: "Site" }),
+      ],
+    });
+
+    await render(CardConnectOrganization, {
+      props: { organization },
+    });
+
+    expect(screen.getByText("Site")).toBeTruthy();
+  });
+
+  it("renders no social links when the organization is null", async () => {
+    const { container } = await render(CardConnectOrganization, {
+      props: { organization: null },
+    });
+
+    expect(
+      container.querySelectorAll("[data-testid='social-link']").length
+    ).toBe(0);
+  });
+});

--- a/frontend/test/components/card/discussion/CardDiscussion.spec.ts
+++ b/frontend/test/components/card/discussion/CardDiscussion.spec.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import type { Discussion } from "../../../../shared/types/discussion";
+
+import CardDiscussion from "../../../../app/components/card/discussion/CardDiscussion.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import { createMockUser } from "../../../mocks/factories";
+import render from "../../../render";
+
+function createDiscussion(overrides: Partial<Discussion> = {}): Discussion {
+  return {
+    title: "Should we host a rally?",
+    createdBy: createMockUser({ userName: "organizer1" }),
+    category: "Planning",
+    upVoters: [],
+    participants: [],
+    messages: 0,
+    creationDate: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("CardDiscussion", () => {
+  it("renders the discussion title", async () => {
+    await render(CardDiscussion, {
+      props: { discussion: createDiscussion() },
+    });
+
+    expect(screen.getByText("Should we host a rally?")).toBeTruthy();
+  });
+
+  it("renders the discussion category on the filter button", async () => {
+    await render(CardDiscussion, {
+      props: { discussion: createDiscussion({ category: "Logistics" }) },
+    });
+
+    const button = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_discussion.filter_discussion_category_aria_label"
+      ),
+    });
+    expect(button.textContent).toContain("Logistics");
+  });
+
+  it("renders the participant count and message count meta tags", async () => {
+    const discussion = createDiscussion({
+      participants: [createMockUser(), createMockUser()],
+      messages: 5,
+    });
+
+    const { container } = await render(CardDiscussion, {
+      props: { discussion },
+    });
+
+    // Participants, message count, and the creation-date meta tags.
+    const metaTags = container.querySelectorAll("[data-testid='meta-tag']");
+    expect(metaTags.length).toBe(3);
+    expect(screen.getByText("5")).toBeTruthy();
+  });
+
+  it("renders the discussion creator's username", async () => {
+    const discussion = createDiscussion({
+      createdBy: createMockUser({ userName: "activist42" }),
+    });
+
+    await render(CardDiscussion, { props: { discussion } });
+
+    expect(screen.getByText("activist42")).toBeTruthy();
+  });
+
+  it("renders exactly one upvote button", async () => {
+    await render(CardDiscussion, {
+      props: { discussion: createDiscussion() },
+    });
+
+    const upvoteButtons = screen.getAllByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card.discussion._global.upvote_discussion_aria_label"
+      ),
+    });
+    expect(upvoteButtons.length).toBe(1);
+  });
+});

--- a/frontend/test/components/card/discussion/CardDiscussionEntry.spec.ts
+++ b/frontend/test/components/card/discussion/CardDiscussionEntry.spec.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import type { DiscussionEntry } from "../../../../shared/types/discussion";
+
+import CardDiscussionEntry from "../../../../app/components/card/discussion/CardDiscussionEntry.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import render from "../../../render";
+
+function createEntry(overrides: Partial<DiscussionEntry> = {}): DiscussionEntry {
+  return {
+    id: 1,
+    author: "activist42",
+    content: "I think this is a great idea!",
+    votes: 3,
+    date: new Date("2024-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("CardDiscussionEntry", () => {
+  it("renders the author and content", async () => {
+    await render(CardDiscussionEntry, {
+      props: { discussionEntry: createEntry() },
+    });
+
+    expect(screen.getByText("activist42")).toBeTruthy();
+    expect(screen.getByText("I think this is a great idea!")).toBeTruthy();
+  });
+
+  it("renders the formatted date preceded by 'on'", async () => {
+    const date = new Date("2024-03-15T00:00:00Z");
+
+    await render(CardDiscussionEntry, {
+      props: { discussionEntry: createEntry({ date }) },
+    });
+
+    expect(
+      screen.getByText(getEnglishText("i18n.components.card_discussion_entry.on"))
+    ).toBeTruthy();
+    expect(screen.getByText(date.toLocaleDateString())).toBeTruthy();
+  });
+
+  it("renders the vote count on the upvote button", async () => {
+    await render(CardDiscussionEntry, {
+      props: { discussionEntry: createEntry({ votes: 7 }) },
+    });
+
+    const button = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card.discussion._global.upvote_discussion_aria_label"
+      ),
+    });
+    expect(button.textContent).toContain("7");
+  });
+});

--- a/frontend/test/components/card/discussion/CardDiscussionInput.spec.ts
+++ b/frontend/test/components/card/discussion/CardDiscussionInput.spec.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import type { DiscussionInput } from "../../../../shared/types/discussion";
+
+import CardDiscussionInput from "../../../../app/components/card/discussion/CardDiscussionInput.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import render from "../../../render";
+
+function createDiscussionInput(
+  overrides: Partial<DiscussionInput> = {}
+): DiscussionInput {
+  return {
+    name: "Test discussion",
+    supporters: 0,
+    description: "",
+    category: "General",
+    highRisk: false,
+    ...overrides,
+  };
+}
+
+describe("CardDiscussionInput", () => {
+  it("renders the Write and Preview toggle buttons in markdown mode, with Write active", async () => {
+    await render(CardDiscussionInput, {
+      props: { discussionInput: createDiscussionInput() },
+    });
+
+    const writeButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_discussion_input.write_aria_label"
+      ),
+    });
+    const previewButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_discussion_input.preview_aria_label"
+      ),
+    });
+
+    expect(writeButton.className).toContain("style-cta ");
+    expect(previewButton.className).toContain("style-cta-secondary");
+  });
+
+  it("switches the active toggle to Preview when clicked", async () => {
+    await render(CardDiscussionInput, {
+      props: { discussionInput: createDiscussionInput() },
+    });
+
+    const previewButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_discussion_input.preview_aria_label"
+      ),
+    });
+    await fireEvent.click(previewButton);
+
+    const writeButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_discussion_input.write_aria_label"
+      ),
+    });
+    expect(previewButton.className).toContain("style-cta ");
+    expect(writeButton.className).toContain("style-cta-secondary");
+  });
+
+  it("switches from the markdown toolbar to the plain-text formatting icons when markdown support is disabled", async () => {
+    const { container } = await render(CardDiscussionInput, {
+      props: { discussionInput: createDiscussionInput() },
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: getEnglishText(
+          "i18n.components.card_discussion_input.write_aria_label"
+        ),
+      })
+    ).toBeTruthy();
+
+    const checkbox = container.querySelector("input[type='checkbox']")!;
+    await fireEvent.click(checkbox);
+
+    expect(
+      screen.queryByRole("button", {
+        name: getEnglishText(
+          "i18n.components.card_discussion_input.write_aria_label"
+        ),
+      })
+    ).toBeNull();
+    expect(container.querySelector(".cursor-pointer")).toBeTruthy();
+  });
+
+  it("updates the textarea value when typed into", async () => {
+    const { container } = await render(CardDiscussionInput, {
+      props: { discussionInput: createDiscussionInput() },
+    });
+
+    const textarea = container.querySelector("textarea")!;
+    await fireEvent.update(textarea, "Hello world");
+
+    expect(textarea.value).toBe("Hello world");
+  });
+
+  it("renders the write textarea and preview editor for a normal-risk discussion", async () => {
+    const { container } = await render(CardDiscussionInput, {
+      props: { discussionInput: createDiscussionInput({ highRisk: false }) },
+    });
+
+    expect(container.querySelector("textarea")).toBeTruthy();
+    expect(container.querySelector(".tiptap")).toBeTruthy();
+  });
+
+  it("shows the warning octagon icon when the discussion is high risk", async () => {
+    await render(CardDiscussionInput, {
+      props: { discussionInput: createDiscussionInput({ highRisk: true }) },
+    });
+
+    expect(
+      screen.getByRole("img", { name: "bi:exclamation-octagon" })
+    ).toBeTruthy();
+  });
+
+  it("shows the warning triangle icon when the discussion is not high risk", async () => {
+    await render(CardDiscussionInput, {
+      props: { discussionInput: createDiscussionInput({ highRisk: false }) },
+    });
+
+    expect(
+      screen.getByRole("img", { name: "bi:exclamation-triangle" })
+    ).toBeTruthy();
+  });
+
+  it("renders the comment button", async () => {
+    await render(CardDiscussionInput, {
+      props: { discussionInput: createDiscussionInput() },
+    });
+
+    const button = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.card_discussion_input.comment_aria_label"
+      ),
+    });
+    expect(button.textContent).toContain(
+      getEnglishText("i18n.components.card_discussion_input.comment")
+    );
+  });
+});

--- a/frontend/test/components/card/get-involved/CardGetInvolved.spec.ts
+++ b/frontend/test/components/card/get-involved/CardGetInvolved.spec.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import CardGetInvolved from "../../../../app/components/card/get-involved/CardGetInvolved.vue";
+import render from "../../../render";
+
+describe("CardGetInvolved", () => {
+  it("renders the card wrapper", async () => {
+    await render(CardGetInvolved);
+
+    expect(screen.getByTestId("card-get-involved")).toBeTruthy();
+  });
+
+  it("renders slotted content", async () => {
+    await render(CardGetInvolved, {
+      slots: { default: "<p>Slot content</p>" },
+    });
+
+    expect(screen.getByText("Slot content")).toBeTruthy();
+  });
+});

--- a/frontend/test/components/card/get-involved/CardGetInvolvedEvent.spec.ts
+++ b/frontend/test/components/card/get-involved/CardGetInvolvedEvent.spec.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CardGetInvolvedEvent from "../../../../app/components/card/get-involved/CardGetInvolvedEvent.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import {
+  createMockEvent,
+  createMockEventText,
+} from "../../../mocks/factories";
+import render from "../../../render";
+import {
+  createUseRouteMock,
+  createUseUserMock,
+} from "../../../mocks/composableMocks";
+
+const stubs = {
+  IconEdit: { template: '<span data-testid="icon-edit" />' },
+  BtnRouteInternal: {
+    template: '<a :data-testid="ariaLabel" />',
+    props: ["ariaLabel", "linkTo", "label", "cta", "fontSize", "iconSize", "rightIcon"],
+  },
+};
+
+const { eventData, mockUserIsSignedIn } = vi.hoisted(() => ({
+  eventData: { value: null as ReturnType<typeof createMockEvent> | null },
+  mockUserIsSignedIn: { value: false },
+}));
+
+mockNuxtImport("useGetEvent", async () => {
+  const { ref } = await import("vue");
+  return () => ({ data: ref(eventData.value) });
+});
+mockNuxtImport(
+  "useModalHandlers",
+  () => () => ({ openModal: vi.fn() })
+);
+mockNuxtImport("useUser", async () => {
+  const { ref } = await import("vue");
+  return () => ({
+    userIsSignedIn: ref(mockUserIsSignedIn.value),
+    canEdit: () => false,
+    canView: () => true,
+    canCreate: () => false,
+    canDelete: () => false,
+    signOutUser: vi.fn(),
+    user: null,
+  });
+});
+
+beforeEach(() => {
+  eventData.value = null;
+  mockUserIsSignedIn.value = false;
+  vi.stubGlobal("useRoute", createUseRouteMock({ eventId: "event-1" }));
+});
+
+describe("CardGetInvolvedEvent", () => {
+  it("renders the Participate heading", async () => {
+    await render(CardGetInvolvedEvent, { global: { stubs } });
+
+    expect(
+      screen.getByText(getEnglishText("i18n.components._global.participate"))
+    ).toBeTruthy();
+  });
+
+  it("shows the default subtext when event has no getInvolved text", async () => {
+    eventData.value = createMockEvent({ texts: [] });
+
+    await render(CardGetInvolvedEvent, { global: { stubs } });
+
+    expect(
+      screen.getByText(
+        getEnglishText(
+          "i18n.components.card_get_involved_event.participate_subtext"
+        )
+      )
+    ).toBeTruthy();
+  });
+
+  it("shows the event's custom getInvolved text when present", async () => {
+    eventData.value = createMockEvent({
+      texts: [createMockEventText({ getInvolved: "Join our march!" })],
+    });
+
+    await render(CardGetInvolvedEvent, { global: { stubs } });
+
+    expect(screen.getByText("Join our march!")).toBeTruthy();
+  });
+
+  it("renders the offer-to-help button", async () => {
+    await render(CardGetInvolvedEvent, { global: { stubs } });
+
+    expect(
+      screen.getByTestId("i18n._global.offer_to_help_aria_label")
+    ).toBeTruthy();
+  });
+
+  it("shows the edit icon when the user is signed in", async () => {
+    mockUserIsSignedIn.value = true;
+
+    await render(CardGetInvolvedEvent, { global: { stubs } });
+
+    expect(screen.getByTestId("icon-edit")).toBeTruthy();
+  });
+
+  it("hides the edit icon when the user is not signed in", async () => {
+    await render(CardGetInvolvedEvent, { global: { stubs } });
+
+    expect(screen.queryByTestId("icon-edit")).toBeNull();
+  });
+});

--- a/frontend/test/components/card/get-involved/CardGetInvolvedGroup.spec.ts
+++ b/frontend/test/components/card/get-involved/CardGetInvolvedGroup.spec.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CardGetInvolvedGroup from "../../../../app/components/card/get-involved/CardGetInvolvedGroup.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import {
+  createMockGroup,
+  createMockGroupText,
+} from "../../../mocks/factories";
+import render from "../../../render";
+import { createUseRouteMock } from "../../../mocks/composableMocks";
+
+const stubs = {
+  IconEdit: { template: '<span data-testid="icon-edit" />' },
+  BtnRouteInternal: {
+    template: '<a :data-testid="ariaLabel" />',
+    props: ["ariaLabel", "linkTo", "label", "cta", "fontSize", "iconSize", "rightIcon"],
+  },
+};
+
+const { groupData, mockUserIsSignedIn } = vi.hoisted(() => ({
+  groupData: { value: null as ReturnType<typeof createMockGroup> | null },
+  mockUserIsSignedIn: { value: false },
+}));
+
+mockNuxtImport("useGetGroup", async () => {
+  const { ref } = await import("vue");
+  return () => ({ data: ref(groupData.value) });
+});
+mockNuxtImport(
+  "useModalHandlers",
+  () => () => ({ openModal: vi.fn() })
+);
+mockNuxtImport("useUser", async () => {
+  const { ref } = await import("vue");
+  return () => ({
+    userIsSignedIn: ref(mockUserIsSignedIn.value),
+    canEdit: () => false,
+    canView: () => true,
+    canCreate: () => false,
+    canDelete: () => false,
+    signOutUser: vi.fn(),
+    user: null,
+  });
+});
+
+beforeEach(() => {
+  groupData.value = null;
+  mockUserIsSignedIn.value = false;
+  vi.stubGlobal("useRoute", createUseRouteMock({ groupId: "group-1" }));
+});
+
+describe("CardGetInvolvedGroup", () => {
+  it("renders the Get involved heading", async () => {
+    await render(CardGetInvolvedGroup, { global: { stubs } });
+
+    expect(
+      screen.getByText(getEnglishText("i18n.components._global.get_involved"))
+    ).toBeTruthy();
+  });
+
+  it("shows the default subtext when group has no getInvolved text", async () => {
+    groupData.value = createMockGroup({ name: "Test Group", texts: [] });
+
+    await render(CardGetInvolvedGroup, { global: { stubs } });
+
+    expect(screen.getByText("Test Group", { exact: false })).toBeTruthy();
+  });
+
+  it("shows the group's custom getInvolved text when present", async () => {
+    groupData.value = createMockGroup({
+      texts: [createMockGroupText({ getInvolved: "Volunteer with us!" })],
+    });
+
+    await render(CardGetInvolvedGroup, { global: { stubs } });
+
+    expect(screen.getByText("Volunteer with us!")).toBeTruthy();
+  });
+
+  it("shows the join button when the group has a getInvolvedUrl", async () => {
+    groupData.value = createMockGroup({
+      texts: [
+        createMockGroupText({ getInvolvedUrl: "https://example.com/join" }),
+      ],
+    });
+
+    await render(CardGetInvolvedGroup, { global: { stubs } });
+
+    expect(screen.getByTestId("get-involved-join-button")).toBeTruthy();
+  });
+
+  it("hides the join button when the group has no getInvolvedUrl", async () => {
+    groupData.value = createMockGroup({
+      texts: [createMockGroupText({ getInvolvedUrl: undefined })],
+    });
+
+    await render(CardGetInvolvedGroup, { global: { stubs } });
+
+    expect(screen.queryByTestId("get-involved-join-button")).toBeNull();
+  });
+
+  it("shows the edit icon when the user is signed in", async () => {
+    mockUserIsSignedIn.value = true;
+
+    await render(CardGetInvolvedGroup, { global: { stubs } });
+
+    expect(screen.getByTestId("icon-edit")).toBeTruthy();
+  });
+
+  it("hides the edit icon when the user is not signed in", async () => {
+    await render(CardGetInvolvedGroup, { global: { stubs } });
+
+    expect(screen.queryByTestId("icon-edit")).toBeNull();
+  });
+});

--- a/frontend/test/components/card/get-involved/CardGetInvolvedOrganization.spec.ts
+++ b/frontend/test/components/card/get-involved/CardGetInvolvedOrganization.spec.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CardGetInvolvedOrganization from "../../../../app/components/card/get-involved/CardGetInvolvedOrganization.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import {
+  createMockGroup,
+  createMockOrganization,
+  createMockOrganizationText,
+} from "../../../mocks/factories";
+import render from "../../../render";
+import { createUseRouteMock } from "../../../mocks/composableMocks";
+
+const stubs = {
+  IconEdit: { template: '<span data-testid="icon-edit" />' },
+  BtnRouteInternal: {
+    template: '<a :data-testid="ariaLabel" />',
+    props: ["ariaLabel", "linkTo", "label", "cta", "fontSize", "iconSize", "rightIcon"],
+  },
+  Feed: true,
+};
+
+const { orgData, mockUserIsSignedIn } = vi.hoisted(() => ({
+  orgData: { value: null as ReturnType<typeof createMockOrganization> | null },
+  mockUserIsSignedIn: { value: false },
+}));
+
+mockNuxtImport("useGetOrganization", async () => {
+  const { ref } = await import("vue");
+  return () => ({ data: ref(orgData.value) });
+});
+mockNuxtImport(
+  "useModalHandlers",
+  () => () => ({ openModal: vi.fn() })
+);
+mockNuxtImport("useUser", async () => {
+  const { ref } = await import("vue");
+  return () => ({
+    userIsSignedIn: ref(mockUserIsSignedIn.value),
+    canEdit: () => false,
+    canView: () => true,
+    canCreate: () => false,
+    canDelete: () => false,
+    signOutUser: vi.fn(),
+    user: null,
+  });
+});
+
+beforeEach(() => {
+  orgData.value = null;
+  mockUserIsSignedIn.value = false;
+  vi.stubGlobal("useRoute", createUseRouteMock({ orgId: "org-1" }));
+});
+
+describe("CardGetInvolvedOrganization", () => {
+  it("renders the Get involved heading", async () => {
+    await render(CardGetInvolvedOrganization, { global: { stubs } });
+
+    expect(
+      screen.getByText(getEnglishText("i18n.components._global.get_involved"))
+    ).toBeTruthy();
+  });
+
+  it("shows working-groups subtext when the organization has groups", async () => {
+    orgData.value = createMockOrganization({
+      name: "Acme Org",
+      groups: [createMockGroup()],
+      texts: [createMockOrganizationText({ getInvolved: "" })],
+    });
+
+    await render(CardGetInvolvedOrganization, { global: { stubs } });
+
+    expect(screen.getByText("Acme Org", { exact: false })).toBeTruthy();
+  });
+
+  it("shows a custom getInvolved text when org has groups and custom text", async () => {
+    orgData.value = createMockOrganization({
+      groups: [createMockGroup()],
+      texts: [
+        createMockOrganizationText({ getInvolved: "Help us change the world!" }),
+      ],
+    });
+
+    await render(CardGetInvolvedOrganization, { global: { stubs } });
+
+    expect(screen.getByText("Help us change the world!")).toBeTruthy();
+  });
+
+  it("shows join-organization subtext when org has a getInvolvedUrl but no groups", async () => {
+    orgData.value = createMockOrganization({
+      name: "Acme Org",
+      groups: [],
+      texts: [
+        createMockOrganizationText({
+          getInvolved: "",
+          getInvolvedUrl: "https://example.com/join",
+        }),
+      ],
+    });
+
+    await render(CardGetInvolvedOrganization, { global: { stubs } });
+
+    expect(
+      screen.getByTestId("i18n._global.join_organization_aria_label")
+    ).toBeTruthy();
+  });
+
+  it("shows no-info text when org has neither groups nor a getInvolvedUrl", async () => {
+    orgData.value = createMockOrganization({
+      name: "Acme Org",
+      groups: [],
+      texts: [
+        createMockOrganizationText({
+          getInvolved: "",
+          getInvolvedUrl: undefined,
+        }),
+      ],
+    });
+
+    await render(CardGetInvolvedOrganization, { global: { stubs } });
+
+    expect(
+      screen.queryByTestId("i18n._global.join_organization_aria_label")
+    ).toBeNull();
+    expect(
+      screen.getByText(
+        "No information provided on joining Acme Org for now."
+      )
+    ).toBeTruthy();
+  });
+
+  it("shows the view-all-groups button when the organization has groups", async () => {
+    orgData.value = createMockOrganization({
+      groups: [createMockGroup()],
+      texts: [createMockOrganizationText()],
+    });
+
+    await render(CardGetInvolvedOrganization, { global: { stubs } });
+
+    expect(
+      screen.getByTestId(
+        "i18n.components.card_get_involved_organization.view_all_groups_aria_label"
+      )
+    ).toBeTruthy();
+  });
+
+  it("shows the edit icon when the user is signed in", async () => {
+    mockUserIsSignedIn.value = true;
+
+    await render(CardGetInvolvedOrganization, { global: { stubs } });
+
+    expect(screen.getByTestId("icon-edit")).toBeTruthy();
+  });
+
+  it("hides the edit icon when the user is not signed in", async () => {
+    await render(CardGetInvolvedOrganization, { global: { stubs } });
+
+    expect(screen.queryByTestId("icon-edit")).toBeNull();
+  });
+});

--- a/frontend/test/components/combobox/ComboboxTopics.spec.ts
+++ b/frontend/test/components/combobox/ComboboxTopics.spec.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
+
+import ComboboxTopics from "../../../app/components/combobox/ComboboxTopics.vue";
+import { TopicEnum } from "../../../shared/types/topics";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import { createMockTopic } from "../../mocks/factories";
+import render from "../../render";
+
+const { topicsData } = vi.hoisted(() => ({
+  topicsData: {
+    value: [
+      { type: "ENVIRONMENT", id: "topic-1" },
+      { type: "ANIMAL_RIGHTS", id: "topic-2" },
+    ],
+  },
+}));
+
+mockNuxtImport("useGetTopics", async () => {
+  const { ref } = await import("vue");
+  return () => ({
+    data: ref(
+      topicsData.value.map((t) =>
+        createMockTopic({ type: t.type as TopicEnum, id: t.id })
+      )
+    ),
+  });
+});
+
+async function openDropdown() {
+  const toggleButton = screen.getByRole("button", {
+    name: getEnglishText("i18n.components.combobox_topics.toggle_dropdown"),
+  });
+  await fireEvent.click(toggleButton);
+}
+
+describe("ComboboxTopics", () => {
+  it("renders the combobox input with the filter placeholder and aria-label", async () => {
+    await render(ComboboxTopics);
+
+    const input = screen.getByRole("combobox");
+    expect(input.getAttribute("aria-label")).toBe(
+      getEnglishText("i18n.components.combobox_topics.filter_by_topic")
+    );
+    expect(input.getAttribute("placeholder")).toBe(
+      getEnglishText("i18n.components.combobox_topics.filter_by_topic")
+    );
+  });
+
+  it("shows the available topic options when the dropdown is opened", async () => {
+    await render(ComboboxTopics);
+
+    await openDropdown();
+
+    const options = screen.getAllByTestId("topics-dropdown-option");
+    expect(options.length).toBe(2);
+    expect(screen.getByText("Environment")).toBeTruthy();
+    expect(screen.getByText("Animal Rights")).toBeTruthy();
+  });
+
+  it("emits update:selectedTopics with the topic value when an option is selected", async () => {
+    const { emitted } = await render(ComboboxTopics);
+
+    await openDropdown();
+    // headlessui's ComboboxOption selects on mousedown, not click.
+    await fireEvent.mouseDown(screen.getByText("Environment"));
+
+    const events = emitted()["update:selectedTopics"];
+    expect(events).toBeTruthy();
+    expect(events!.at(-1)).toEqual([[TopicEnum.ENVIRONMENT]]);
+  });
+
+  it("shows the no-matching-topics message when the query does not match any topic", async () => {
+    const { container } = await render(ComboboxTopics);
+
+    await openDropdown();
+    const input = container.querySelector("input")!;
+    await fireEvent.update(input, "nonexistent-topic-query");
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.combobox_topics.no_matching_topics")
+      )
+    ).toBeTruthy();
+    expect(screen.queryAllByTestId("topics-dropdown-option").length).toBe(0);
+  });
+
+  it("pre-selects topics passed in via receivedSelectedTopics", async () => {
+    await render(ComboboxTopics, {
+      props: { receivedSelectedTopics: [TopicEnum.ANIMAL_RIGHTS] },
+    });
+
+    await openDropdown();
+
+    const options = screen.getAllByTestId("topics-dropdown-option");
+    const selectedOption = options.find((option) =>
+      option.textContent?.includes("Animal Rights")
+    );
+    expect(selectedOption?.getAttribute("aria-selected")).toBe("true");
+  });
+});

--- a/frontend/test/components/discussion/Discussion.spec.ts
+++ b/frontend/test/components/discussion/Discussion.spec.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { describe, expect, it } from "vitest";
+
+import Discussion from "../../../app/components/discussion/Discussion.vue";
+import { createMockOrganization } from "../../mocks/factories";
+import render from "../../render";
+
+describe("Discussion", () => {
+  it("renders the discussion input when organizations and discussionInput are provided", async () => {
+    const { container } = await render(Discussion, {
+      props: {
+        organizations: [createMockOrganization()],
+        discussionInput: {
+          name: "Test",
+          supporters: 0,
+          description: "",
+          category: "General",
+          highRisk: false,
+        },
+      },
+    });
+
+    expect(container.querySelector("textarea")).toBeTruthy();
+  });
+
+  it("does not render the discussion input when organizations is missing", async () => {
+    const { container } = await render(Discussion, {
+      props: {
+        discussionInput: {
+          name: "Test",
+          supporters: 0,
+          description: "",
+          category: "General",
+          highRisk: false,
+        },
+      },
+    });
+
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+
+  it("does not render the discussion input when discussionInput is missing", async () => {
+    const { container } = await render(Discussion, {
+      props: { organizations: [createMockOrganization()] },
+    });
+
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+});

--- a/frontend/test/components/discussion/DiscussionHeader.spec.ts
+++ b/frontend/test/components/discussion/DiscussionHeader.spec.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import DiscussionHeader from "../../../app/components/discussion/DiscussionHeader.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+describe("DiscussionHeader", () => {
+  it("renders the discussion header text", async () => {
+    await render(DiscussionHeader);
+
+    expect(
+      screen.getByText(getEnglishText("i18n._global.discussion"))
+    ).toBeTruthy();
+  });
+});

--- a/frontend/test/components/dropdown/DropdownCreate.spec.ts
+++ b/frontend/test/components/dropdown/DropdownCreate.spec.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import DropdownCreate from "../../../app/components/dropdown/DropdownCreate.vue";
+import { useModals } from "../../../app/stores/modals";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+describe("DropdownCreate", () => {
+  it("renders the menu button with the create label and aria-label", async () => {
+    await render(DropdownCreate);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText("i18n.components.dropdown_create.create_aria_label"),
+    });
+    expect(menuButton.textContent).toContain(
+      getEnglishText("i18n.components.dropdown_create.create")
+    );
+  });
+
+  it("shows the new event, organization, and group options when opened", async () => {
+    await render(DropdownCreate);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText("i18n.components.dropdown_create.create_aria_label"),
+    });
+    await fireEvent.click(menuButton);
+
+    const menuItems = await screen.findAllByRole("menuitem");
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      getEnglishText("i18n._global.new_event"),
+      getEnglishText("i18n.components.dropdown_create.new_organization"),
+      getEnglishText("i18n._global.new_group"),
+    ]);
+  });
+
+  it("opens the create-event modal when the new event option is clicked", async () => {
+    await render(DropdownCreate);
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: getEnglishText(
+          "i18n.components.dropdown_create.create_aria_label"
+        ),
+      })
+    );
+    const menuItems = await screen.findAllByRole("menuitem");
+    await fireEvent.click(menuItems[0]!);
+
+    const modals = useModals();
+    expect(modals.modals["ModalCreateEvent"]?.isOpen).toBe(true);
+  });
+
+  it("opens the create-organization modal when the new organization option is clicked", async () => {
+    await render(DropdownCreate);
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: getEnglishText(
+          "i18n.components.dropdown_create.create_aria_label"
+        ),
+      })
+    );
+    const menuItems = await screen.findAllByRole("menuitem");
+    await fireEvent.click(menuItems[1]!);
+
+    const modals = useModals();
+    expect(modals.modals["ModalCreateOrganization"]?.isOpen).toBe(true);
+  });
+
+  it("opens the create-group modal when the new group option is clicked", async () => {
+    await render(DropdownCreate);
+
+    await fireEvent.click(
+      screen.getByRole("button", {
+        name: getEnglishText(
+          "i18n.components.dropdown_create.create_aria_label"
+        ),
+      })
+    );
+    const menuItems = await screen.findAllByRole("menuitem");
+    await fireEvent.click(menuItems[2]!);
+
+    const modals = useModals();
+    expect(modals.modals["ModalCreateGroup"]?.isOpen).toBe(true);
+  });
+});

--- a/frontend/test/components/dropdown/DropdownDateFilter.spec.ts
+++ b/frontend/test/components/dropdown/DropdownDateFilter.spec.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import DropdownDateFilter from "../../../app/components/dropdown/DropdownDateFilter.vue";
+import render from "../../render";
+
+describe("DropdownDateFilter", () => {
+  it("defaults to the 'Last 30 days' filter", async () => {
+    await render(DropdownDateFilter);
+
+    expect(screen.getByText("Last 30 days")).toBeTruthy();
+  });
+
+  it("shows all filter options when opened", async () => {
+    await render(DropdownDateFilter);
+
+    await fireEvent.click(screen.getByRole("button"));
+
+    const listbox = await screen.findByRole("listbox");
+    expect(listbox).toBeTruthy();
+    const options = screen.getAllByRole("option");
+    expect(options.map((option) => option.textContent?.trim())).toEqual([
+      "Last week",
+      "Last 30 days",
+      "Last 60 days",
+      "Last year",
+    ]);
+  });
+
+  it("switches the selected filter when a different option is chosen", async () => {
+    await render(DropdownDateFilter);
+
+    await fireEvent.click(screen.getByRole("button"));
+    await fireEvent.click(screen.getByRole("option", { name: "Last year" }));
+
+    expect(screen.getByText("Last year")).toBeTruthy();
+    expect(screen.queryByText("Last 30 days")).toBeNull();
+  });
+});

--- a/frontend/test/components/dropdown/DropdownInfo.spec.ts
+++ b/frontend/test/components/dropdown/DropdownInfo.spec.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import DropdownInfo from "../../../app/components/dropdown/DropdownInfo.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+beforeEach(() => {
+  vi.stubGlobal("useLocalePath", () => (path: string) => path);
+});
+
+describe("DropdownInfo", () => {
+  it("renders the menu button with the info label and aria-label", async () => {
+    await render(DropdownInfo);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText("i18n.components.dropdown_info.info_aria_label"),
+    });
+    expect(menuButton.textContent).toContain(
+      getEnglishText("i18n.components.dropdown_info.info")
+    );
+  });
+
+  it("shows the help, documentation, and legal links when opened", async () => {
+    await render(DropdownInfo);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText("i18n.components.dropdown_info.info_aria_label"),
+    });
+    await fireEvent.click(menuButton);
+
+    const menuItems = await screen.findAllByRole("menuitem");
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      getEnglishText("i18n.components.dropdown_info.help"),
+      getEnglishText("i18n.components._global.documentation"),
+      getEnglishText("i18n.components.dropdown_info.legal"),
+    ]);
+  });
+});

--- a/frontend/test/components/dropdown/DropdownLanguage.spec.ts
+++ b/frontend/test/components/dropdown/DropdownLanguage.spec.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import DropdownLanguage from "../../../app/components/dropdown/DropdownLanguage.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+beforeEach(() => {
+  vi.stubGlobal("useI18n", () => ({
+    locale: { value: "en" },
+    locales: {
+      value: [
+        { code: "en", name: "English" },
+        { code: "es", name: "Español" },
+      ],
+    },
+  }));
+  vi.stubGlobal("useSwitchLocalePath", () => (code: string) => `/${code}`);
+});
+
+describe("DropdownLanguage", () => {
+  it("renders the menu button with the current locale and aria-label", async () => {
+    await render(DropdownLanguage);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.dropdown_language.open_dropdown_aria_label"
+      ),
+    });
+    expect(menuButton.textContent).toContain("en");
+  });
+
+  it("lists the other available locales, excluding the current one", async () => {
+    await render(DropdownLanguage);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.dropdown_language.open_dropdown_aria_label"
+      ),
+    });
+    await fireEvent.click(menuButton);
+
+    expect(screen.getByText("Español")).toBeTruthy();
+    expect(screen.queryByText("English")).toBeNull();
+  });
+
+  it("sets the document's lang attribute when a locale is selected", async () => {
+    await render(DropdownLanguage);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.dropdown_language.open_dropdown_aria_label"
+      ),
+    });
+    await fireEvent.click(menuButton);
+
+    await fireEvent.click(screen.getByText("Español"));
+
+    expect(document.documentElement.getAttribute("lang")).toBe("es");
+  });
+});

--- a/frontend/test/components/dropdown/DropdownUserOptions.spec.ts
+++ b/frontend/test/components/dropdown/DropdownUserOptions.spec.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import DropdownUserOptions from "../../../app/components/dropdown/DropdownUserOptions.vue";
+import { useModals } from "../../../app/stores/modals";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+const mockUserIsSignedIn = vi.hoisted(() => ({ value: true }));
+const mockClear = vi.hoisted(() => vi.fn());
+
+mockNuxtImport("useUser", () => () => ({
+  userIsSignedIn: mockUserIsSignedIn.value,
+  userIsAdmin: false,
+  roles: [],
+  signOutUser: () => {},
+  canDelete: () => false,
+  canCreate: () => false,
+  canView: () => true,
+  canEdit: () => false,
+  user: null,
+}));
+
+beforeEach(() => {
+  mockUserIsSignedIn.value = true;
+  mockClear.mockClear();
+  vi.stubGlobal("useUserSession", () => ({
+    loggedIn: { value: mockUserIsSignedIn.value },
+    user: { value: null },
+    clear: mockClear,
+  }));
+  vi.stubGlobal("useLocalePath", () => (path: string) => path);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok: true } as Response)
+  );
+});
+
+async function openMenu(ariaLabel: string) {
+  const menuButton = screen.getByRole("button", { name: ariaLabel });
+  await fireEvent.click(menuButton);
+}
+
+describe("DropdownUserOptions", () => {
+  it("shows the username label when signed in", async () => {
+    await render(DropdownUserOptions);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.dropdown_user_options.username_aria_label"
+      ),
+    });
+    expect(menuButton.textContent).toContain(
+      getEnglishText("i18n.components.dropdown_user_options.username")
+    );
+  });
+
+  it("shows the signed-in options menu", async () => {
+    await render(DropdownUserOptions);
+
+    await openMenu(
+      getEnglishText(
+        "i18n.components.dropdown_user_options.username_aria_label"
+      )
+    );
+
+    const menuItems = await screen.findAllByRole("menuitem");
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      getEnglishText("i18n.components.dropdown_user_options.your_profile"),
+      getEnglishText("i18n.components.dropdown_user_options.your_events"),
+      getEnglishText("i18n.components.dropdown_user_options.your_orgs"),
+      getEnglishText("i18n._global.notifications"),
+      getEnglishText("i18n._global.settings"),
+      getEnglishText("i18n.components.dropdown_user_options.sign_out"),
+    ]);
+  });
+
+  it("opens the create-event modal when 'Your events' is clicked", async () => {
+    await render(DropdownUserOptions);
+
+    await openMenu(
+      getEnglishText(
+        "i18n.components.dropdown_user_options.username_aria_label"
+      )
+    );
+    await fireEvent.click(
+      screen.getByTestId("user-options-your-events")
+    );
+
+    const modals = useModals();
+    expect(modals.modals["ModalCreateEvent"]?.isOpen).toBe(true);
+  });
+
+  it("clears the session on sign-out", async () => {
+    await render(DropdownUserOptions);
+
+    await openMenu(
+      getEnglishText(
+        "i18n.components.dropdown_user_options.username_aria_label"
+      )
+    );
+    await fireEvent.click(
+      screen.getByTestId("user-options-your-sign-out")
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "api/public/logout",
+      expect.objectContaining({ method: "POST" })
+    );
+    await vi.waitFor(() => {
+      expect(mockClear).toHaveBeenCalled();
+    });
+  });
+
+  it("shows the sign-up and sign-in options when signed out", async () => {
+    mockUserIsSignedIn.value = false;
+
+    await render(DropdownUserOptions);
+
+    const menuButton = screen.getByRole("button", {
+      name: getEnglishText(
+        "i18n.components.dropdown_user_options.username_aria_label"
+      ),
+    });
+    expect(menuButton.textContent).toContain(
+      getEnglishText("i18n.components.dropdown_user_options.join_activist")
+    );
+
+    await fireEvent.click(menuButton);
+    const menuItems = await screen.findAllByRole("menuitem");
+    expect(menuItems.map((item) => item.textContent?.trim())).toEqual([
+      getEnglishText("i18n._global.sign_up"),
+      getEnglishText("i18n._global.sign_in"),
+    ]);
+  });
+});

--- a/frontend/test/components/events/EventsCalendar.spec.ts
+++ b/frontend/test/components/events/EventsCalendar.spec.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import EventsCalendar from "../../../app/components/events/EventsCalendar.vue";
+import { createMockEvent } from "../../mocks/factories";
+import render from "../../render";
+
+const stubs = {
+  MediaCalendar: {
+    props: ["calendarArgs"],
+    template: `
+      <div data-testid="media-calendar">
+        <div v-for="item in calendarArgs" :key="item.key">
+          <slot :customData="item.customData" />
+        </div>
+      </div>
+    `,
+  },
+};
+
+beforeEach(() => {
+  vi.stubGlobal("useLocalePath", () => (path: string) => path);
+});
+
+describe("EventsCalendar", () => {
+  it("renders a calendar entry for an action event", async () => {
+    const event = createMockEvent({
+      id: "event-1",
+      name: "Climate March",
+      type: "action",
+      times: [
+        { startTime: "", endTime: "", allDay: false, date: "2024-01-01" },
+      ],
+    });
+
+    const { container } = await render(EventsCalendar, {
+      props: { events: [event] },
+      global: { stubs },
+    });
+
+    expect(screen.getByText("Climate March")).toBeTruthy();
+    const link = container.querySelector("a[href='/events/event-1']");
+    expect(link).toBeTruthy();
+  });
+
+  it("renders a calendar entry for a learn event", async () => {
+    const event = createMockEvent({
+      id: "event-2",
+      name: "Know Your Rights Workshop",
+      type: "learn",
+      times: [
+        { startTime: "", endTime: "", allDay: false, date: "2024-01-02" },
+      ],
+    });
+
+    await render(EventsCalendar, {
+      props: { events: [event] },
+      global: { stubs },
+    });
+
+    expect(screen.getByText("Know Your Rights Workshop")).toBeTruthy();
+  });
+
+  it("renders one entry per event when there are both action and learn events", async () => {
+    const events = [
+      createMockEvent({
+        id: "event-1",
+        name: "Climate March",
+        type: "action",
+        times: [
+          { startTime: "", endTime: "", allDay: false, date: "2024-01-01" },
+        ],
+      }),
+      createMockEvent({
+        id: "event-2",
+        name: "Know Your Rights Workshop",
+        type: "learn",
+        times: [
+          { startTime: "", endTime: "", allDay: false, date: "2024-01-02" },
+        ],
+      }),
+    ];
+
+    const { container } = await render(EventsCalendar, {
+      props: { events },
+      global: { stubs },
+    });
+
+    expect(
+      container.querySelectorAll("[data-testid='media-calendar'] a").length
+    ).toBe(2);
+  });
+});

--- a/frontend/test/components/events/EventsList.spec.ts
+++ b/frontend/test/components/events/EventsList.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import EventsList from "../../../app/components/events/EventsList.vue";
+import { createMockEvent } from "../../mocks/factories";
+import render from "../../render";
+
+const stubs = {
+  CardSearchResultEntityEvent: {
+    props: ["event", "isPrivate"],
+    template: '<div data-testid="event-card">{{ event.name }}</div>',
+  },
+};
+
+describe("EventsList", () => {
+  it("renders nothing when there are no events", async () => {
+    const { container } = await render(EventsList, {
+      props: { events: [] },
+      global: { stubs },
+    });
+
+    expect(container.querySelectorAll("[data-testid='event-card']").length).toBe(
+      0
+    );
+  });
+
+  it("renders one card per event", async () => {
+    const events = [
+      createMockEvent({ id: "event-1", name: "Climate March" }),
+      createMockEvent({ id: "event-2", name: "Housing Rally" }),
+    ];
+
+    await render(EventsList, {
+      props: { events },
+      global: { stubs },
+    });
+
+    const cards = screen.getAllByTestId("event-card");
+    expect(cards.length).toBe(2);
+    expect(screen.getByText("Climate March")).toBeTruthy();
+    expect(screen.getByText("Housing Rally")).toBeTruthy();
+  });
+});

--- a/frontend/test/components/events/EventsMap.spec.ts
+++ b/frontend/test/components/events/EventsMap.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import EventsMap from "../../../app/components/events/EventsMap.vue";
+import { createMockEvent } from "../../mocks/factories";
+import render from "../../render";
+
+const stubs = {
+  MediaMapEvents: {
+    props: ["events"],
+    template: '<div data-testid="media-map-events" />',
+  },
+};
+
+describe("EventsMap", () => {
+  it("does not render the map when there are no events", async () => {
+    await render(EventsMap, {
+      props: { events: [] },
+      global: { stubs },
+    });
+
+    expect(screen.queryByTestId("media-map-events")).toBeNull();
+  });
+
+  it("renders the map with the events when there are events", async () => {
+    const events = [createMockEvent()];
+
+    await render(EventsMap, {
+      props: { events },
+      global: { stubs },
+    });
+
+    expect(screen.getByTestId("media-map-events")).toBeTruthy();
+  });
+});

--- a/frontend/test/components/feed/Feed.spec.ts
+++ b/frontend/test/components/feed/Feed.spec.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Feed from "../../../app/components/feed/Feed.vue";
+import { createUseRouteMock } from "../../mocks/composableMocks";
+import { createMockGroup, createMockOrganization } from "../../mocks/factories";
+import render from "../../render";
+
+const stubs = {
+  FeedItem: {
+    props: ["name", "url"],
+    template: '<div data-testid="feed-item">{{ name }}</div>',
+  },
+};
+
+const { organizationData } = vi.hoisted(() => ({
+  organizationData: {
+    value: null as ReturnType<typeof createMockOrganization> | null,
+  },
+}));
+
+mockNuxtImport("useGetOrganization", async () => {
+  const { ref } = await import("vue");
+  return () => ({ data: ref(organizationData.value) });
+});
+
+beforeEach(() => {
+  organizationData.value = null;
+  vi.stubGlobal("useRoute", createUseRouteMock({ orgId: "org-1" }));
+});
+
+describe("Feed", () => {
+  it("renders nothing when the organization has no groups", async () => {
+    organizationData.value = createMockOrganization({ groups: [] });
+
+    const { container } = await render(Feed, { global: { stubs } });
+
+    expect(container.querySelectorAll("[data-testid='feed-item']").length).toBe(
+      0
+    );
+  });
+
+  it("renders a feed item for each of the organization's groups", async () => {
+    organizationData.value = createMockOrganization({
+      id: "org-1",
+      groups: [
+        createMockGroup({ id: "group-1", name: "Local Chapter" }),
+        createMockGroup({ id: "group-2", name: "Youth Wing" }),
+      ],
+    });
+
+    await render(Feed, { global: { stubs } });
+
+    const items = screen.getAllByTestId("feed-item");
+    expect(items.length).toBe(2);
+    expect(screen.getByText("Local Chapter")).toBeTruthy();
+    expect(screen.getByText("Youth Wing")).toBeTruthy();
+  });
+});

--- a/frontend/test/components/feed/FeedItem.spec.ts
+++ b/frontend/test/components/feed/FeedItem.spec.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import FeedItem from "../../../app/components/feed/FeedItem.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+beforeEach(() => {
+  vi.stubGlobal("useLocalePath", () => (path: string) => path);
+});
+
+describe("FeedItem", () => {
+  it("renders the name as the title", async () => {
+    await render(FeedItem, {
+      props: { name: "Local Chapter", url: "/organizations/org-1/groups/group-1/about" },
+    });
+
+    expect(screen.getByText("Local Chapter")).toBeTruthy();
+  });
+
+  it("links to the given url", async () => {
+    const { container } = await render(FeedItem, {
+      props: { name: "Local Chapter", url: "/organizations/org-1/groups/group-1/about" },
+    });
+
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe(
+      "/organizations/org-1/groups/group-1/about"
+    );
+    expect(link?.getAttribute("aria-label")).toBe(
+      getEnglishText("i18n.components._global.navigate_to_group_aria_label")
+    );
+  });
+
+  it("shows the people icon when the url is an activist.org link", async () => {
+    await render(FeedItem, {
+      props: {
+        name: "Local Chapter",
+        url: "https://activist.org/organizations/org-1/groups/group-1/about",
+      },
+    });
+
+    expect(screen.getByRole("img", { name: "bi:people" })).toBeTruthy();
+  });
+
+  it("shows the mastodon icon for a mastodon link", async () => {
+    await render(FeedItem, {
+      props: { name: "Our Mastodon", url: "https://mastodon.social/@ourorg" },
+    });
+
+    expect(
+      screen.getByRole("img", { name: "simple-icons:mastodon" })
+    ).toBeTruthy();
+  });
+
+  it("shows the facebook icon for a facebook link", async () => {
+    await render(FeedItem, {
+      props: { name: "Our Facebook", url: "https://facebook.com/ourorg" },
+    });
+
+    expect(
+      screen.getByRole("img", { name: "simple-icons:facebook" })
+    ).toBeTruthy();
+  });
+
+  it("shows the instagram icon for an instagram link", async () => {
+    await render(FeedItem, {
+      props: { name: "Our Instagram", url: "https://instagram.com/ourorg" },
+    });
+
+    expect(
+      screen.getByRole("img", { name: "simple-icons:instagram" })
+    ).toBeTruthy();
+  });
+
+  it("shows the fallback group icon in the image area when there is no imgUrl", async () => {
+    await render(FeedItem, {
+      props: {
+        name: "Local Chapter",
+        url: "/organizations/org-1/groups/group-1/about",
+      },
+    });
+
+    expect(screen.getByRole("img", { name: "IconGroup" })).toBeTruthy();
+  });
+});

--- a/frontend/test/components/footer/FooterWebsite.spec.ts
+++ b/frontend/test/components/footer/FooterWebsite.spec.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import FooterWebsite from "../../../app/components/footer/FooterWebsite.vue";
+import { getEnglishText } from "../../../shared/utils/i18n";
+import render from "../../render";
+
+beforeEach(() => {
+  vi.stubGlobal("useLocalePath", () => (path: string) => path);
+});
+
+describe("FooterWebsite", () => {
+  it("renders the tagline", async () => {
+    await render(FooterWebsite);
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.footer_website.activist_tagline")
+      )
+    ).toBeTruthy();
+  });
+
+  it("renders the platform links, including the internal roadmap link", async () => {
+    const { container } = await render(FooterWebsite);
+
+    const sourceCodeLink = screen.getByRole("link", {
+      name: getEnglishText(
+        "i18n.components.footer_website.source_code_aria_label"
+      ),
+    });
+    expect(sourceCodeLink.getAttribute("href")).toBe(
+      "https://github.com/activist-org/activist"
+    );
+
+    const roadmapLink = screen.getByRole("link", {
+      name: getEnglishText("i18n.components.footer_website.road_map_aria_label"),
+    });
+    expect(roadmapLink.getAttribute("href")).toBe(
+      "https://docs.activist.org/activist/product/about/roadmap"
+    );
+    // Internal links go through localePath.
+    expect(container.contains(roadmapLink)).toBe(true);
+  });
+
+  it("renders the connect links", async () => {
+    await render(FooterWebsite);
+
+    expect(
+      screen.getByRole("link", {
+        name: getEnglishText("i18n.components._global.github_aria_label"),
+      })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", {
+        name: getEnglishText("i18n.components._global.matrix_aria_label"),
+      })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", {
+        name: getEnglishText("i18n.components._global.instagram_aria_label"),
+      })
+    ).toBeTruthy();
+  });
+
+  it("renders the resources, organization, and legal links", async () => {
+    await render(FooterWebsite);
+
+    expect(
+      screen.getByRole("link", {
+        name: getEnglishText(
+          "i18n.components.footer_website.documentation_aria_label"
+        ),
+      })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", {
+        name: getEnglishText("i18n.components.footer_website.about_aria_label"),
+      })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", {
+        name: getEnglishText(
+          "i18n.components.footer_website.trademark_policy_aria_label"
+        ),
+      })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", {
+        name: getEnglishText(
+          "i18n.components.footer_website.privacy_policy_aria_label"
+        ),
+      })
+    ).toBeTruthy();
+  });
+
+  it("renders the Netlify and copyright notices", async () => {
+    await render(FooterWebsite);
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.footer_website.powered_by_netlify")
+      )
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.components.footer_website.copyright")
+      )
+    ).toBeTruthy();
+  });
+});

--- a/frontend/test/components/form/selector/FormSelectorComboboxGroups.spec.ts
+++ b/frontend/test/components/form/selector/FormSelectorComboboxGroups.spec.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { describe, expect, it, vi } from "vitest";
+
+import FormSelectorComboboxGroups from "../../../../app/components/form/selector/FormSelectorComboboxGroups.vue";
+import { createMockGroup } from "../../../mocks/factories";
+import render from "../../../render";
+
+const mockGetMore = vi.fn();
+
+const stubs = {
+  FormSelectorCombobox: {
+    props: [
+      "id",
+      "canFetchMore",
+      "fetchMore",
+      "hasColOptions",
+      "label",
+      "options",
+      "selectedOptions",
+    ],
+    emits: ["update:selectedOptions"],
+    template: `
+      <div
+        data-testid="form-selector-combobox"
+        :data-options="JSON.stringify(options)"
+        :data-selected="JSON.stringify(selectedOptions)"
+        :data-label="label"
+        :data-has-col-options="hasColOptions"
+      >
+        <button
+          data-testid="emit-selection"
+          @click="$emit('update:selectedOptions', options.map((o) => o.value))"
+        />
+      </div>
+    `,
+  },
+};
+
+mockNuxtImport("useGetGroups", () => () => ({
+  data: {
+    value: [
+      createMockGroup({ id: "group-1", name: "Local Chapter" }),
+      createMockGroup({ id: "group-2", name: "Youth Wing" }),
+    ],
+  },
+  getMore: mockGetMore,
+}));
+
+describe("FormSelectorComboboxGroups", () => {
+  it("builds combobox options from the fetched groups", async () => {
+    const { container } = await render(FormSelectorComboboxGroups, {
+      props: {
+        id: "groups-selector",
+        selectedGroups: [],
+        linkedOrganizations: ["org-1"],
+        label: "Groups",
+      },
+      global: { stubs },
+    });
+
+    const combobox = container.querySelector(
+      "[data-testid='form-selector-combobox']"
+    )!;
+    expect(JSON.parse(combobox.getAttribute("data-options")!)).toEqual([
+      { label: "Local Chapter", id: "group-1", value: "group-1" },
+      { label: "Youth Wing", id: "group-2", value: "group-2" },
+    ]);
+  });
+
+  it("passes the label, hasColOptions, and selectedGroups through", async () => {
+    const selectedGroup = createMockGroup({ id: "group-2" });
+
+    const { container } = await render(FormSelectorComboboxGroups, {
+      props: {
+        id: "groups-selector",
+        selectedGroups: [selectedGroup],
+        linkedOrganizations: [],
+        label: "Groups",
+        hasColOptions: false,
+      },
+      global: { stubs },
+    });
+
+    const combobox = container.querySelector(
+      "[data-testid='form-selector-combobox']"
+    )!;
+    expect(combobox.getAttribute("data-label")).toBe("Groups");
+    expect(combobox.getAttribute("data-has-col-options")).toBe("false");
+    expect(JSON.parse(combobox.getAttribute("data-selected")!)).toEqual([
+      selectedGroup,
+    ]);
+  });
+
+  it("defaults selectedOptions to an empty array when selectedGroups is not provided", async () => {
+    const { container } = await render(FormSelectorComboboxGroups, {
+      props: {
+        id: "groups-selector",
+        selectedGroups: undefined as never,
+        linkedOrganizations: [],
+        label: "Groups",
+      },
+      global: { stubs },
+    });
+
+    const combobox = container.querySelector(
+      "[data-testid='form-selector-combobox']"
+    )!;
+    expect(combobox.getAttribute("data-selected")).toBe("[]");
+  });
+
+  it("emits update:selectedGroups when the combobox selection changes", async () => {
+    const { emitted } = await render(FormSelectorComboboxGroups, {
+      props: {
+        id: "groups-selector",
+        selectedGroups: [],
+        linkedOrganizations: [],
+        label: "Groups",
+      },
+      global: { stubs },
+    });
+
+    await fireEvent.click(screen.getByTestId("emit-selection"));
+
+    expect(emitted()["update:selectedGroups"]).toEqual([
+      [["group-1", "group-2"]],
+    ]);
+  });
+});

--- a/frontend/test/components/form/selector/FormSelectorComboboxOrganizations.spec.ts
+++ b/frontend/test/components/form/selector/FormSelectorComboboxOrganizations.spec.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { fireEvent, screen } from "@testing-library/vue";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import FormSelectorComboboxOrganizations from "../../../../app/components/form/selector/FormSelectorComboboxOrganizations.vue";
+import { createMockOrganization } from "../../../mocks/factories";
+import render from "../../../render";
+
+const mockGetMore = vi.fn();
+const mockPending = { value: false };
+
+const stubs = {
+  FormSelectorCombobox: {
+    props: [
+      "id",
+      "disabled",
+      "canFetchMore",
+      "fetchMore",
+      "hasColOptions",
+      "label",
+      "options",
+      "selectedOptions",
+      "showLoadingSlot",
+    ],
+    emits: ["update:selectedOptions", "update:filterValue"],
+    template: `
+      <div
+        data-testid="form-selector-combobox"
+        :data-options="JSON.stringify(options)"
+        :data-selected="JSON.stringify(selectedOptions)"
+        :data-label="label"
+        :data-disabled="disabled"
+        :data-show-loading-slot="showLoadingSlot"
+      >
+        <button
+          data-testid="emit-selection"
+          @click="$emit('update:selectedOptions', options.map((o) => o.value))"
+        />
+        <button
+          data-testid="emit-filter"
+          @click="$emit('update:filterValue', 'search text')"
+        />
+      </div>
+    `,
+  },
+};
+
+mockNuxtImport("useGetOrganizationsByUser", () => () => ({
+  data: {
+    value: [
+      createMockOrganization({ id: "org-1", name: "Human Rights Watch" }),
+      createMockOrganization({ id: "org-2", name: "Local Advocacy Group" }),
+    ],
+  },
+  getMore: mockGetMore,
+  pending: mockPending,
+}));
+
+beforeEach(() => {
+  mockPending.value = false;
+  vi.stubGlobal("useDebounce", () => ({
+    debounce: <T extends (...args: unknown[]) => void>(fn: T) => fn,
+  }));
+});
+
+describe("FormSelectorComboboxOrganizations", () => {
+  it("builds combobox options from the fetched organizations", async () => {
+    const { container } = await render(FormSelectorComboboxOrganizations, {
+      props: {
+        id: "orgs-selector",
+        selectedOrganizations: [],
+        label: "Organizations",
+      },
+      global: { stubs },
+    });
+
+    const combobox = container.querySelector(
+      "[data-testid='form-selector-combobox']"
+    )!;
+    expect(JSON.parse(combobox.getAttribute("data-options")!)).toEqual([
+      { label: "Human Rights Watch", id: "org-1", value: "org-1" },
+      { label: "Local Advocacy Group", id: "org-2", value: "org-2" },
+    ]);
+  });
+
+  it("passes the label, disabled, and selectedOrganizations through", async () => {
+    const selectedOrganization = createMockOrganization({ id: "org-2" });
+
+    const { container } = await render(FormSelectorComboboxOrganizations, {
+      props: {
+        id: "orgs-selector",
+        selectedOrganizations: [selectedOrganization],
+        label: "Organizations",
+        disabled: true,
+      },
+      global: { stubs },
+    });
+
+    const combobox = container.querySelector(
+      "[data-testid='form-selector-combobox']"
+    )!;
+    expect(combobox.getAttribute("data-label")).toBe("Organizations");
+    expect(combobox.getAttribute("data-disabled")).toBe("true");
+    expect(JSON.parse(combobox.getAttribute("data-selected")!)).toEqual([
+      selectedOrganization,
+    ]);
+  });
+
+  it("defaults selectedOptions to an empty array when selectedOrganizations is not provided", async () => {
+    const { container } = await render(FormSelectorComboboxOrganizations, {
+      props: {
+        id: "orgs-selector",
+        selectedOrganizations: undefined as never,
+        label: "Organizations",
+      },
+      global: { stubs },
+    });
+
+    const combobox = container.querySelector(
+      "[data-testid='form-selector-combobox']"
+    )!;
+    expect(combobox.getAttribute("data-selected")).toBe("[]");
+  });
+
+  it("reflects the pending fetch state as showLoadingSlot", async () => {
+    mockPending.value = true;
+
+    const { container } = await render(FormSelectorComboboxOrganizations, {
+      props: {
+        id: "orgs-selector",
+        selectedOrganizations: [],
+        label: "Organizations",
+      },
+      global: { stubs },
+    });
+
+    const combobox = container.querySelector(
+      "[data-testid='form-selector-combobox']"
+    )!;
+    expect(combobox.getAttribute("data-show-loading-slot")).toBe("true");
+  });
+
+  it("emits update:selectedOrganizations when the combobox selection changes", async () => {
+    const { emitted } = await render(FormSelectorComboboxOrganizations, {
+      props: {
+        id: "orgs-selector",
+        selectedOrganizations: [],
+        label: "Organizations",
+      },
+      global: { stubs },
+    });
+
+    await fireEvent.click(screen.getByTestId("emit-selection"));
+
+    expect(emitted()["update:selectedOrganizations"]).toEqual([
+      [["org-1", "org-2"]],
+    ]);
+  });
+
+  it("does not throw when the filter value changes", async () => {
+    await render(FormSelectorComboboxOrganizations, {
+      props: {
+        id: "orgs-selector",
+        selectedOrganizations: [],
+        label: "Organizations",
+      },
+      global: { stubs },
+    });
+
+    await expect(
+      fireEvent.click(screen.getByTestId("emit-filter"))
+    ).resolves.not.toThrow();
+  });
+});

--- a/frontend/test/pages/auth/confirm/email.spec.ts
+++ b/frontend/test/pages/auth/confirm/email.spec.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import ConfirmEmail from "../../../../app/pages/auth/confirm/email.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import render from "../../../render";
+
+describe("confirm/email", () => {
+  it("renders the confirmation title", async () => {
+    await render(ConfirmEmail);
+
+    expect(
+      screen.getByText(getEnglishText("i18n.pages.auth.confirm.email.title"))
+    ).toBeTruthy();
+  });
+
+  it("renders the issues prompt text", async () => {
+    await render(ConfirmEmail);
+
+    expect(
+      screen.getByText(
+        getEnglishText("i18n.pages.auth.confirm.email.issues_prompt"),
+        { exact: false }
+      )
+    ).toBeTruthy();
+  });
+
+  it("renders the Matrix support link with the correct href", async () => {
+    await render(ConfirmEmail);
+
+    const link = screen.getByRole("link", {
+      name: /matrix:activist_community/i,
+    });
+    expect(link.getAttribute("href")).toBe(
+      "https://matrix.to/#/#activist_community:matrix.org"
+    );
+  });
+});

--- a/frontend/test/pages/auth/pwreset/email.spec.ts
+++ b/frontend/test/pages/auth/pwreset/email.spec.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { fireEvent, screen, waitFor } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import PwresetEmail from "../../../../app/pages/auth/pwreset/email.vue";
+import { getEnglishText } from "../../../../shared/utils/i18n";
+import render from "../../../render";
+import { createUseRouterMock } from "../../../mocks/composableMocks";
+
+// Provide a router stub so the submit handler can call useRouter().push without throwing.
+globalThis.useRouter = createUseRouterMock();
+
+describe("pwreset/email", () => {
+  it("renders the page title", async () => {
+    await render(PwresetEmail);
+
+    expect(
+      screen.getByText(getEnglishText("i18n.pages.auth.pwreset.email.title"))
+    ).toBeTruthy();
+  });
+
+  it("renders the email input with an interactive border", async () => {
+    await render(PwresetEmail);
+
+    const border = screen.getByTestId("form-item-email-border");
+    expect(border.className).toMatch("border-interactive");
+  });
+
+  it("shows error border when submitted with no email", async () => {
+    await render(PwresetEmail);
+
+    const submitButton = screen.getByRole("button", {
+      name: getEnglishText("i18n.components.submit_aria_label"),
+    });
+    await fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("form-item-email-border").className
+      ).toMatch("border-action-red dark:border-action-red");
+    });
+  });
+
+  it("shows error border when submitted with an invalid email format", async () => {
+    await render(PwresetEmail);
+
+    const emailInput = screen.getByLabelText(
+      getEnglishText("i18n.pages.auth._global.enter_email")
+    );
+    await fireEvent.update(emailInput, "not-an-email");
+
+    const submitButton = screen.getByRole("button", {
+      name: getEnglishText("i18n.components.submit_aria_label"),
+    });
+    await fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("form-item-email-border").className
+      ).toMatch("border-action-red dark:border-action-red");
+    });
+  });
+
+  it("shows an error message for an invalid email format", async () => {
+    await render(PwresetEmail);
+
+    const emailInput = screen.getByLabelText(
+      getEnglishText("i18n.pages.auth._global.enter_email")
+    );
+    await fireEvent.update(emailInput, "not-an-email");
+
+    const submitButton = screen.getByRole("button", {
+      name: getEnglishText("i18n.components.submit_aria_label"),
+    });
+    await fireEvent.click(submitButton);
+
+    // The FormErrorMessage renders the raw i18n key as its text content.
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeTruthy();
+      expect(screen.getByTestId("form-item-email-error").textContent).toContain(
+        "i18n.pages.auth._global.invalid_email"
+      );
+    });
+  });
+
+  it.todo("navigates to home on successful password reset email submission");
+  it.todo("shows an error when the password reset email request fails");
+});

--- a/frontend/test/vitest-globals.d.ts
+++ b/frontend/test/vitest-globals.d.ts
@@ -31,6 +31,11 @@ declare global {
     params: Record<string, unknown>;
     query: Record<string, unknown>;
   };
+  // create a mock for useRouter that includes push and currentRoute
+  var useRouter: () => {
+    push: (...args: unknown[]) => unknown;
+    currentRoute: { value: { name: string } };
+  };
   var useDevice: () => {
     isMobile: boolean;
     isTablet: boolean;


### PR DESCRIPTION
## Summary
- Adds unit tests for `Card*` components (change-account-info, connect, discussion, about, and standalone cards), dropdown components, `ComboboxTopics`, and `Discussion`/`DiscussionHeader`.
- Adds unit tests for `Feed`, `FeedItem`, `FooterWebsite`, `Events*` components, and `FormSelectorCombobox*` selectors.
- Includes a couple of accompanying bug fixes surfaced while writing tests: a stray assignment (`=` vs `===`) in `FeedItem.vue` that made the PEOPLE icon always render, and an incorrect `aria-label` binding in `FooterWebsite.vue` that used the visible link name instead of each link's dedicated `ariaLabel`.

## Test plan
- [x] `frontend/test/components/**` unit tests added/pass locally via Vitest
- [ ] CI green