### PR TITLE
fix(frontend): render theme icon using picture element in spa loading template (#2391)

### DIFF
--- a/frontend/app/spa-loading-template.html
+++ b/frontend/app/spa-loading-template.html
@@ -1,21 +1,4 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
-<div>
-  <img
-    class="img-light-mode"
-    src="/icons/activist/activist_icon_light.png"
-    height="160"
-    width="160"
-    alt="activist - loading the platform"
-  />
-  <img
-    class="img-dark-mode"
-    src="/icons/activist/activist_icon_dark.png"
-    height="160"
-    width="160"
-    alt="activist - loading the platform"
-  />
-</div>
-
 <style>
   html,
   body {
@@ -41,10 +24,6 @@
     margin: auto;
   }
 
-  .img-dark-mode {
-    display: none;
-  }
-
   @media (prefers-color-scheme: dark) {
     html,
     body {
@@ -54,13 +33,20 @@
       padding: 0;
       background-color: #161b22;
     }
-
-    .img-dark-mode {
-      display: block;
-    }
-
-    .img-light-mode {
-      display: none;
-    }
   }
 </style>
+
+<div>
+  <picture>
+    <source
+      srcset="/icons/activist/activist_icon_dark.png"
+      media="(prefers-color-scheme: dark)"
+    />
+    <img
+      src="/icons/activist/activist_icon_light.png"
+      height="160"
+      width="160"
+      alt="activist - loading the platform"
+    />
+  </picture>
+</div>


### PR DESCRIPTION
### Summary of Changes

Fixes #2391 where the activist "a" icon was displayed in both light and dark mode simultaneously on page load when `spa-loading-template.html` was rendered.

#### Problem:
`frontend/app/spa-loading-template.html` rendered two distinct `<img>` tags (`.img-light-mode` and `.img-dark-mode`) and relied on CSS classes in a trailing `<style>` block to hide `.img-dark-mode` or `.img-light-mode`. Prior to stylesheet parsing or when styles were delayed/blocked, both images were rendered side-by-side or stacked on top of each other.

#### Solution:
- Replaced the two separate `<img>` elements with a single semantic `<picture>` element using a `<source>` with `media="(prefers-color-scheme: dark)"` and fallback `<img>`.
- The browser natively selects and renders exactly one image based on user color scheme preference without relying on class toggles or risking multiple image elements displaying at once.
- Moved the `<style>` block above the DOM elements to prevent flash of unstyled content.

### Related Issue

- Fixes #2391