### PR TITLE
test(e2e): add organization FAQ and resource pages empty state tests (#2143)

### DIFF
--- a/frontend/test-e2e/specs/all/organizations/organization-faq/organization-faq-empty-states.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/organization-faq/organization-faq-empty-states.spec.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * Organization FAQ lists come from `useGetOrganization` (embedded `faqEntries`), not a separate list URL.
+ * Mock GET `/api/public/communities/organizations/:id` before navigation (client-only fetch; see nuxt `ssr: false`).
+ */
+import { getEnglishText } from "#shared/utils/i18n";
+import { MEMBER_AUTH_STATE_PATH } from "~/test-e2e/constants/authPaths";
+import { expect, test } from "~/test-e2e/global-fixtures";
+import { newOrganizationPage } from "~/test-e2e/page-objects/organization/OrganizationPage";
+import {
+  MOCK_ORGANIZATION_EMPTY_STATE_ID,
+  mockOrganizationDetailPayload,
+  routeMockPublicOrganizationDetail,
+  sampleOrganizationFaqEntryForMock,
+} from "~/test-e2e/utils/mock-public-organization-detail";
+import { logTestPath } from "~/test-e2e/utils/test-traceability";
+
+test.describe(
+  "Admin sees editable empty state on organization FAQ page",
+  { tag: ["@desktop", "@mobile"] },
+  () => {
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    test("Shows empty state with editable copy when organization has no FAQ entries", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await routeMockPublicOrganizationDetail(
+        page,
+        MOCK_ORGANIZATION_EMPTY_STATE_ID,
+        mockOrganizationDetailPayload(MOCK_ORGANIZATION_EMPTY_STATE_ID, { faqEntries: [] })
+      );
+      await page.goto(`/organizations/${MOCK_ORGANIZATION_EMPTY_STATE_ID}/faq`);
+
+      const { faqPage } = newOrganizationPage(page);
+      await expect(faqPage.emptyState).toBeVisible({ timeout: 15000 });
+      await expect(faqPage.faqList).not.toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(
+            getEnglishText("i18n.components.empty_state.faq_header"),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          level: 4,
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.empty_state.message_with_permission"
+            ),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(faqPage.newFAQButton).toBeVisible();
+    });
+
+    test("Does not show empty state when organization has FAQ entries", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await routeMockPublicOrganizationDetail(
+        page,
+        MOCK_ORGANIZATION_EMPTY_STATE_ID,
+        mockOrganizationDetailPayload(MOCK_ORGANIZATION_EMPTY_STATE_ID, {
+          faqEntries: [sampleOrganizationFaqEntryForMock],
+        })
+      );
+      await page.goto(`/organizations/${MOCK_ORGANIZATION_EMPTY_STATE_ID}/faq`);
+
+      const { faqPage } = newOrganizationPage(page);
+      await expect(faqPage.faqList).toBeVisible({ timeout: 15000 });
+      await expect(faqPage.faqCards).toHaveCount(1);
+      await expect(faqPage.emptyState).not.toBeVisible();
+    });
+  }
+);
+
+test.describe(
+  "Non-admin member sees read-only empty state on organization FAQ page",
+  { tag: ["@desktop", "@mobile", "@member"] },
+  () => {
+    test.use({ storageState: MEMBER_AUTH_STATE_PATH });
+
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    test("Shows read-only empty state when organization has no FAQ entries", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await routeMockPublicOrganizationDetail(
+        page,
+        MOCK_ORGANIZATION_EMPTY_STATE_ID,
+        mockOrganizationDetailPayload(MOCK_ORGANIZATION_EMPTY_STATE_ID, { faqEntries: [] })
+      );
+      await page.goto(`/organizations/${MOCK_ORGANIZATION_EMPTY_STATE_ID}/faq`);
+
+      const { faqPage } = newOrganizationPage(page);
+      await expect(faqPage.emptyState).toBeVisible({ timeout: 15000 });
+      await expect(
+        page.getByRole("heading", {
+          level: 4,
+          name: new RegExp(
+            getEnglishText("i18n.components.empty_state.message_no_permission"),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(faqPage.newFAQButton).not.toBeVisible();
+    });
+  }
+);

--- a/frontend/test-e2e/specs/all/organizations/organization-resources/organization-resources-empty-states.spec.ts
+++ b/frontend/test-e2e/specs/all/organizations/organization-resources/organization-resources-empty-states.spec.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * Organization resources lists come from `useGetOrganization` (embedded `resources`), not a separate list URL.
+ * Mock GET `/api/public/communities/organizations/:id` before navigation (client-only fetch; see nuxt `ssr: false`).
+ */
+import { getEnglishText } from "#shared/utils/i18n";
+import { MEMBER_AUTH_STATE_PATH } from "~/test-e2e/constants/authPaths";
+import { expect, test } from "~/test-e2e/global-fixtures";
+import { newOrganizationPage } from "~/test-e2e/page-objects/organization/OrganizationPage";
+import {
+  MOCK_ORGANIZATION_EMPTY_STATE_ID,
+  mockOrganizationDetailPayload,
+  routeMockPublicOrganizationDetail,
+  sampleOrganizationResourceForMock,
+} from "~/test-e2e/utils/mock-public-organization-detail";
+import { logTestPath } from "~/test-e2e/utils/test-traceability";
+
+test.describe(
+  "Admin sees editable empty state on organization resources page",
+  { tag: ["@desktop", "@mobile"] },
+  () => {
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    test("Shows empty state with editable copy when organization has no resources", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await routeMockPublicOrganizationDetail(
+        page,
+        MOCK_ORGANIZATION_EMPTY_STATE_ID,
+        mockOrganizationDetailPayload(MOCK_ORGANIZATION_EMPTY_STATE_ID, { resources: [] })
+      );
+      await page.goto(`/organizations/${MOCK_ORGANIZATION_EMPTY_STATE_ID}/resources`);
+
+      const { resourcesPage } = newOrganizationPage(page);
+      await expect(resourcesPage.emptyState).toBeVisible({ timeout: 15000 });
+      await expect(resourcesPage.resourcesList).not.toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          name: new RegExp(
+            getEnglishText("i18n.components.empty_state.resources_header"),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", {
+          level: 4,
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.empty_state.message_with_permission"
+            ),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", {
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.empty_state.create_resource_aria_label"
+            ),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(resourcesPage.newResourceButton).toBeVisible();
+    });
+
+    test("Does not show empty state when organization has resources", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await routeMockPublicOrganizationDetail(
+        page,
+        MOCK_ORGANIZATION_EMPTY_STATE_ID,
+        mockOrganizationDetailPayload(MOCK_ORGANIZATION_EMPTY_STATE_ID, {
+          resources: [sampleOrganizationResourceForMock],
+        })
+      );
+      await page.goto(`/organizations/${MOCK_ORGANIZATION_EMPTY_STATE_ID}/resources`);
+
+      const { resourcesPage } = newOrganizationPage(page);
+      await expect(resourcesPage.resourcesList).toBeVisible({
+        timeout: 15000,
+      });
+      await expect(resourcesPage.resourceCards).toHaveCount(1);
+      await expect(resourcesPage.emptyState).not.toBeVisible();
+    });
+  }
+);
+
+test.describe(
+  "Non-admin member sees read-only empty state on organization resources page",
+  { tag: ["@desktop", "@mobile", "@member"] },
+  () => {
+    test.use({ storageState: MEMBER_AUTH_STATE_PATH });
+
+    test.afterEach(async ({ page }) => {
+      await page.unrouteAll();
+    });
+
+    test("Shows read-only empty state when organization has no resources", async ({
+      page,
+    }, testInfo) => {
+      logTestPath(testInfo);
+      await routeMockPublicOrganizationDetail(
+        page,
+        MOCK_ORGANIZATION_EMPTY_STATE_ID,
+        mockOrganizationDetailPayload(MOCK_ORGANIZATION_EMPTY_STATE_ID, { resources: [] })
+      );
+      await page.goto(`/organizations/${MOCK_ORGANIZATION_EMPTY_STATE_ID}/resources`);
+
+      const { resourcesPage } = newOrganizationPage(page);
+      await expect(resourcesPage.emptyState).toBeVisible({ timeout: 15000 });
+      await expect(
+        page.getByRole("heading", {
+          level: 4,
+          name: new RegExp(
+            getEnglishText("i18n.components.empty_state.message_no_permission"),
+            "i"
+          ),
+        })
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", {
+          name: new RegExp(
+            getEnglishText(
+              "i18n.components.empty_state.create_resource_aria_label"
+            ),
+            "i"
+          ),
+        })
+      ).not.toBeVisible();
+      await expect(resourcesPage.newResourceButton).not.toBeVisible();
+    });
+  }
+);

--- a/frontend/test-e2e/utils/mock-public-organization-detail.ts
+++ b/frontend/test-e2e/utils/mock-public-organization-detail.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { Page } from "@playwright/test";
+
+/** Stable UUID for cold `page.goto` + `page.route` organization-detail mocks (SSR off). */
+export const MOCK_ORGANIZATION_EMPTY_STATE_ID = "00000000-0000-4000-8000-00000000o214";
+
+export function isPublicOrganizationDetailGet(url: string): boolean {
+  try {
+    const u = new URL(url);
+    const m = u.pathname.match(/\/api\/public\/communities\/organizations\/([^/?#]+)$/);
+    if (!m?.[1]) return false;
+    return /^[0-9a-f-]{36}$/i.test(m[1]);
+  } catch {
+    return false;
+  }
+}
+
+function organizationIdFromDetailUrl(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const m = u.pathname.match(/\/api\/public\/communities\/organizations\/([^/?#]+)$/);
+    return m?.[1]?.toLowerCase() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fulfill GET `/api/public/communities/organizations/:id` for a single org id; other requests continue.
+ * Matches the client fetch used by `getOrganization` (`withoutAuth` → public API base).
+ */
+export async function routeMockPublicOrganizationDetail(
+  page: Page,
+  expectedOrgId: string,
+  body: Record<string, unknown>
+): Promise<void> {
+  const want = expectedOrgId.toLowerCase();
+  await page.route("**/api/public/communities/organizations/**", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    if (!isPublicOrganizationDetailGet(route.request().url())) {
+      await route.continue();
+      return;
+    }
+    const id = organizationIdFromDetailUrl(route.request().url());
+    if (!id || id !== want) {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    });
+  });
+}
+
+/** Minimal organization JSON for `mapOrganization` / FAQ + resources subpages. */
+export function mockOrganizationDetailPayload(
+  orgId: string,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    id: orgId,
+    name: "E2E empty-state organization",
+    tagline: "E2E tagline",
+    status: "active",
+    createdBy: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    socialLinks: [],
+    resources: [],
+    faqEntries: [],
+    texts: [],
+    groups: [],
+    location: null,
+    ...overrides,
+  };
+}
+
+export const sampleOrganizationFaqEntryForMock = {
+  id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+  iso: "en",
+  order: 0,
+  question: "E2E question?",
+  answer: "E2E answer.",
+};
+
+export const sampleOrganizationResourceForMock = {
+  id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+  name: "E2E resource",
+  description: "E2E resource description",
+  url: "https://example.com/e2e-resource",
+  order: 0,
+  createdBy: {
+    id: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    userName: "e2e",
+    name: "E2E User",
+    socialLinks: [],
+  },
+};


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have added E2E tests for empty states and permission variants

---

### Description

Adds Playwright E2E specs for Organization FAQ () and Organization Resources () pages to verify empty states when embedded  and  arrays are empty vs when items are present.

#### What was added:
1. **Mock Utility** ():
   - Created helper  matching  ( → ).
   - Added  generator and sample mock items.

2. **Organization FAQ Empty-State Spec** ():
   - Admin view: Asserts  component visibility, headers, and  presence.
   - Viewer / non-admin view: Asserts read-only empty state copy () and absence of .
   - Non-empty view: Asserts empty state is hidden and FAQ cards are rendered when  has items.

3. **Organization Resources Empty-State Spec** ():
   - Admin view: Asserts  component visibility, headers, and  / link presence.
   - Viewer / non-admin view: Asserts read-only empty state copy () and absence of .
   - Non-empty view: Asserts empty state is hidden and resource cards are rendered when  has items.

### Related issue

- Closes #2143