### PR TITLE
test: cover unauthorized group FAQ creation

### DIFF
--- a/backend/communities/groups/tests/faq/test_group_faq_create.py
+++ b/backend/communities/groups/tests/faq/test_group_faq_create.py
@@ -12,6 +12,7 @@ from communities.groups.factories import (
     GroupFactory,
     GroupFaqFactory,
 )
+from communities.groups.models import GroupFaq
 
 pytestmark = pytest.mark.django_db
 
@@ -79,14 +80,6 @@ def test_group_faq_create_ok_200() -> None:
 
     assert response.status_code == status.HTTP_201_CREATED
 
-    # MARK: Update Success with Group ID
-
-    # TODO: Test that should be added:
-    # * Test with user that is not a the creator of the group. -> 403
-    # assert response == status.HTTP_403_FORBIDDEN
-    # Test unauthenticated user
-    # assert response == status.HTTP_401_UNAUTHORIZED
-
     # MARK: Update Failure
 
     response = client.post(
@@ -101,3 +94,59 @@ def test_group_faq_create_ok_200() -> None:
     )
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_group_faq_create_forbidden_403(authenticated_client) -> None:
+    """
+    Test that a non-creator, non-staff user cannot create a Group FAQ.
+    """
+    client, user = authenticated_client
+    user.is_staff = False
+    user.save(update_fields=["is_staff"])
+
+    group_owner = UserFactory(username="group_owner")
+    group = GroupFactory(created_by=group_owner)
+    faq = GroupFaqFactory.build(group=group)
+    faq_count_before = GroupFaq.objects.count()
+
+    response = client.post(
+        path="/v1/communities/group_faqs",
+        data={
+            "iso": faq.iso,
+            "primary": faq.primary,
+            "question": faq.question,
+            "answer": faq.answer,
+            "order": faq.order,
+            "group": group.id,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert GroupFaq.objects.count() == faq_count_before
+
+
+def test_group_faq_create_unauthenticated_401() -> None:
+    """
+    Test that an unauthenticated user cannot create a Group FAQ.
+    """
+    client = APIClient()
+    group = GroupFactory()
+    faq = GroupFaqFactory.build(group=group)
+    faq_count_before = GroupFaq.objects.count()
+
+    response = client.post(
+        path="/v1/communities/group_faqs",
+        data={
+            "iso": faq.iso,
+            "primary": faq.primary,
+            "question": faq.question,
+            "answer": faq.answer,
+            "order": faq.order,
+            "group": group.id,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert GroupFaq.objects.count() == faq_count_before

--- a/backend/communities/groups/tests/faq/test_group_faq_create.py
+++ b/backend/communities/groups/tests/faq/test_group_faq_create.py
@@ -126,7 +126,7 @@ def test_group_faq_create_forbidden_403(authenticated_client) -> None:
     assert GroupFaq.objects.count() == faq_count_before
 
 
-def test_group_faq_create_unauthenticated_401() -> None:
+def test_group_faq_create_unauthorized_401() -> None:
     """
     Test that an unauthenticated user cannot create a Group FAQ.
     """


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

Adds the two missing authorization test cases in
`backend/communities/groups/tests/faq/test_group_faq_create.py`:

- verifies that an authenticated user who does not own the group receives `403 Forbidden`;
- verifies that an anonymous user receives `401 Unauthorized`;
- verifies that rejected requests do not create additional `GroupFaq` records.

### Testing

- `uv run pytest communities/groups/tests/faq/test_group_faq_create.py -vv`

### AI disclosure

AI tools were used to assist with repository analysis and drafting the tests. I reviewed, understood, and tested the final changes.

### Related issue

- Closes #2298