### PR TITLE
Add mapEvent to createEvent return value

### DIFF
--- a/frontend/app/components/form/selector/FormSelectorComboboxGroups.vue
+++ b/frontend/app/components/form/selector/FormSelectorComboboxGroups.vue
@@ -10,6 +10,7 @@
     :label="label"
     :options="options"
     :selectedOptions="selectedGroups || []"
+    :showLoadingSlot="pending!"
   />
 </template>
 
@@ -35,7 +36,7 @@ const props = withDefaults(defineProps<Props>(), {
 const filters = computed(() => ({
   linked_organizations: props.linkedOrganizations,
 }));
-const { data: groups, getMore } = useGetGroups(filters);
+const { data: groups, getMore, pending } = useGetGroups(filters);
 
 const emit = defineEmits<{
   (e: "update:selectedGroups", value: Group[]): void;

--- a/frontend/app/services/event/event.ts
+++ b/frontend/app/services/event/event.ts
@@ -104,7 +104,7 @@ export async function createEvent(
     const res = await post<EventResponse, typeof data>(`/events/events`, data, {
       headers: { "Content-Type": "application/json" },
     });
-    return res;
+    return mapEvent(res);
   } catch (e) {
     throw errorHandler(e);
   }

--- a/frontend/test/services/event/event.spec.ts
+++ b/frontend/test/services/event/event.spec.ts
@@ -171,9 +171,9 @@ describe("services/event", () => {
     } as const;
 
     const created = "evt-3";
-    post.mockResolvedValueOnce(created);
+    post.mockResolvedValueOnce({ id: created, ...newEventInput });
 
-    const id = await createEvent({ ...newEventInput });
+    const createdEvent = await createEvent({ ...newEventInput });
 
     expect(post).toHaveBeenCalledTimes(1);
     // The service constructs a specific payload subset.
@@ -184,7 +184,7 @@ describe("services/event", () => {
       description: newEventInput.description,
       topics: newEventInput.topics,
     });
-    expect(id).toBe("evt-3");
+    expect(createdEvent.id).toBe("evt-3");
   });
 
   // MARK: Delete


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have run the tests for the backend and frontend depending on what's needed for my changes as described in the [testing section of the contributing guide](CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to achieve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
- Any risks that should be accounted for in your change
- A disclosure of which parts of the contribution include AI generated code
-->

Adds a missing `mapEvent` on the result of `createEvent`. Event was created with this change, so we're just checking if tests pass.

### Related issue

<!--- activist prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- No related issue