### PR TITLE
feat(frontend): add useAppAnnouncer composable for accessibility screen reader live updates (#2070)

### DIFF
--- a/frontend/app/composables/generic/index.ts
+++ b/frontend/app/composables/generic/index.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+export * from "./useAppAnnouncer";
 export * from "./useAppError";
 export * from "./useBreakpoint";
 export * from "./useCustomInfiniteScroll";

--- a/frontend/app/composables/generic/useAppAnnouncer.ts
+++ b/frontend/app/composables/generic/useAppAnnouncer.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/**
+ * Composable for handling accessibility screen reader live announcements.
+ * Standardizes ARIA live region announcements for dynamic UI updates,
+ * toasts, modal state changes, and async error/success messages.
+ */
+export function useAppAnnouncer() {
+  const announceMessage = (
+    message: string,
+    politeness: "polite" | "assertive" = "polite"
+  ) => {
+    if (!message) return;
+    try {
+      const announcer = useAnnouncer();
+      if (announcer && typeof announcer.announce === "function") {
+        announcer.announce(message, politeness);
+      }
+    } catch {
+      // Fallback if useAnnouncer is unavailable in test or non-Nuxt contexts
+    }
+  };
+
+  const announcePolite = (message: string) => {
+    announceMessage(message, "polite");
+  };
+
+  const announceAssertive = (message: string) => {
+    announceMessage(message, "assertive");
+  };
+
+  return {
+    announceMessage,
+    announcePolite,
+    announceAssertive,
+  };
+}

--- a/frontend/app/composables/generic/useToaster.ts
+++ b/frontend/app/composables/generic/useToaster.ts
@@ -2,14 +2,19 @@
 import { toast } from "vue-sonner";
 
 export const useToaster = () => {
+  const { announcePolite, announceAssertive } = useAppAnnouncer();
+
   const showToastError = (message: string) => {
     toast.error(message);
+    announceAssertive(message);
   };
   const showToastInfo = (message: string) => {
     toast.info(message);
+    announcePolite(message);
   };
   const showToastSuccess = (message: string) => {
     toast.success(message);
+    announcePolite(message);
   };
   return {
     showToastError,

--- a/frontend/test/composables/useAppAnnouncer.spec.ts
+++ b/frontend/test/composables/useAppAnnouncer.spec.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { describe, expect, it } from "vitest";
+
+import { useAppAnnouncer } from "../../app/composables/generic/useAppAnnouncer";
+
+describe("useAppAnnouncer composable", () => {
+  it("provides announceMessage, announcePolite, and announceAssertive methods", () => {
+    const announcer = useAppAnnouncer();
+    expect(typeof announcer.announceMessage).toBe("function");
+    expect(typeof announcer.announcePolite).toBe("function");
+    expect(typeof announcer.announceAssertive).toBe("function");
+  });
+
+  it("handles missing useAnnouncer context gracefully", () => {
+    const announcer = useAppAnnouncer();
+    expect(() => announcer.announcePolite("Test message")).not.toThrow();
+  });
+});


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have added unit tests for the new composable

---

### Description

Adds an accessible screen reader announcement composable (`useAppAnnouncer`) to standardize live region announcements for dynamic UI updates, toast notifications, and async errors/successes across the application.

#### What was added:
1. **useAppAnnouncer Composable** (`frontend/app/composables/generic/useAppAnnouncer.ts`):
   - Integrates with Nuxt's built-in `useAnnouncer()` to issue ARIA live announcements with `polite` and `assertive` priorities.
   - Handles graceful fallback for testing/non-Nuxt contexts.

2. **Toaster Integration** (`frontend/app/composables/generic/useToaster.ts`):
   - Automatically triggers assertive announcements for error toasts and polite announcements for info/success toasts.

3. **Unit Tests** (`frontend/test/composables/useAppAnnouncer.spec.ts`):
   - Unit test coverage for `useAppAnnouncer` methods and error resilience.

### Related issue

- Closes #2070