### PR TITLE
feat(frontend): connect single-event calendar actions to download .ics export endpoint (#2301)

### DIFF
--- a/frontend/app/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
+++ b/frontend/app/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
@@ -46,14 +46,19 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   event: CommunityEvent;
 }>();
 
 const emit = defineEmits(["tab"]);
 const { handleTabPress } = useTabNavigationEmit(emit);
 
-const downloadCalendarEntry = () => {};
+const { handleDownload } = useDownloadEventCalendar();
+const downloadCalendarEntry = () => {
+  if (props.event?.id) {
+    handleDownload(props.event.id, props.event.name);
+  }
+};
 
 const { openModal: openModalSharePage } = useModalHandlers("ModalSharePage");
 </script>

--- a/frontend/app/composables/useDownloadEventCalendar.ts
+++ b/frontend/app/composables/useDownloadEventCalendar.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { downloadEventCalendar } from "~/services/event/event";
+
+export const useDownloadEventCalendar = () => {
+  const { showToastError } = useToaster();
+
+  const handleDownload = async (eventId: string, eventName?: string) => {
+    if (!eventId) return;
+    try {
+      await downloadEventCalendar(eventId, eventName);
+    } catch {
+      showToastError("Failed to download calendar entry. Please try again.");
+    }
+  };
+
+  return {
+    handleDownload,
+  };
+};

--- a/frontend/app/pages/events/[eventId]/about.vue
+++ b/frontend/app/pages/events/[eventId]/about.vue
@@ -121,7 +121,12 @@ function updateShareBtnLabel() {
   }
 }
 
-const downloadCalendarEntry = () => {};
+const { handleDownload } = useDownloadEventCalendar();
+const downloadCalendarEntry = () => {
+  if (event.value?.id) {
+    handleDownload(event.value.id, event.value.name);
+  }
+};
 
 onMounted(() => {
   window.addEventListener("resize", updateShareBtnLabel);

--- a/frontend/app/services/event/event.ts
+++ b/frontend/app/services/event/event.ts
@@ -94,3 +94,41 @@ export async function deleteEvent(eventId: string): Promise<void> {
     throw errorHandler(e);
   }
 }
+
+// MARK: Download Calendar (.ics)
+
+export async function downloadEventCalendar(
+  eventId: string,
+  eventName?: string
+): Promise<void> {
+  const config = useRuntimeConfig();
+  const res = await fetch(
+    `${config.public.apiBaseUrl}/events/event_calendar?event_id=${eventId}`
+  );
+  if (!res.ok) {
+    throw new Error("Failed to download calendar entry");
+  }
+
+  const blob = await res.blob();
+  const contentDisposition = res.headers.get("content-disposition");
+  let filename = `${eventName ? eventName.replace(/[^a-zA-Z0-9_-]/g, "_") : "event"}.ics`;
+
+  if (contentDisposition) {
+    const filenameMatch = contentDisposition.match(
+      /filename\*?=['"]?(?:UTF-8'')?([^;'"\r\n]+)['"]?/i
+    );
+    if (filenameMatch && filenameMatch[1]) {
+      filename = decodeURIComponent(filenameMatch[1]);
+    }
+  }
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+

--- a/frontend/test/composables/useDownloadEventCalendar.spec.ts
+++ b/frontend/test/composables/useDownloadEventCalendar.spec.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useDownloadEventCalendar } from "../../app/composables/useDownloadEventCalendar";
+import * as eventService from "../../app/services/event/event";
+
+vi.mock("../../app/services/event/event", () => ({
+  downloadEventCalendar: vi.fn(),
+}));
+
+describe("useDownloadEventCalendar composable", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls downloadEventCalendar service with correct event ID and name", async () => {
+    const downloadSpy = vi.spyOn(eventService, "downloadEventCalendar").mockResolvedValue();
+    const { handleDownload } = useDownloadEventCalendar();
+
+    await handleDownload("event-uuid-123", "Test Event");
+
+    expect(downloadSpy).toHaveBeenCalledTimes(1);
+    expect(downloadSpy).toHaveBeenCalledWith("event-uuid-123", "Test Event");
+  });
+
+  it("handles missing event ID gracefully without calling download service", async () => {
+    const downloadSpy = vi.spyOn(eventService, "downloadEventCalendar");
+    const { handleDownload } = useDownloadEventCalendar();
+
+    await handleDownload("", "Test Event");
+
+    expect(downloadSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have added unit tests for the new composable
- [x] I have tested my changes locally

---

### Description

Connects single-event calendar download actions in the event About page (`/events/[eventId]/about.vue`) and event card menu (`TooltipMenuSearchResultEvent.vue`) to the backend export endpoint `GET /v1/events/event_calendar?event_id=<UUID>`.

#### Changes made:
- Added `downloadEventCalendar` service helper in `frontend/app/services/event/event.ts` to request event `.ics` files and parse suggested filenames from `Content-Disposition`.
- Created `useDownloadEventCalendar` composable (`frontend/app/composables/useDownloadEventCalendar.ts`) for clean error handling and Toast notifications.
- Connected the calendar download action handlers in `about.vue` and `TooltipMenuSearchResultEvent.vue`.
- Added unit tests in `frontend/test/composables/useDownloadEventCalendar.spec.ts`.

### Related issue

- Fixes #2301