### PR TITLE
fix: add --project ./backend to run-i18n-check pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
       - id: run-i18n-check
         name: run i18n-check key-value checks
         files: ^frontend/
-        entry: "uv run i18n-check -a"
+        entry: "uv run --project ./backend i18n-check -a"
         language: python
         pass_filenames: false
 


### PR DESCRIPTION
## Summary
- `run-i18n-check`'s `entry` was `"uv run i18n-check -a"`, with no `--project` flag. Run from the repo root (no root-level `pyproject.toml`), `uv run` can't resolve a project context, so it falls back to spawning `i18n-check` directly off PATH — which fails on a clean machine since `i18n-check` is only installed via `backend`'s dev dependencies, not globally.
- This matches the fix already applied to the `mypy-check` hook (`--project ./backend`), which `run-i18n-check` never got.
- Verified on a fresh Ubuntu 24.04 container with `prek 0.5.0`: `run-i18n-check` fails with `error: Failed to spawn: i18n-check: No such file or directory` without the flag, and passes with it. Also confirmed quoting the `entry` string makes no difference either way — not the actual variable in play.

Closes #2375

## Test plan
- [x] Ran `prek run mypy-check --all-files` and `prek run run-i18n-check --all-files` on Ubuntu 24.04 (Docker) with the fix applied — both pass.
- [x] Reproduced the failure on the same setup without the fix to confirm the diagnosis.
- [x] Confirmed unquoting the entry string has no effect on the outcome.