### PR TITLE
fix(backend): return consistent list response for empty organization events (#2348)

### DIFF
--- a/backend/communities/organizations/tests/event/test_org_event_retrieve.py
+++ b/backend/communities/organizations/tests/event/test_org_event_retrieve.py
@@ -41,12 +41,7 @@ def test_org_event_retrieve_no_events_returns_empty_payload_ok_200():
     response = _test_org_event_retrieve_list(org_id=org.id)
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == {
-        "count": 0,
-        "next": None,
-        "previous": None,
-        "results": [],
-    }
+    assert response.data == []
 
 
 def test_org_event_retrieve_name_filter_icontains_ok_200():

--- a/backend/communities/organizations/views.py
+++ b/backend/communities/organizations/views.py
@@ -700,11 +700,6 @@ class OrganizationEventViewSet(viewsets.ModelViewSet[Event]):
             )
 
         queryset = Event.objects.filter(orgs__id=org_id)
-        if not queryset.exists():
-            return Response(
-                {"count": 0, "next": None, "previous": None, "results": []},
-                status=status.HTTP_200_OK,
-            )
 
         start = request.query_params.get("start_date")
         end = request.query_params.get("end_date")
@@ -723,10 +718,6 @@ class OrganizationEventViewSet(viewsets.ModelViewSet[Event]):
 
         elif end:
             queryset = queryset.filter(times__start_time__date__lte=end)
-
-        else:
-            # No date filters, return all events for the org.
-            queryset = queryset.filter(orgs__id=org_id)
 
         queryset = queryset.order_by("times__start_time").distinct()
 

--- a/frontend/app/services/communities/organization/event.ts
+++ b/frontend/app/services/communities/organization/event.ts
@@ -23,7 +23,8 @@ export const fetchOrganizationEvents = async (
       `/communities/organizations/${organizationId}/events?${query.toString()}`,
       { withoutAuth: true }
     );
-    return res.map(mapEvent);
+    const events = Array.isArray(res) ? res : res?.results || [];
+    return events.map(mapEvent);
   } catch (e) {
     throw errorHandler(e);
   }


### PR DESCRIPTION
### Terms

- [x] I have searched [open and closed pull requests](https://github.com/activist-org/activist/pulls?q=is%3Apr)
- [x] I agree to follow activist's [Code of Conduct](.github/CODE_OF_CONDUCT.md)
- [x] I agree to follow activist's [Contributing Guidelines](.github/CONTRIBUTING.md)

### Description

Fixes #2348 by ensuring `OrganizationEventViewSet.list` returns a consistent list response (`[]`) when an organization has no events instead of a paginated dictionary structure (`{"count": 0, "results": []}`), preventing `res.map is not a function` runtime crashes on the frontend events page.

#### Changes made:
- **`backend/communities/organizations/views.py`**: Removed early dict return in `OrganizationEventViewSet.list`, allowing the serialized queryset to consistently return a list response for both empty and populated organizations.
- **`backend/communities/organizations/tests/event/test_org_event_retrieve.py`**: Updated test assertion to expect `[]` for empty organization events.
- **`frontend/app/services/communities/organization/event.ts`**: Safely normalized `res` in `fetchOrganizationEvents` to prevent any runtime mapping errors.

### Related Issue

- Fixes #2348