### PR TITLE
fix: scope Mailhog lookups to recipient to fix e2e signup race (#2350)

### DIFF
--- a/frontend/test-e2e/specs/all/authentication/password-reset/password-reset-authentication.spec.ts
+++ b/frontend/test-e2e/specs/all/authentication/password-reset/password-reset-authentication.spec.ts
@@ -8,7 +8,6 @@ import {
 } from "~/test-e2e/page-objects/PasswordResetPage";
 import { newSignUpPage } from "~/test-e2e/page-objects/SignUpPage";
 import {
-  clearEmails,
   waitAndConfirmEmail,
   waitAndOpenPasswordResetLink,
 } from "~/test-e2e/utils/mailhog";
@@ -25,10 +24,6 @@ test.describe.serial(
       await context.clearCookies();
     });
 
-    test.afterEach(async () => {
-      await clearEmails();
-    });
-
     test("User can reset password via email and sign in with new password", async ({
       page,
     }, testInfo) => {
@@ -40,8 +35,6 @@ test.describe.serial(
       const newPassword = "Activist456!?New";
 
       const signUpPage = newSignUpPage(page);
-
-      await clearEmails();
 
       await withTestStep(testInfo, "Register and confirm email", async () => {
         await page.goto("/auth/sign-up");
@@ -57,10 +50,8 @@ test.describe.serial(
         await expect(page).toHaveURL(/\/auth\/confirm\/email/, {
           timeout: 10000,
         });
-        await waitAndConfirmEmail(page);
+        await waitAndConfirmEmail(page, email);
       });
-
-      await clearEmails();
 
       await withTestStep(testInfo, "Request password reset email", async () => {
         await page.goto("/auth/pwreset/email");
@@ -85,7 +76,7 @@ test.describe.serial(
       });
 
       await withTestStep(testInfo, "Open reset link from MailHog", async () => {
-        await waitAndOpenPasswordResetLink(page);
+        await waitAndOpenPasswordResetLink(page, email);
       });
 
       await withTestStep(testInfo, "Set new password", async () => {

--- a/frontend/test-e2e/specs/all/authentication/sign-up/sign-up-authentication.spec.ts
+++ b/frontend/test-e2e/specs/all/authentication/sign-up/sign-up-authentication.spec.ts
@@ -4,7 +4,7 @@ import { signIn } from "~/test-e2e/actions/authentication";
 import { expect, test } from "~/test-e2e/global-fixtures";
 import { newSignInPage } from "~/test-e2e/page-objects/SignInPage";
 import { newSignUpPage } from "~/test-e2e/page-objects/SignUpPage";
-import { clearEmails, waitAndConfirmEmail } from "~/test-e2e/utils/mailhog";
+import { waitAndConfirmEmail } from "~/test-e2e/utils/mailhog";
 import { logTestPath, withTestStep } from "~/test-e2e/utils/test-traceability";
 
 test.beforeEach(async ({ page }) => {
@@ -34,8 +34,6 @@ test.describe.serial(
 
       const signUpPage = newSignUpPage(page);
 
-      await clearEmails();
-
       await withTestStep(testInfo, "Fill in sign-up form", async () => {
         await signUpPage.usernameInput.fill(username);
         await signUpPage.emailInput.fill(email);
@@ -58,7 +56,7 @@ test.describe.serial(
       });
 
       await withTestStep(testInfo, "Confirm email via link", async () => {
-        await waitAndConfirmEmail(page);
+        await waitAndConfirmEmail(page, email);
       });
 
       await withTestStep(testInfo, "Sign in with new account", async () => {

--- a/frontend/test-e2e/utils/mailhog.ts
+++ b/frontend/test-e2e/utils/mailhog.ts
@@ -127,12 +127,28 @@ export function extractPasswordResetCode(body: string): string {
 const PWRESET_LINK_RE = /\/(?:[a-z]{2}\/)?auth\/pwreset\/[a-f0-9-]{36}/i;
 const CONFIRM_LINK_RE = /\/auth\/confirm\/[a-f0-9-]{36}/i;
 
+// Mailhog's `To` header is normally the plain address, but be tolerant of a
+// `Name <email>` form so a substring match still finds the right recipient.
+function messageIsTo(
+  item: MailhogMessageItem,
+  recipientEmail: string
+): boolean {
+  const to = item.Content?.Headers?.To?.[0] ?? "";
+  return to.toLowerCase().includes(recipientEmail.toLowerCase());
+}
+
+// Signup and password-reset e2e specs run in parallel Playwright workers and
+// both send mail matching these link patterns, so selection must be scoped to
+// the recipient. Without this, one spec can pick up (or wait on) the other's
+// message, since both only differ by contents, not by who they're addressed to.
 function newestPasswordResetEmail(
-  items: MailhogMessageItem[]
+  items: MailhogMessageItem[],
+  recipientEmail: string
 ): MailhogEmail | undefined {
   let best: { item: MailhogMessageItem; t: number } | null = null;
 
   for (const item of items) {
+    if (!messageIsTo(item, recipientEmail)) continue;
     const body = item.Content?.Body ?? "";
     const decoded = decodeQuotedPrintable(body);
     if (!PWRESET_LINK_RE.test(decoded)) continue;
@@ -145,11 +161,13 @@ function newestPasswordResetEmail(
 }
 
 function newestConfirmationEmail(
-  items: MailhogMessageItem[]
+  items: MailhogMessageItem[],
+  recipientEmail: string
 ): MailhogEmail | undefined {
   let best: { item: MailhogMessageItem; t: number } | null = null;
 
   for (const item of items) {
+    if (!messageIsTo(item, recipientEmail)) continue;
     const body = item.Content?.Body ?? "";
     const decoded = decodeQuotedPrintable(body);
     if (!CONFIRM_LINK_RE.test(decoded)) continue;
@@ -162,10 +180,11 @@ function newestConfirmationEmail(
 }
 
 /**
- * Poll Mailhog until a message whose body contains a password-reset link is found.
- * Returns the newest matching message (by Mailhog `Created` timestamp).
+ * Poll Mailhog until a password-reset message addressed to `recipientEmail`
+ * is found. Returns the newest matching message (by Mailhog `Created` timestamp).
  */
 export async function findPasswordResetEmail(
+  recipientEmail: string,
   maxAttempts = 40,
   pollIntervalMs = 500
 ): Promise<MailhogEmail> {
@@ -173,21 +192,27 @@ export async function findPasswordResetEmail(
     limit: 50,
     maxAttempts,
     pollIntervalMs,
-    select: newestPasswordResetEmail,
+    select: (items) => newestPasswordResetEmail(items, recipientEmail),
     errorMessage: (n) =>
-      `No password reset email found in Mailhog after ${n} attempts`,
+      `No password reset email addressed to ${recipientEmail} found in Mailhog after ${n} attempts`,
   });
 }
 
 /**
- * Waits for a password-reset email, then opens the reset form in the browser.
+ * Waits for a password-reset email addressed to `recipientEmail`, then opens
+ * the reset form in the browser.
  */
 export async function waitAndOpenPasswordResetLink(
   page: Page,
+  recipientEmail: string,
   maxAttempts = 40,
   pollIntervalMs = 500
 ): Promise<void> {
-  const email = await findPasswordResetEmail(maxAttempts, pollIntervalMs);
+  const email = await findPasswordResetEmail(
+    recipientEmail,
+    maxAttempts,
+    pollIntervalMs
+  );
   const decoded = decodeQuotedPrintable(email.body);
   const code = extractPasswordResetCodeFromDecoded(decoded);
   await page.goto(`/auth/pwreset/${code}`, { waitUntil: "domcontentloaded" });
@@ -199,21 +224,25 @@ export async function waitAndOpenPasswordResetLink(
 }
 
 /**
- * Waits for a verification email to arrive in Mailhog, then navigates the
- * Playwright page to the confirmation link from the email body. This exercises
- * the full frontend confirmation flow (auth/confirm/[code].vue → sign-in
- * redirect) rather than calling the backend API directly.
+ * Waits for a verification email addressed to `recipientEmail` to arrive in
+ * Mailhog, then navigates the Playwright page to the confirmation link from
+ * the email body. This exercises the full frontend confirmation flow
+ * (auth/confirm/[code].vue → sign-in redirect) rather than calling the
+ * backend API directly.
  *
- * Scans recent messages (`limit=50`) and picks the newest whose body contains
- * an `/auth/confirm/{uuid}` link so the correct mail is chosen when Mailhog
- * holds multiple messages.
+ * Scans recent messages (`limit=50`) and picks the newest one addressed to
+ * `recipientEmail` whose body contains an `/auth/confirm/{uuid}` link, so
+ * concurrently running specs that also send confirmation mail (e.g. the
+ * password-reset flow's own signup step) can never be picked up by mistake.
  *
  * @param page - Playwright page object
+ * @param recipientEmail - The email address this signup used, to disambiguate from other in-flight signups
  * @param maxAttempts - Maximum number of Mailhog polling attempts (default: 10)
  * @param pollIntervalMs - Milliseconds between each poll after fast polls (default: 500)
  */
 export async function waitAndConfirmEmail(
   page: Page,
+  recipientEmail: string,
   maxAttempts = 10,
   pollIntervalMs = 500
 ): Promise<void> {
@@ -221,9 +250,9 @@ export async function waitAndConfirmEmail(
     limit: 50,
     maxAttempts,
     pollIntervalMs,
-    select: newestConfirmationEmail,
+    select: (items) => newestConfirmationEmail(items, recipientEmail),
     errorMessage: (n) =>
-      `No verification email arrived in Mailhog after ${n} attempts`,
+      `No verification email addressed to ${recipientEmail} arrived in Mailhog after ${n} attempts`,
   });
 
   const decoded = decodeQuotedPrintable(email.body);

--- a/run-e2e-tests.sh
+++ b/run-e2e-tests.sh
@@ -211,11 +211,13 @@ fi
 # starting. Note: this wipes locally created dev data by design.
 docker compose --env-file .env.dev down -v >/dev/null 2>&1 || true
 
-# Start the backend and database (USE_PREVIEW skips full build inside Docker).
+# Start the backend, database, and db_worker (USE_PREVIEW skips full build
+# inside Docker). db_worker drains the background-task queue that signup and
+# other emails are enqueued onto; without it, emails never reach Mailhog.
 # Fail fast if Docker itself is unreachable, otherwise we'd waste ~2 minutes
 # on the frontend build only to hit a misleading "frontend did not become ready"
 # error downstream.
-USE_PREVIEW=true docker compose --env-file .env.dev up backend db -d || {
+USE_PREVIEW=true docker compose --env-file .env.dev up backend db db_worker -d || {
   echo "run-e2e-tests.sh: failed to start Docker services (is the Docker daemon running?)" >&2
   exit 1
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

The signup and password-reset e2e specs poll Mailhog for "the newest email matching a link pattern" and call `clearEmails()` to wipe the whole inbox. That race was harmless when email was sent synchronously, but #2179 moved it to an async `db_worker` queue, giving the two specs, which run in parallel Playwright workers, a window to steal or delete each other's email. The affected user never gets confirmed, so sign-in hangs waiting for a redirect that never comes.

**Changes:**
- `mailhog.ts`: email lookups now require a recipient and filter by the `To` header instead of just picking the newest link-shaped message.
- Auth specs: pass their own email into these helpers, drop the destructive shared `clearEmails()` calls.
- `run-e2e-tests.sh`: start `db_worker` locally to match CI.

**Testing:** Rebuilt the stack with `db_worker`, ran both specs in parallel per Playwright project. Reproduced the CI failure before the fix; 7/7 clean runs per project after.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- Closes #2350