### PR TITLE
fix(frontend): make SidebarLeft icon sizes consistent

### DIFF
--- a/frontend/app/components/sidebar/left/SidebarLeftSelector.vue
+++ b/frontend/app/components/sidebar/left/SidebarLeftSelector.vue
@@ -9,6 +9,7 @@
           v-if="iconUrl"
           class="h-5 w-5 shrink-0"
           :class="{
+            'scale-125': iconUrl.startsWith('bi:'),
             'dark:group-hover:fill-cta-orange': !selected,
             'fill-layer-1': selected,
           }"

--- a/frontend/app/components/sidebar/left/SidebarLeftSelector.vue
+++ b/frontend/app/components/sidebar/left/SidebarLeftSelector.vue
@@ -7,9 +7,8 @@
       <span class="pl-1">
         <Icon
           v-if="iconUrl"
-          class="h-5 w-5 shrink-0"
+          class="h-5! w-5! block! shrink-0"
           :class="{
-            'scale-125': iconUrl.startsWith('bi:'),
             'dark:group-hover:fill-cta-orange': !selected,
             'fill-layer-1': selected,
           }"

--- a/frontend/test/components/sidebar/SidebarLeftSelector.spec.ts
+++ b/frontend/test/components/sidebar/SidebarLeftSelector.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { screen } from "@testing-library/vue";
+import { describe, expect, it } from "vitest";
+
+import SidebarLeftSelector from "../../../app/components/sidebar/left/SidebarLeftSelector.vue";
+import render from "../../../test/render";
+import { createUseLocalePathMock } from "../../mocks/composableMocks";
+
+globalThis.useLocalePath = createUseLocalePathMock();
+
+const baseProps = {
+  label: "i18n._global.about",
+  routeUrl: "/organizations/1/about",
+  selected: false,
+};
+
+const renderSelector = (iconUrl: string) =>
+  render(SidebarLeftSelector, {
+    props: { ...baseProps, iconUrl },
+  });
+
+describe("SidebarLeftSelector", () => {
+  it("scales Bootstrap icons to match custom icons", async () => {
+    await renderSelector("bi:card-text");
+
+    const icon = screen.getByRole("img", { name: "bi:card-text" });
+    expect(icon.classList).toContain("scale-125");
+  });
+
+  it("keeps custom icons at their native scale", async () => {
+    await renderSelector("IconGroup");
+
+    const icon = screen.getByRole("img", { name: "IconGroup" });
+    expect(icon.classList).not.toContain("scale-125");
+  });
+});

--- a/frontend/test/components/sidebar/SidebarLeftSelector.spec.ts
+++ b/frontend/test/components/sidebar/SidebarLeftSelector.spec.ts
@@ -6,11 +6,11 @@ import SidebarLeftSelector from "../../../app/components/sidebar/left/SidebarLef
 import render from "../../../test/render";
 import { createUseLocalePathMock } from "../../mocks/composableMocks";
 
-globalThis.useLocalePath = createUseLocalePathMock();
+globalThis.useLocalePath = createUseLocalePathMock("");
 
 const baseProps = {
   label: "i18n._global.about",
-  routeUrl: "/organizations/1/about",
+  routeUrl: "/",
   selected: false,
 };
 
@@ -20,17 +20,16 @@ const renderSelector = (iconUrl: string) =>
   });
 
 describe("SidebarLeftSelector", () => {
-  it("scales Bootstrap icons to match custom icons", async () => {
-    await renderSelector("bi:card-text");
+  it.each([
+    ["Bootstrap", "bi:card-text"],
+    ["custom", "IconGroup"],
+  ])("uses fixed dimensions for %s icons", async (_type, iconUrl) => {
+    await renderSelector(iconUrl);
 
-    const icon = screen.getByRole("img", { name: "bi:card-text" });
-    expect(icon.classList).toContain("scale-125");
-  });
-
-  it("keeps custom icons at their native scale", async () => {
-    await renderSelector("IconGroup");
-
-    const icon = screen.getByRole("img", { name: "IconGroup" });
+    const icon = screen.getByRole("img", { name: iconUrl });
+    expect([...icon.classList]).toEqual(
+      expect.arrayContaining(["block!", "h-5!", "w-5!"])
+    );
     expect(icon.classList).not.toContain("scale-125");
   });
 });


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the frontend as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

This fixes inconsistent icon sizing in `SidebarLeft` by giving every icon a fixed 20 × 20 px box and block layout. The same sizing now applies to Iconify icons and custom SVG components without icon-specific transforms.

A regression test covers both Bootstrap and custom sidebar icons. In a production build checked with Chromium, all nine organization sidebar icons rendered at 20 × 20 px with 40 px rows and no transforms.

#### Screenshot

<img width="215" height="360" alt="SidebarLeft icons rendered at consistent sizes" src="https://github.com/user-attachments/assets/d31e6341-cf9d-45aa-bde3-7a567d4cd4ae" />

#### Tests

- `corepack yarn vitest run test/components/sidebar/SidebarLeftSelector.spec.ts`
- `corepack yarn typecheck`
- `corepack yarn lint`
- `corepack yarn test --coverage --silent`
- `corepack yarn build`

### Related issue

- Closes #2330