### PR TITLE
fix(frontend): reset pagination page state immediately on filter changes (#2204)

### DIFF
--- a/frontend/app/composables/queries/useGetEvents.ts
+++ b/frontend/app/composables/queries/useGetEvents.ts
@@ -9,6 +9,16 @@ export function useGetEvents(
   const page = ref(1);
   const { handleError } = useAppError();
   const eventFilters = computed(() => unref(filters));
+
+  watch(
+    eventFilters,
+    () => {
+      page.value = 1;
+      store.setPage(1);
+    },
+    { deep: true }
+  );
+
   // UseAsyncData for SSR, hydration, and cache.
   const { data, pending, error, refresh } = useAsyncData<CommunityEvent[]>(
     () => getKeyForGetEvents(),

--- a/frontend/app/composables/queries/useGetOrganizations.ts
+++ b/frontend/app/composables/queries/useGetOrganizations.ts
@@ -9,6 +9,16 @@ export function useGetOrganizations(
   const page = ref(1);
   const { handleError } = useAppError();
   const orgFilters = computed(() => unref(filters));
+
+  watch(
+    orgFilters,
+    () => {
+      page.value = 1;
+      store.setPage(1);
+    },
+    { deep: true }
+  );
+
   // Use AsyncData for SSR, hydration, and cache.
   const { data, pending, error, refresh } = useAsyncData<Organization[]>(
     () => getKeyForGetOrganizations(),


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my changes locally

---

### Description

Fixes an issue where paginated events (`useGetEvents`) and organizations (`useGetOrganizations`) lists retained a stale `page` ref (e.g. `page = 2`) when filters changed, causing pagination inconsistency, duplicate cards, or page skipping.

- **Root Cause**: `page.value` was only reset to `1` inside the `useAsyncData` callback after the API fetch completed. While the fetch was in flight or when `getMore()` was invoked, `page.value` remained at its pre-filter page number.
- **Fix**: Added explicit deep watchers on `eventFilters` and `orgFilters` in `useGetEvents.ts` and `useGetOrganizations.ts` to immediately reset `page.value = 1` and `store.setPage(1)` as soon as filters change.

### Related issue

- Fixes #2204