### PR TITLE
fix: implement calendar .ics download for single events

### DIFF
--- a/frontend/app/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
+++ b/frontend/app/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
@@ -46,14 +46,36 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   event: CommunityEvent;
 }>();
 
 const emit = defineEmits(["tab"]);
 const { handleTabPress } = useTabNavigationEmit(emit);
 
-const downloadCalendarEntry = () => {};
+const config = useRuntimeConfig();
+
+const downloadCalendarEntry = async () => {
+  try {
+    const url = `${config.public.apiBase}/v1/events/event_calendar?event_id=${props.event.id}`;
+    const response = await fetch(url);
+    if (!response.ok) throw new Error("Download failed");
+    const blob = await response.blob();
+    const disposition = response.headers.get("Content-Disposition") || "";
+    const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+    const filename = match ? match[1].replace(/['"]/g, "") : `event-${props.event.id}.ics`;
+    const blobUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = blobUrl;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(blobUrl);
+  } catch (err) {
+    console.error("Failed to download calendar entry:", err);
+  }
+};
 
 const { openModal: openModalSharePage } = useModalHandlers("ModalSharePage");
 </script>

--- a/frontend/app/pages/events/[eventId]/about.vue
+++ b/frontend/app/pages/events/[eventId]/about.vue
@@ -121,7 +121,29 @@ function updateShareBtnLabel() {
   }
 }
 
-const downloadCalendarEntry = () => {};
+const config = useRuntimeConfig();
+
+const downloadCalendarEntry = async () => {
+  try {
+    const url = `${config.public.apiBase}/v1/events/event_calendar?event_id=${eventId}`;
+    const response = await fetch(url);
+    if (!response.ok) throw new Error("Download failed");
+    const blob = await response.blob();
+    const disposition = response.headers.get("Content-Disposition") || "";
+    const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+    const filename = match ? match[1].replace(/['"]/g, "") : `event-${eventId}.ics`;
+    const blobUrl = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = blobUrl;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(blobUrl);
+  } catch (err) {
+    console.error("Failed to download calendar entry:", err);
+  }
+};
 
 onMounted(() => {
   window.addEventListener("resize", updateShareBtnLabel);


### PR DESCRIPTION
## What

This PR wires up the `downloadCalendarEntry` function in both the event tooltip menu (`TooltipMenuSearchResultEvent.vue`) and the event about page (`about.vue`) to call the backend `/v1/events/event_calendar` endpoint and trigger a browser file download.

Previously both functions were empty stubs, so clicking the "Download the calendar entry" button had no effect.

## Why

The backend already exposes `GET /v1/events/event_calendar?event_id=<UUID>` which returns an iCalendar file with a suggested filename via `Content-Disposition`. The frontend buttons were wired to an empty function, so users could not actually download event calendar entries.

## Testing

- Verified the download function fetches the .ics file from the API
- Extracts the filename from Content-Disposition header (falls back to `event-<id>.ics`)
- Creates a blob URL and triggers browser download via a temporary anchor element
- Cleans up the object URL after download
- Errors are caught and logged to console without disrupting the UI