### PR TITLE
feat(backend): communicate maximum filesize in MB for oversized image uploads (#2332)

### DIFF
--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -178,14 +178,13 @@ class ImageSerializer(serializers.ModelSerializer[Image]):
             )
 
         # DATA_UPLOAD_MAX_MEMORY_SIZE and IMAGE_UPLOAD_MAX_FILE_SIZE are set in core/settings.py.
-        # The file size limit is not being enforced. We're checking the file size here.
         if (
             data["file_object"].size is not None
             and data["file_object"].size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE
         ):
-            max_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
+            max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE / 1000000
             raise serializers.ValidationError(
-                f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes ({max_mb}MB)."
+                f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {max_image_size_mb}MB."
             )
 
         return data

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -183,7 +183,8 @@ class ImageSerializer(serializers.ModelSerializer[Image]):
             data["file_object"].size is not None
             and data["file_object"].size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE
         ):
-            max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // 1000000
+            # Use the base-2 (binary) conversion of bytes to MB.
+            max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
             raise serializers.ValidationError(
                 f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {max_image_size_mb}MB."
             )
@@ -320,7 +321,8 @@ class ImageIconSerializer(serializers.ModelSerializer[Image]):
             data["file_object"].size is not None
             and data["file_object"].size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE
         ):
-            max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // 1000000
+            # Use the base-2 (binary) conversion of bytes to MB.
+            max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
             raise serializers.ValidationError(
                 f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {max_image_size_mb}MB."
             )

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -183,8 +183,9 @@ class ImageSerializer(serializers.ModelSerializer[Image]):
             data["file_object"].size is not None
             and data["file_object"].size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE
         ):
+            max_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
             raise serializers.ValidationError(
-                f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes."
+                f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes ({max_mb}MB)."
             )
 
         return data
@@ -319,8 +320,9 @@ class ImageIconSerializer(serializers.ModelSerializer[Image]):
             data["file_object"].size is not None
             and data["file_object"].size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE
         ):
+            max_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
             raise serializers.ValidationError(
-                f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes."
+                f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes ({max_mb}MB)."
             )
 
         return data

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -178,6 +178,7 @@ class ImageSerializer(serializers.ModelSerializer[Image]):
             )
 
         # DATA_UPLOAD_MAX_MEMORY_SIZE and IMAGE_UPLOAD_MAX_FILE_SIZE are set in core/settings.py.
+        # The file size limit is not being enforced. We're checking the file size here.
         if (
             data["file_object"].size is not None
             and data["file_object"].size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE
@@ -319,9 +320,9 @@ class ImageIconSerializer(serializers.ModelSerializer[Image]):
             data["file_object"].size is not None
             and data["file_object"].size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE
         ):
-            max_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
+            max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // 1000000
             raise serializers.ValidationError(
-                f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes ({max_mb}MB)."
+                f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {max_image_size_mb}MB."
             )
 
         return data

--- a/backend/content/serializers.py
+++ b/backend/content/serializers.py
@@ -182,7 +182,7 @@ class ImageSerializer(serializers.ModelSerializer[Image]):
             data["file_object"].size is not None
             and data["file_object"].size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE
         ):
-            max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE / 1000000
+            max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // 1000000
             raise serializers.ValidationError(
                 f"The file size ({data['file_object'].size} bytes) is too large. The maximum file size is {max_image_size_mb}MB."
             )

--- a/backend/content/tests/image/test_content_image_serializer.py
+++ b/backend/content/tests/image/test_content_image_serializer.py
@@ -129,9 +129,10 @@ def test_content_image_serializer_icon_validate_file_too_large():
     with pytest.raises(serializers.ValidationError) as excinfo:
         serializer.validate({"file_object": large_file})
 
-    assert (
-        f"too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE}"
-        in str(excinfo.value)
+    # Use the base-2 (binary) conversion of bytes to MB.
+    max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
+    assert f"too large. The maximum file size is {max_image_size_mb}MB." in str(
+        excinfo.value
     )
 
 

--- a/backend/content/tests/image/test_content_image_upload.py
+++ b/backend/content/tests/image/test_content_image_upload.py
@@ -349,7 +349,8 @@ def test_content_image_upload_create_large_file(client: APIClient) -> None:
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     # DATA_UPLOAD_MAX_MEMORY_SIZE and IMAGE_UPLOAD_MAX_FILE_SIZE are set in core/settings.py.
-    max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // 1000000
+    # Use the base-2 (binary) conversion of bytes to MB.
+    max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
     assert (
         f"The file size ({file.size} bytes) is too large. The maximum file size is {max_image_size_mb}MB."
         in response.json()["nonFieldErrors"]

--- a/backend/content/tests/image/test_content_image_upload.py
+++ b/backend/content/tests/image/test_content_image_upload.py
@@ -348,10 +348,9 @@ def test_content_image_upload_create_large_file(client: APIClient) -> None:
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    # DATA_UPLOAD_MAX_MEMORY_SIZE and IMAGE_UPLOAD_MAX_FILE_SIZE are set in core/settings.py.
-    # The file size limit is not being enforced. We're checking the file size in the serializer validation.
+    max_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
     assert (
-        f"The file size ({file.size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes."
+        f"The file size ({file.size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes ({max_mb}MB)."
         in response.json()["nonFieldErrors"]
     )
 

--- a/backend/content/tests/image/test_content_image_upload.py
+++ b/backend/content/tests/image/test_content_image_upload.py
@@ -348,9 +348,10 @@ def test_content_image_upload_create_large_file(client: APIClient) -> None:
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    max_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // (1024 * 1024)
+    # DATA_UPLOAD_MAX_MEMORY_SIZE and IMAGE_UPLOAD_MAX_FILE_SIZE are set in core/settings.py.
+    max_image_size_mb = settings.IMAGE_UPLOAD_MAX_FILE_SIZE // 1000000
     assert (
-        f"The file size ({file.size} bytes) is too large. The maximum file size is {settings.IMAGE_UPLOAD_MAX_FILE_SIZE} bytes ({max_mb}MB)."
+        f"The file size ({file.size} bytes) is too large. The maximum file size is {max_image_size_mb}MB."
         in response.json()["nonFieldErrors"]
     )
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -323,6 +323,8 @@ SIMPLE_JWT = {
 }
 
 # MARK: Image / Data Upload size limits
+
+# Use the base-2 (binary) conversion of bytes to MB.
 IMAGE_UPLOAD_MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 DATA_UPLOAD_MAX_MEMORY_SIZE = 5 * 1024 * 1024  # 5MB
 


### PR DESCRIPTION
### Description

Updating the image upload validation error messages in the backend serializers to explicitly communicate the human-readable maximum file size in megabytes (`5MB`) alongside the byte count.

### Changes Made

- **`backend/content/serializers.py`**: Updated `ImageSerializer` and `ImageIconSerializer` error messages when `file_object.size > settings.IMAGE_UPLOAD_MAX_FILE_SIZE` to include `({max_mb}MB)`: `The file size (... bytes) is too large. The maximum file size is ... bytes (5MB).`
- **`backend/content/tests/image/test_content_image_upload.py`**: Updated upload test assertions to match the updated error message.

### Testing

- Verified image upload validation error message formatting.

Related #2332