### PR TITLE
fix: remove invalid --silent=passed-only flag from Vitest CI command

### DIFF
--- a/.github/workflows/dependency_update_check.yaml
+++ b/.github/workflows/dependency_update_check.yaml
@@ -179,7 +179,7 @@ jobs:
 
           echo -e "\n### Vitest Results" >> ../reports.md
           echo "\`\`\`" >> ../reports.md
-          yarn test --reporter=dot 2>&1 | tee -a ../reports.md || true
+          yarn test --reporter=dot --silent='passed-only' 2>&1 | tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
 
       # MARK: Create Issue

--- a/.github/workflows/dependency_update_check.yaml
+++ b/.github/workflows/dependency_update_check.yaml
@@ -179,7 +179,7 @@ jobs:
 
           echo -e "\n### Vitest Results" >> ../reports.md
           echo "\`\`\`" >> ../reports.md
-          yarn test --reporter=dot --silent=passed-only 2>&1 | tee -a ../reports.md || true
+          yarn test --reporter=dot 2>&1 | tee -a ../reports.md || true
           echo "\`\`\`" >> ../reports.md
 
       # MARK: Create Issue


### PR DESCRIPTION
## Summary

Fixes #2309

The Vitest CI command in dependency_update_check.yaml uses `--silent=passed-only` which is **not a valid Vitest CLI option**. In Vitest, `--silent` is a boolean flag that doesn't accept a value. Passing `--silent=passed-only` causes the test runner to either fail or silently skip all tests.

## Change

Removed the invalid `--silent=passed-only` flag from the Vitest test command. The `--reporter=dot` flag is kept to maintain concise output (dots for passed tests, failure details at the end).

## Before

```yaml
yarn test --reporter=dot --silent=passed-only 2>&1 | tee -a ../reports.md || true
```

## After

```yaml
yarn test --reporter=dot 2>&1 | tee -a ../reports.md || true
```

## Testing

The fix is in the CI workflow file only — no functional code changes to the frontend application.