### PR TITLE
fix(frontend): clear Nuxt payload cache before refresh to prevent stale deduplicated data on rapid saves (#2250)

### DIFF
--- a/frontend/app/composables/queries/useGetGroup.ts
+++ b/frontend/app/composables/queries/useGetGroup.ts
@@ -64,7 +64,8 @@ export function useGetGroup(id: MaybeRef<string>) {
       return;
     }
 
-    // Let useAsyncData refetch and update store in the success path above.
+    // Clear cached payload before refetching to prevent silent deduplication of stale data.
+    clearNuxtData(key.value);
     await refreshNuxtData(key.value);
   }
 

--- a/frontend/app/composables/queries/useGetOrganization.ts
+++ b/frontend/app/composables/queries/useGetOrganization.ts
@@ -61,7 +61,8 @@ export function useGetOrganization(id: MaybeRef<string>) {
 
   async function refresh() {
     if (!key.value) return;
-    // Let useAsyncData refetch and update store in the success path above.
+    // Clear cached payload before refetching to prevent silent deduplication of stale data.
+    clearNuxtData(key.value);
     await refreshNuxtData(key.value);
   }
 

--- a/frontend/app/composables/queries/useGetOrganizationEvents.ts
+++ b/frontend/app/composables/queries/useGetOrganizationEvents.ts
@@ -98,6 +98,7 @@ export function useGetOrganizationEvents(
     if (organizationId.value) {
       store.clearEvents();
     }
+    clearNuxtData(key.value);
     // Let useAsyncData refetch and update store in the success path above.
     await refreshNuxtData(key.value);
   }


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my changes locally

---

### Description

Fixes an issue where rapid consecutive mutations/saves (e.g., creating, editing, or deleting FAQ entries or social links in quick succession) resulted in stale UI content because Nuxt's `useAsyncData` deduplicated incoming `refreshNuxtData(key)` requests against the ongoing pending fetch.

#### Fix:
- Added explicit `clearNuxtData(key.value)` calls prior to `refreshNuxtData(key.value)` in `useGetOrganization`, `useGetGroup`, and `useGetOrganizationEvents` to invalidate the cached payload and ensure a fresh request is dispatched to the server upon mutation completion.

### Related issue

- Fixes #2250