### PR TITLE
fix(ci): remove --silent flag from Vitest invocation in dependency update workflow (#2309)

### DIFF
--- a/.github/workflows/dependency_update_check.yaml
+++ b/.github/workflows/dependency_update_check.yaml
@@ -222,7 +222,7 @@ jobs:
 
           echo -e "\n### Vitest Results" >> ../reports.md
           echo "\`\`\`" >> ../reports.md
-          yarn test --silent 2>&1 | tee -a ../reports.md || true
+          yarn test 2>&1 | tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
 
       - name: Set date


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my changes locally

---

### Description

Fixes #2309 where the Vitest test suite output was being suppressed in `.github/workflows/dependency_update_check.yaml` due to passing the `--silent` flag.

#### Changes made:
- Removed `--silent` flag from `yarn test` invocation in `.github/workflows/dependency_update_check.yaml` to ensure test execution summaries print cleanly to the update report markdown file.

### Related issue

- Fixes #2309