### PR TITLE
test(backend): standardize HTTP 401 and 403 test cases for organization FAQs (#2318)

### DIFF
--- a/backend/communities/organizations/tests/faq/test_org_faq_create.py
+++ b/backend/communities/organizations/tests/faq/test_org_faq_create.py
@@ -80,7 +80,7 @@ def test_org_faq_create_bad_request_400(authenticated_client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_org_faq_create_unathorized(authenticated_client) -> None:
+def test_org_faq_create_forbidden_403(authenticated_client) -> None:
     client, user = authenticated_client
     user.is_staff = False
     user.save()
@@ -91,6 +91,8 @@ def test_org_faq_create_unathorized(authenticated_client) -> None:
     test_question = faqs.question
     test_answer = faqs.answer
     test_order = faqs.order
+
+    initial_count = OrganizationFaqFactory._meta.model.objects.count()
 
     response = client.post(
         path="/v1/communities/organization_faqs",
@@ -106,3 +108,27 @@ def test_org_faq_create_unathorized(authenticated_client) -> None:
     )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert OrganizationFaqFactory._meta.model.objects.count() == initial_count
+
+
+def test_org_faq_create_unauthorized_401(api_client) -> None:
+    org = OrganizationFactory()
+    faqs = OrganizationFaqFactory()
+
+    initial_count = OrganizationFaqFactory._meta.model.objects.count()
+
+    response = api_client.post(
+        path="/v1/communities/organization_faqs",
+        data={
+            "iso": "en",
+            "primary": True,
+            "question": faqs.question,
+            "answer": faqs.answer,
+            "order": faqs.order,
+            "org": org.id,
+        },
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert OrganizationFaqFactory._meta.model.objects.count() == initial_count

--- a/backend/communities/organizations/tests/faq/test_org_faq_delete.py
+++ b/backend/communities/organizations/tests/faq/test_org_faq_delete.py
@@ -13,86 +13,70 @@ from communities.organizations.models import OrganizationFaq
 
 
 @pytest.mark.django_db
-def test_org_faq_delete(authenticated_client) -> None:
-    """
-    Test OrganizationFaqViewSet destroy method (DELETE request)
-
-    Test cases:
-    1. Verify that an unauthenticated user cannot delete an FAQ
-    2. Verify that a non-creator, non-staff user cannot delete an FAQ (403 Forbidden)
-    3. Verify that the creator can successfully delete an FAQ
-    4. Verify that a staff user can delete an FAQ even if they are not the creator
-    5. Verify that deleting a non-existent FAQ returns 404
-    6. Verify that the FAQ is actually removed from the database after deletion
-    """
-    client, _ = authenticated_client
-    unauthenticated_client = APIClient()
-
-    # Create organization creator.
-    creator: UserModel = UserFactory.create(is_confirmed=True)
-
-    # Create staff user.
-    staff_user: UserModel = UserFactory.create(is_confirmed=True, is_staff=True)
-
-    # Create an organization with the creator.
+def test_org_faq_delete_unauthorized_401(api_client) -> None:
+    creator = UserFactory.create(is_confirmed=True)
     org = OrganizationFactory.create(created_by=creator)
-
-    # Create an FAQ for the organization.
     faq = OrganizationFaqFactory.create(org=org)
-    assert OrganizationFaq.objects.filter(id=faq.id).exists()
 
-    # MARK: Unauthenticated DELETE
+    response = api_client.delete(f"/v1/communities/organization_faqs/{faq.id}")
 
-    # Test 1: Unauthenticated user cannot delete FAQ
-    response = unauthenticated_client.delete(
-        f"{'/v1/communities/organization_faqs'}/{faq.id}"
-    )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
     assert OrganizationFaq.objects.filter(id=faq.id).exists()
 
-    # MARK: Unauthorized DELETE
 
-    # Test 2: Regular user (not creator, not staff) cannot delete FAQ.
-    # Using the authenticated_client fixture user who is not the creator.
-    response = client.delete(f"{'/v1/communities/organization_faqs'}/{faq.id}")
+@pytest.mark.django_db
+def test_org_faq_delete_forbidden_403(authenticated_client) -> None:
+    client, _ = authenticated_client
+    creator = UserFactory.create(is_confirmed=True)
+    org = OrganizationFactory.create(created_by=creator)
+    faq = OrganizationFaqFactory.create(org=org)
+
+    response = client.delete(f"/v1/communities/organization_faqs/{faq.id}")
+
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.data["detail"] == "You are not authorized to delete this FAQ."
     assert OrganizationFaq.objects.filter(id=faq.id).exists()
 
-    # MARK: Staff DELETE
 
-    # Test 3: Staff user can delete FAQ even if not the creator.
-    faq_for_staff = OrganizationFaqFactory.create(org=org)
-    assert OrganizationFaq.objects.filter(id=faq_for_staff.id).exists()
+@pytest.mark.django_db
+def test_org_faq_delete_success(authenticated_client) -> None:
+    client, user = authenticated_client
+    org = OrganizationFactory.create(created_by=user)
+    faq = OrganizationFaqFactory.create(org=org)
 
-    staff_client = APIClient()
-    staff_client.force_authenticate(user=staff_user)
-    response = staff_client.delete(
-        f"{'/v1/communities/organization_faqs'}/{faq_for_staff.id}"
-    )
+    response = client.delete(f"/v1/communities/organization_faqs/{faq.id}")
+
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert response.data["message"] == "FAQ deleted successfully."
-    assert not OrganizationFaq.objects.filter(id=faq_for_staff.id).exists()
-
-    # MARK: Creator DELETE
-
-    # Test 4: Creator can successfully delete their own FAQ.
-    creator_client = APIClient()
-    creator_client.force_authenticate(user=creator)
-    response = creator_client.delete(f"{'/v1/communities/organization_faqs'}/{faq.id}")
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-    assert response.data["message"] == "FAQ deleted successfully."
-
-    # Verify FAQ is removed from database.
     assert not OrganizationFaq.objects.filter(id=faq.id).exists()
 
-    # MARK: Non-existent FAQ DELETE
 
-    # Test 5: Deleting a non-existent FAQ returns 404.
+@pytest.mark.django_db
+def test_org_faq_delete_staff_success(authenticated_client) -> None:
+    client, user = authenticated_client
+    user.is_staff = True
+    user.save()
+
+    creator = UserFactory.create(is_confirmed=True)
+    org = OrganizationFactory.create(created_by=creator)
+    faq = OrganizationFaqFactory.create(org=org)
+
+    response = client.delete(f"/v1/communities/organization_faqs/{faq.id}")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert response.data["message"] == "FAQ deleted successfully."
+    assert not OrganizationFaq.objects.filter(id=faq.id).exists()
+
+
+@pytest.mark.django_db
+def test_org_faq_delete_not_found_404(authenticated_client) -> None:
+    client, user = authenticated_client
+    user.is_staff = True
+    user.save()
+
     fake_uuid = "00000000-0000-0000-0000-000000000000"
-    response = creator_client.delete(
-        f"{'/v1/communities/organization_faqs'}/{fake_uuid}"
-    )
+    response = client.delete(f"/v1/communities/organization_faqs/{fake_uuid}")
+
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert response.data["detail"] == "FAQ not found."
 
@@ -101,33 +85,25 @@ def test_org_faq_delete(authenticated_client) -> None:
 def test_org_faq_delete_multiple_faqs(authenticated_client) -> None:
     """
     Test that multiple FAQs can be deleted independently.
-
-    This verifies that deleting one FAQ doesn't affect other FAQs
-    in the same organization.
     """
     client, user = authenticated_client
 
-    # Create an organization with the authenticated user as creator.
     org = OrganizationFactory.create(created_by=user)
 
-    # Create multiple FAQs for the organization.
     faq1 = OrganizationFaqFactory.create(org=org)
     faq2 = OrganizationFaqFactory.create(org=org)
     faq3 = OrganizationFaqFactory.create(org=org)
 
     assert OrganizationFaq.objects.filter(org=org).count() == 3
 
-    # Delete first FAQ.
     response = client.delete(f"/v1/communities/organization_faqs/{faq1.id}")
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not OrganizationFaq.objects.filter(id=faq1.id).exists()
     assert OrganizationFaq.objects.filter(org=org).count() == 2
 
-    # Delete second FAQ.
     response = client.delete(f"/v1/communities/organization_faqs/{faq2.id}")
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not OrganizationFaq.objects.filter(id=faq2.id).exists()
     assert OrganizationFaq.objects.filter(org=org).count() == 1
 
-    # Verify third FAQ still exists.
     assert OrganizationFaq.objects.filter(id=faq3.id).exists()

--- a/backend/communities/organizations/tests/faq/test_org_faq_update.py
+++ b/backend/communities/organizations/tests/faq/test_org_faq_update.py
@@ -95,7 +95,7 @@ def test_org_faq_update_not_found_404(authenticated_client):
     assert response_body["detail"] == "FAQ not found."
 
 
-def test_org_faq_update_unauthorized_forbidden_403(authenticated_client) -> None:
+def test_org_faq_update_forbidden_403(authenticated_client) -> None:
     client, user = authenticated_client
     user.is_staff = False
     user.save()
@@ -122,3 +122,23 @@ def test_org_faq_update_unauthorized_forbidden_403(authenticated_client) -> None
     )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_org_faq_update_unauthorized_401(api_client) -> None:
+    org = OrganizationFactory()
+    faqs = OrganizationFaqFactory(org=org)
+
+    response = api_client.put(
+        path=f"/v1/communities/organization_faqs/{faqs.id}",
+        data={
+            "id": faqs.id,
+            "iso": "en",
+            "primary": True,
+            "question": faqs.question,
+            "answer": faqs.answer,
+            "order": faqs.order,
+        },
+        content_type="application/json",
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my changes locally

---

### Description

Standardizes HTTP 401 Unauthorized and HTTP 403 Forbidden backend unit test cases for organization FAQs as requested in #2318.

#### Changes made:
- **`test_org_faq_create.py`**: Fixed typo in `test_org_faq_create_unathorized` -> `test_org_faq_create_forbidden_403`, asserted database state immutability on rejected write, and added `test_org_faq_create_unauthorized_401` using `api_client`.
- **`test_org_faq_update.py`**: Renamed `test_org_faq_update_unauthorized_forbidden_403` to `test_org_faq_update_forbidden_403` and added `test_org_faq_update_unauthorized_401`.
- **`test_org_faq_delete.py`**: Refactored monolithic `test_org_faq_delete` into dedicated, standardized test functions (`test_org_faq_delete_unauthorized_401`, `test_org_faq_delete_forbidden_403`, `test_org_faq_delete_success`, `test_org_faq_delete_staff_success`, and `test_org_faq_delete_not_found_404`).

### Related issue

- Fixes part of #2318