### PR TITLE
fix: localize password reset email validation messages

### DIFF
--- a/frontend/app/pages/auth/pwreset/email.vue
+++ b/frontend/app/pages/auth/pwreset/email.vue
@@ -38,8 +38,8 @@ const t = useI18n().t;
 const emailResetPasswordSchema = z.object({
   email: z
     .string()
-    .email("i18n.pages.auth._global.invalid_email")
-    .min(1, "i18n._global.required"),
+    .email(t("i18n.pages.auth._global.invalid_email"))
+    .min(1, t("i18n._global.required")),
 });
 
 const submit = async (values: unknown) => {

--- a/frontend/test/pages/auth/pwreset/email.spec.ts
+++ b/frontend/test/pages/auth/pwreset/email.spec.ts
@@ -74,11 +74,10 @@ describe("pwreset/email", () => {
     });
     await fireEvent.click(submitButton);
 
-    // The FormErrorMessage renders the raw i18n key as its text content.
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeTruthy();
       expect(screen.getByTestId("form-item-email-error").textContent).toContain(
-        "i18n.pages.auth._global.invalid_email"
+        getEnglishText("i18n.pages.auth._global.invalid_email")
       );
     });
   });


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

`frontend/app/pages/auth/pwreset/email.vue` passed its i18n keys to the Zod schema as bare strings, so the raw key was rendered as the validation message:

```ts
.email("i18n.pages.auth._global.invalid_email")
.min(1, "i18n._global.required"),
```

`t` was already in scope in that file (line 36), and the other auth pages already wrap their schema messages — `sign-in.vue:97` and `sign-up.vue:202` both use `t("i18n._global.required")` — so this page was the outlier rather than the pattern needing to change. That matches @andrewtavis's note that the key itself is valid.

**Files changed**

- `app/pages/auth/pwreset/email.vue` — wrap both schema messages in `t()`
- `test/pages/auth/pwreset/email.spec.ts` — the existing test asserted the raw key as the expected output (with a comment stating the raw key is rendered), so the bug was codified in the suite. It now asserts the localized string via `getEnglishText()`, matching how the e2e specs assert translated text.

**Testing**

- `yarn test test/pages/auth/pwreset/email.spec.ts` — 5 passed, 2 todo
- `yarn test` (full unit suite) — 1888 passed, 177 files
- `yarn prettier --check` and `yarn eslint` on both changed files — clean

I also confirmed the updated test actually discriminates: reverting the `.email()` fix makes it fail, so it isn't passing vacuously.

**One thing worth flagging**

I fixed `.min(1, ...)` alongside `.email(...)` for consistency, but I could not write a meaningful test for it. `z.string().email()` rejects an empty string before `.min(1)` is reached, so that message appears unreachable through the form — reverting only the `.min()` fix leaves the whole suite green. I removed a test I had written for it rather than ship something that looks like coverage but proves nothing. Happy to drop the `.min()` change if you'd rather keep this strictly to the reported line.

**Risks**

Low. No behaviour changes beyond the rendered message text; both keys already exist in `en-US.json` (`"Invalid email address"` and `"Required"`).

**AI disclosure**

Per the template: this contribution was written with AI assistance. The diagnosis, the code change, the test update, and this description were produced with an AI coding assistant, and every claim above was verified by running the commands locally rather than asserted.

### Related issue

- #2355