### PR TITLE
Enable event calendar downloads

### DIFF
--- a/frontend/app/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
+++ b/frontend/app/components/tooltip/menu-search-result/TooltipMenuSearchResultEvent.vue
@@ -32,7 +32,6 @@
       />
       <BtnAction
         @click="downloadCalendarEntry"
-        @keydown.enter="downloadCalendarEntry"
         ariaLabel="i18n._global.subscribe_to_event_aria_label"
         class="flex max-h-10 w-full items-center"
         :cta="true"
@@ -46,14 +45,16 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   event: CommunityEvent;
 }>();
 
 const emit = defineEmits(["tab"]);
 const { handleTabPress } = useTabNavigationEmit(emit);
 
-const downloadCalendarEntry = () => {};
+const { downloadCalendarEntry: downloadEventCalendarEntry } =
+  useEventCalendarDownload();
+const downloadCalendarEntry = () => downloadEventCalendarEntry(props.event.id);
 
 const { openModal: openModalSharePage } = useModalHandlers("ModalSharePage");
 </script>

--- a/frontend/app/composables/useEventCalendarDownload.ts
+++ b/frontend/app/composables/useEventCalendarDownload.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+export function useEventCalendarDownload() {
+  const { t } = useI18n();
+  const { showToastError } = useToaster();
+  const isDownloading = ref(false);
+
+  async function downloadCalendarEntry(eventId: string) {
+    if (isDownloading.value || !eventId) return;
+
+    isDownloading.value = true;
+
+    try {
+      const { calendar, filename } = await downloadEventCalendar(eventId);
+      const url = URL.createObjectURL(calendar);
+      const link = document.createElement("a");
+
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch {
+      showToastError(t("i18n.pages.auth._global.error_occurred"));
+    } finally {
+      isDownloading.value = false;
+    }
+  }
+
+  return { downloadCalendarEntry, isDownloading };
+}

--- a/frontend/app/pages/events/[eventId]/about.vue
+++ b/frontend/app/pages/events/[eventId]/about.vue
@@ -48,7 +48,6 @@
         />
         <BtnAction
           @click="downloadCalendarEntry"
-          @keydown.enter="downloadCalendarEntry"
           ariaLabel="i18n._global.subscribe_to_event_aria_label"
           class="w-full sm:w-max"
           :cta="true"
@@ -102,6 +101,9 @@ const paramsEventId = useRoute().params.eventId;
 const eventId = typeof paramsEventId === "string" ? paramsEventId : "";
 
 const { data: event } = useGetEvent(eventId);
+const { downloadCalendarEntry: downloadEventCalendarEntry } =
+  useEventCalendarDownload();
+const downloadCalendarEntry = () => downloadEventCalendarEntry(eventId);
 
 const textExpanded = ref(false);
 const expandReduceText = () => {
@@ -120,8 +122,6 @@ function updateShareBtnLabel() {
     shareButtonLabel.value = "i18n._global.share_event";
   }
 }
-
-const downloadCalendarEntry = () => {};
 
 onMounted(() => {
   window.addEventListener("resize", updateShareBtnLabel);

--- a/frontend/app/services/event/event.ts
+++ b/frontend/app/services/event/event.ts
@@ -2,7 +2,9 @@
 // Events service: plain exported functions (no composables, no state).
 // Uses services/http.ts helpers and centralizes error handling + normalization.
 
-import { del, get, post } from "~/services/http";
+import { del, get, getRaw, post } from "~/services/http";
+
+const DEFAULT_CALENDAR_FILENAME = "activist-event.ics";
 
 // MARK: Map API Response to Type
 
@@ -34,6 +36,50 @@ export async function getEvent(id: string): Promise<EventResponse> {
       withoutAuth: true,
     });
     return mapEvent(res);
+  } catch (e) {
+    throw errorHandler(e);
+  }
+}
+
+export function getCalendarFilename(
+  contentDisposition: string | null
+): string {
+  const match = contentDisposition?.match(
+    /filename\*?=(?:UTF-8''|\")?([^\";]+)\"?/i
+  );
+  const encodedFilename = match?.[1]?.trim();
+
+  if (!encodedFilename) return DEFAULT_CALENDAR_FILENAME;
+
+  try {
+    const filename = decodeURIComponent(encodedFilename).replace(/[\\/]/g, "_");
+    return filename.toLowerCase().endsWith(".ics")
+      ? filename
+      : DEFAULT_CALENDAR_FILENAME;
+  } catch {
+    return DEFAULT_CALENDAR_FILENAME;
+  }
+}
+
+export async function downloadEventCalendar(eventId: string): Promise<{
+  calendar: Blob;
+  filename: string;
+}> {
+  try {
+    const response = await getRaw<Blob>("/events/event_calendar", {
+      withoutAuth: true,
+      query: { event_id: eventId },
+      responseType: "blob",
+    });
+
+    if (!response._data) {
+      throw new Error("Calendar response did not contain a file.");
+    }
+
+    return {
+      calendar: response._data,
+      filename: getCalendarFilename(response.headers.get("content-disposition")),
+    };
   } catch (e) {
     throw errorHandler(e);
   }

--- a/frontend/app/services/http.ts
+++ b/frontend/app/services/http.ts
@@ -19,6 +19,18 @@ export function get<T>(url: string, options?: ServiceOptions) {
   });
 }
 
+export function getRaw<T>(url: string, options?: ServiceOptions) {
+  const headers = {
+    ...(options?.headers || {}),
+  };
+  return $fetch.raw<T>(url, {
+    baseURL: baseURL(!options?.withoutAuth),
+    method: "GET" as const,
+    ...options,
+    headers,
+  });
+}
+
 export function post<T, X extends AcceptedBody>(
   url: string,
   body?: X,

--- a/frontend/test/services/event/event.spec.ts
+++ b/frontend/test/services/event/event.spec.ts
@@ -5,6 +5,8 @@ import { defaultEventText } from "../../../app/constants/event";
 import {
   createEvent,
   deleteEvent,
+  downloadEventCalendar,
+  getCalendarFilename,
   getEvent,
   listEvents,
   mapEvent,
@@ -19,6 +21,45 @@ import {
 
 describe("services/event", () => {
   const getMocks = setupServiceTestMocks();
+
+  describe("downloadEventCalendar", () => {
+    it("downloads the event calendar through the public proxy", async () => {
+      const { fetchRawMock } = getMocks();
+      const calendar = new Blob(["BEGIN:VCALENDAR"], {
+        type: "text/calendar",
+      });
+      const response = {
+        _data: calendar,
+        headers: new Headers({
+          "content-disposition": 'attachment; filename="community-event.ics"',
+        }),
+      };
+      fetchRawMock.mockResolvedValueOnce(response);
+
+      const result = await downloadEventCalendar("evt-calendar");
+
+      expect(fetchRawMock).toHaveBeenCalledTimes(1);
+      expectRequest(fetchRawMock, "/events/event_calendar", "GET");
+      const [, options] = getFetchCall(fetchRawMock);
+      expect(options.headers?.Authorization).toBeUndefined();
+      expect(options.query).toEqual({ event_id: "evt-calendar" });
+      expect(options.responseType).toBe("blob");
+      expect(result).toEqual({
+        calendar,
+        filename: "community-event.ics",
+      });
+    });
+
+    it("uses a safe filename when the response header is missing or invalid", () => {
+      expect(getCalendarFilename(null)).toBe("activist-event.ics");
+      expect(getCalendarFilename('attachment; filename="event.txt"')).toBe(
+        "activist-event.ics"
+      );
+      expect(getCalendarFilename('attachment; filename="../event.ics"')).toBe(
+        ".._event.ics"
+      );
+    });
+  });
 
   // MARK: Get
 


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a separate branch and not the main branch
- [ ] I have run all required frontend tests successfully

---

### Description

Closes #2301 by restoring the download action for individual event calendar entries.

The event About page and event search-result menu displayed calendar download actions, but both called empty handlers. The backend already provides a public `event_calendar` endpoint that returns the event’s `.ics` file.

This PR:
- adds one shared calendar-download flow for both actions;
- downloads through the existing public API proxy;
- uses the response filename with a safe `.ics` fallback;
- removes duplicate Enter-key handlers to prevent double downloads;
- cleans up temporary browser object URLs;
- adds service coverage for the request and filename fallback.

### Testing

- `corepack yarn typecheck` passes.
- `git diff --check` passes.
- The focused Vitest run is blocked before tests execute because Nuxt setup exceeds its 10-second hook timeout.
- GitHub static-analysis and i18n checks are currently failing and need log review.

### Risk

Low. This is a frontend-only restoration of an existing, tested backend endpoint. It does not change permissions, data models, or API contracts.