### PR TITLE
fix(security): restrict style sources in CSP

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -136,6 +136,7 @@ export default defineNuxtConfig({
     headers: {
       contentSecurityPolicy: {
         "img-src": ["'self'", "data:", "blob:"],
+        "style-src": ["'self'", "https:"],
         "script-src": [
           "'self'",
           "https:",


### PR DESCRIPTION
Closes #1257

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds an explicit `style-src` Content Security Policy directive.
- Allows styles only from `'self'` and HTTPS sources.
- Prevents the CSP from allowing `unsafe-inline` styles.

## Changes

| File | Change |
|------|--------|
| `frontend/nuxt.config.ts` | Added an explicit `style-src` policy without `unsafe-inline`. |

## Test Plan

- [x] Prettier check passed.
- [x] ESLint check passed for `nuxt.config.ts`.
- [x] Nuxt typecheck passed.
- [ ] Full Vitest suite: 1602 tests passed; 8 suites failed because Nuxt Test Utils exceeded its 10-second setup timeout.
- [ ] Verify the deployed CSP header after merge.

## Contributor Checklist

- [ ] Linked an issue with the `status:approved` label.
- [ ] Added exactly one `type:*` label: `type:bug`.
- [x] Conventional commit format used.
- [x] No `Co-Authored-By` or AI attribution.
- [x] No shell scripts were modified; shellcheck is not applicable.