### PR TITLE
chore(frontend): upgrade Playwright to 1.62.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "@nuxtjs/i18n": "10.4.0",
     "@pinia/colada-nuxt": "1.0.0",
     "@pinia/nuxt": "0.11.3",
-    "@playwright/test": "1.61.1",
+    "@playwright/test": "1.62.1",
     "@testing-library/vue": "8.1.0",
     "@types/node": "26.1.1",
     "@types/zxcvbn": "4.4.5",
@@ -60,7 +60,7 @@
     "nuxt": "4.4.8",
     "nuxt-auth-utils": "0.5.29",
     "nuxt-security": "2.6.0",
-    "playwright-core": "1.61.1",
+    "playwright-core": "1.62.1",
     "prettier": "3.9.5",
     "prettier-plugin-tailwindcss": "0.8.0",
     "rollup": "4.62.2",
@@ -129,7 +129,7 @@
   },
   "resolutions": {
     "chokidar": "3.6.0",
-    "playwright-core": "1.61.0",
+    "playwright-core": "1.62.1",
     "commander": "15.0.0",
     "glob": "^13.0.6"
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4010,14 +4010,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:1.61.1":
-  version: 1.61.1
-  resolution: "@playwright/test@npm:1.61.1"
+"@playwright/test@npm:1.62.1":
+  version: 1.62.1
+  resolution: "@playwright/test@npm:1.62.1"
   dependencies:
-    playwright: "npm:1.61.1"
+    playwright: "npm:1.62.1"
   bin:
     playwright: cli.js
-  checksum: 10c0/45004139eaa7c7ec8129e4ed77a9d734aa09ed40b69162b871e4123f1d70217b7b73651431a9343ed5090d5fed11c6df1bff2a56ff4b87dc7b0371b5da87cf9c
+  checksum: 10c0/4b76f2f717723f84a73601f74fde97f5d92e4b5c869cf87c0f5628bf247fa1d18c9dc6c8e136463303233239e8ce58f902513d4281a9fabc3c426e911ded2c83
   languageName: node
   linkType: hard
 
@@ -6898,7 +6898,7 @@ __metadata:
     "@pinia/colada": "npm:^1.2.0"
     "@pinia/colada-nuxt": "npm:1.0.0"
     "@pinia/nuxt": "npm:0.11.3"
-    "@playwright/test": "npm:1.61.1"
+    "@playwright/test": "npm:1.62.1"
     "@popperjs/core": "npm:2.11.8"
     "@somushq/vue3-friendly-captcha": "npm:1.0.2"
     "@tailwindcss/vite": "npm:4.3.2"
@@ -6949,7 +6949,7 @@ __metadata:
     nuxt-security: "npm:2.6.0"
     pinia: "npm:3.0.4"
     pinia-plugin-persistedstate: "npm:4.7.1"
-    playwright-core: "npm:1.61.1"
+    playwright-core: "npm:1.62.1"
     postcss: "npm:8.5.22"
     postcss-custom-properties: "npm:15.0.1"
     prettier: "npm:3.9.5"
@@ -13358,27 +13358,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.61.0":
-  version: 1.61.0
-  resolution: "playwright-core@npm:1.61.0"
+"playwright-core@npm:1.62.1":
+  version: 1.62.1
+  resolution: "playwright-core@npm:1.62.1"
   bin:
     playwright-core: cli.js
-  checksum: 10c0/64cbf5e9f4ad81cbb005d59417e96435e324a6e3801f1c79b36850ad99f6bb90853c4b569a32c49b9eca1e07925bbb2a5a864babdba2178c3c395e0c589d5941
+  checksum: 10c0/a37d0f03bb73364cfd0eba704c4b3359b609c4779ae2649a88d8e2b3a29c7357dfcc58bdcf0cb68ddffdef7687abf78902c8356e89f189682c7e19be38e108f0
   languageName: node
   linkType: hard
 
-"playwright@npm:1.61.1":
-  version: 1.61.1
-  resolution: "playwright@npm:1.61.1"
+"playwright@npm:1.62.1":
+  version: 1.62.1
+  resolution: "playwright@npm:1.62.1"
   dependencies:
     fsevents: "npm:2.3.2"
-    playwright-core: "npm:1.61.1"
+    playwright-core: "npm:1.62.1"
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 10c0/cea1bc4d2a64ec3ef683891606774029da7b8a8036ed98332565cec2f8e89549ca1fab9a89fbfba4e08e27e0d7e7d148031e965af66d5ff97bb3c34058cfcad0
+  checksum: 10c0/4d3522cd46325f50c46f8874d31f70d036f6983228a9f8b9d68fc249e4c17464edcd97cc4adfbb24e712d1829c1386d3bc24e17f58a1ced94e7c423300c21845
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

Upgrades Playwright from 1.61 to 1.62.1, which brings Chromium 151. Only `frontend/package.json` and `frontend/yarn.lock` change; CI installs browsers off the pinned version, so there's no image pin or cache key to update.

It also fixes a skew we already had: `resolutions` forced `playwright-core` to `1.61.0` while `@playwright/test` was `1.61.1`, so the installed driver did not match the test package. All three pins now sit at 1.62.1.

**Why this is worth doing, mostly for flakiness.**

- `Reporter.preprocess()` is a new hook that can mark individual tests as skipped or excluded before the run starts. With `failOnFlakyTests` on, a single recurring flake currently reds the job on PRs that never touched it. This lets us keep a quarantine list in one place instead of scattering `test.fixme` through specs, and makes it obvious what's quarantined and why.
- `locator.waitForFunction()` waits until a function called with the matching element returns truthy. It's a first-class replacement for the `expect.poll` around `locator.count()` pattern we fall back on whenever a spec has to wait for DOM state to settle, which is where several of our races have come from.
- A new `scroll: "none"` option on actions opts out of automatic scroll-into-view, which is worth trying against the mobile drag-and-drop reorder flake.

**Risk.** A browser bump can shift timing on existing flakes either way. This is deliberately separate from the open @pinia/colada work so its own CI run shows what moves under the new browser with no application changes in the diff.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- No related issue; this is a routine dependency upgrade.