### PR TITLE
fix(backend): apply EXIF orientation before stripping metadata on upload

### DIFF
--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -10,6 +10,7 @@ from typing import Any
 from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile, UploadedFile
 from PIL import Image as PILImage
+from PIL import ImageOps  # New Import
 from rest_framework import serializers
 
 from communities.groups.models import GroupImage
@@ -96,6 +97,9 @@ def scrub_exif(image_file: InMemoryUploadedFile) -> InMemoryUploadedFile:
     """
     try:
         img: PILImage.Image = PILImage.open(image_file)
+        img = (
+            ImageOps.exif_transpose(img) or img
+        )  # physically apply the orientation before stripping EXIF
         output_format = img.format
 
         if output_format == "JPEG":

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -10,7 +10,7 @@ from typing import Any
 from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile, UploadedFile
 from PIL import Image as PILImage
-from PIL import ImageOps  # New Import
+from PIL import ImageOps
 from rest_framework import serializers
 
 from communities.groups.models import GroupImage
@@ -97,9 +97,8 @@ def scrub_exif(image_file: InMemoryUploadedFile) -> InMemoryUploadedFile:
     """
     try:
         img: PILImage.Image = PILImage.open(image_file)
-        img = (
-            ImageOps.exif_transpose(img) or img
-        )  # physically apply the orientation before stripping EXIF
+        # Apply the orientation before stripping EXIF.
+        img = ImageOps.exif_transpose(img) or img
         output_format = img.format
 
         if output_format == "JPEG":


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

Fixes #2333

Images uploaded with a non-default EXIF orientation tag (e.g. photos taken in portrait mode on a phone) were displaying rotated/flipped after upload.

**Root cause:** `scrub_exif()` in `backend/content/serializers.py` opens uploaded images with PIL and strips their EXIF metadata for privacy, but never read the `Orientation` tag before doing so. Since browsers/OSes rely on that tag (not the raw pixel data) to display images correctly, stripping it without applying it first left the raw sideways/upside-down pixel data as the final saved image, permanently baked in wrong.

**Fix:** call `PIL.ImageOps.exif_transpose()` immediately after opening the image, which physically rotates the pixel data to match the EXIF orientation *before* the EXIF data is stripped. A `or img` fallback handles the (rare) case where `exif_transpose()` returns `None`.

**Testing:** verified locally using the standard [EXIF orientation test images](https://github.com/recurser/exif-orientation-examples) (`Portrait_3.jpg`, `Portrait_6.jpg`) — both displayed correctly rotated after the fix, versus sideways/upside-down before.